### PR TITLE
hide cobra CLI completion command

### DIFF
--- a/cmd/spiderpool-agent/cmd/command_root.go
+++ b/cmd/spiderpool-agent/cmd/command_root.go
@@ -30,5 +30,7 @@ func Execute() {
 }
 
 func init() {
+	rootCmd.CompletionOptions.HiddenDefaultCmd = true
+
 	rootCmd.AddCommand(cmdgenmd.GenMarkDownCmd(BinNameAgent, rootCmd, logger))
 }

--- a/cmd/spiderpool-controller/cmd/command_root.go
+++ b/cmd/spiderpool-controller/cmd/command_root.go
@@ -30,5 +30,7 @@ func Execute() {
 }
 
 func init() {
+	rootCmd.CompletionOptions.HiddenDefaultCmd = true
+
 	rootCmd.AddCommand(cmdgenmd.GenMarkDownCmd(BinNameController, rootCmd, logger))
 }

--- a/cmd/spiderpoolctl/cmd/command_root.go
+++ b/cmd/spiderpoolctl/cmd/command_root.go
@@ -29,5 +29,7 @@ func Execute() {
 }
 
 func init() {
+	rootCmd.CompletionOptions.HiddenDefaultCmd = true
+
 	rootCmd.AddCommand(cmdgenmd.GenMarkDownCmd(SPIDERPOOL_CTL, rootCmd, logger))
 }


### PR DESCRIPTION
No need to keep the 'completion' command for CLI

Signed-off-by: Icarus9913 <icaruswu66@qq.com>

