### PR TITLE
fix:Failed to rollback IP when serializing Pod IP allocation annotations

### DIFF
--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -467,7 +466,7 @@ func execAllocate(ctx context.Context, ipPoolManager ippoolmanager.IPPoolManager
 
 				annoPodAssigned.IPv4Pool = ipv4.IPPool
 				annoPodAssigned.IPv4 = *ipv4.Address
-				annoPodAssigned.Vlan = strconv.FormatInt(ipv4.Vlan, 10)
+				annoPodAssigned.Vlan = int(ipv4.Vlan)
 
 				v4Succeed = true
 				break
@@ -492,7 +491,7 @@ func execAllocate(ctx context.Context, ipPoolManager ippoolmanager.IPPoolManager
 
 				annoPodAssigned.IPv6Pool = ipv6.IPPool
 				annoPodAssigned.IPv6 = *ipv6.Address
-				annoPodAssigned.Vlan = strconv.FormatInt(ipv6.Vlan, 10)
+				annoPodAssigned.Vlan = int(ipv6.Vlan)
 
 				v6Succeed = true
 				break
@@ -505,7 +504,7 @@ func execAllocate(ctx context.Context, ipPoolManager ippoolmanager.IPPoolManager
 
 		v, err := json.Marshal(annoPodAssigned)
 		if err != nil {
-			return nil, nil, err
+			return resIPs, nil, err
 		}
 		podAnnotations[constant.AnnotationPre+"/assigned-"+e.NIC] = string(v)
 	}

--- a/pkg/types/k8s.go
+++ b/pkg/types/k8s.go
@@ -35,7 +35,7 @@ type AnnoPodAssignedEthxValue struct {
 	IPv6Pool string `json:"ipv6pool"`
 	IPv4     string `json:"ipv4"`
 	IPv6     string `json:"ipv6"`
-	Vlan     string `json:"vlan"`
+	Vlan     int    `json:"vlan"`
 }
 
 type AnnoNSDefautlV4PoolValue []string


### PR DESCRIPTION
- Return resIPs in execAllocate() when serializing Pod IP allocation fails.
- Change the type of vlan field in pod IP allocation annotation to int.

Signed-off-by: iiiceoo <ziqian.xue@daocloud.io>