### PR TITLE
E2E: add test cases according to the documentation

### DIFF
--- a/test/doc/annotation.md
+++ b/test/doc/annotation.md
@@ -1,9 +1,10 @@
 # e2e case for annotation
 
-| case id | title                                                                                | priority | smoke | status | other |
-|---------|--------------------------------------------------------------------------------------|----------|-------|--------|-------|
-| A00001  | it fails to run a pod with different VLAN for ipv4 and ipv6 ippool                   | p2       |       | NA     |       |
-| A00002  | succeed to run a pod for multiple NICS with different pools                          | p2       |       | NA     |       |
-| A00003  | fail to run a pod with invalid annotations                                           | p2       |       | NA     |       |
-| A00004  | the pod annotation has the highest priority over namespace and global default ippool | p2       |       | NA     |       |
-| A00005  | the "ippools" annotation has the higher priority over the "ippool" annotation        | p2       |       | NA     |       |
+| case id | title                                                                                     | priority | smoke | status | other |
+|---------|-------------------------------------------------------------------------------------------|----------|-------|--------|-------|
+| A00001  | it fails to run a pod with different VLAN for ipv4 and ipv6 ippool                        | p2       |       | NA     |       |
+| A00002  | succeed to run a pod for multiple NICS with different pools                               | p2       |       | NA     |       |
+| A00003  | fail to run a pod with invalid annotations                                                | p2       |       | NA     |       |
+| A00004  | the pod annotation has the highest priority over namespace and global default ippool      | p2       |       | NA     |       |
+| A00005  | the "ippools" annotation has the higher priority over the "ippool" annotation             | p2       |       | NA     |       |
+| A00006  | the namespace annotation has precedence over global default ippool                        | p2       | true  | NA     |       |

--- a/test/doc/configmap.md
+++ b/test/doc/configmap.md
@@ -1,5 +1,5 @@
 # e2e case for configmap
 
-| case id  | title                                                                                                                               | priority | smoke | status | other |
-|----------|-------------------------------------------------------------------------------------------------------------------------------------|----------|-------|--------|-------|
-| C00001  | fail to run a pod whose requested IP is not coordinated with the 'enableIPv4' and 'enableIPv6' field of configmap 'spiderpool-conf'  | p2       |       | NA     |       |
+| case id  | title                                                                                                                                    | priority | smoke | status | other |
+|----------|------------------------------------------------------------------------------------------------------------------------------------------|----------|-------|--------|-------|
+| C00001   | fail to run a pod whose requested IP is not coordinated with the 'enableIPv4' and 'enableIPv6' field of configmap 'spiderpool-conf'      | p2       |       | NA     |       |

--- a/test/doc/editcrd.md
+++ b/test/doc/editcrd.md
@@ -1,9 +1,9 @@
 # e2e case for edit crd
 
-| case id   | title                                                                                             | priority | smoke | status | other |
-|-----------|---------------------------------------------------------------------------------------------------|----------|-------|--------|-------|
-| D00001    | it fails to append an ip that already exists in another ippool to the ippool                      | p2       |       | NA     |       |
-| D00002    | check the consistency between the revised ippool gateway, route etc. and the previous one         | p2       |       | NA     |       |
-| D00003    | the wrong ippool gateway, route etc return error                                                  | p2       |       | NA     |       |
-| D00004    | if the pod's ip in one ippool is occupied by the pod, it fails to delete the ippool, vice verse   | p2       |       | NA     |       |
-| D00005    | if ippool/Spec/disabled in ipam is true, it fails to allocate ip from ippool, but de-allocates ip | p2       |       | NA     |       |
+| case id   | title                                                                                                      | priority | smoke | status | other |
+|-----------|------------------------------------------------------------------------------------------------------------|----------|-------|--------|-------|
+| D00001    | an ippool fails to add an IP that already exists in another ippool                                         | p2       |       | NA     |       |
+| D00002    | Successes to add correct ippool gateway and route etc. to a ippool CR                                      | p2       |       | NA     |       |
+| D00003    | fails to add wrong ippool gateway and route to a ippool CR                                                 | p2       |       | NA     |       |
+| D00004    | it fails to delete an ippool whose IP is not de-allocated at all                                            | p2       |       | NA     |       |
+| D00005    | a "true" value of ippool/Spec/disabled should forbid IP allocation, but still allow ip de-allocation        | p2       |       | NA     |       |


### PR DESCRIPTION
1. fix case A00004：
- the pod annotation has the highest priority over namespace and global default ippool, with namespace annotation having the second highest priority

2. add case for editcrd.md
- D00006
- D00007