### PR TITLE
fix:IP leakage caused by IP rollback failure of incomplete IP allocation

### DIFF
--- a/charts/spiderpool/templates/deployment.yaml
+++ b/charts/spiderpool/templates/deployment.yaml
@@ -172,7 +172,7 @@ spec:
           value: {{ .Values.spiderpoolController.cliPort | quote }}
         - name: SPIDERPOOL_HEALTH_PORT
           value: {{ .Values.spiderpoolController.healthPort | quote }}
-        - name: SPIDERPOOL_GC_IPPOOL_ENABLED
+        - name: SPIDERPOOL_GC_IP_ENABLED
           value: {{ .Values.spiderpoolController.gc.enabled | quote }}
         - name: SPIDERPOOL_GC_TERMINATING_POD_IP_ENABLED
           value: {{ .Values.spiderpoolController.gc.gcTerminatingPodIPEnabled | quote }}

--- a/pkg/ipam/tools.go
+++ b/pkg/ipam/tools.go
@@ -1,0 +1,142 @@
+// Copyright 2022 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+
+package ipam
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/spidernet-io/spiderpool/api/v1/agent/models"
+	"github.com/spidernet-io/spiderpool/pkg/constant"
+	"github.com/spidernet-io/spiderpool/pkg/ippoolmanager"
+	spiderpoolv1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/v1"
+	"github.com/spidernet-io/spiderpool/pkg/types"
+)
+
+func convertToIPConfigs(details []spiderpoolv1.IPAllocationDetail) []*models.IPConfig {
+	var ipConfigs []*models.IPConfig
+	for _, d := range details {
+		var version int64
+		if d.IPv4 != nil {
+			version = 4
+			ipConfigs = append(ipConfigs, &models.IPConfig{
+				Address: d.IPv4,
+				Nic:     &d.NIC,
+				Version: &version,
+				Vlan:    int64(*d.Vlan),
+				Gateway: *d.IPv4Gateway,
+			})
+		}
+
+		if d.IPv6 != nil {
+			version = 6
+			ipConfigs = append(ipConfigs, &models.IPConfig{
+				Address: d.IPv6,
+				Nic:     &d.NIC,
+				Version: &version,
+				Vlan:    int64(*d.Vlan),
+				Gateway: *d.IPv6Gateway,
+			})
+		}
+	}
+
+	return ipConfigs
+}
+
+func convertToIPDetails(ipConfigs []*models.IPConfig) []spiderpoolv1.IPAllocationDetail {
+	nicToDetail := map[string]*spiderpoolv1.IPAllocationDetail{}
+	for _, c := range ipConfigs {
+		if d, ok := nicToDetail[*c.Nic]; ok {
+			if *c.Version == 4 {
+				d.IPv4 = c.Address
+				d.IPv4Pool = &c.IPPool
+				d.IPv4Gateway = &c.Gateway
+			} else {
+				d.IPv6 = c.Address
+				d.IPv6Pool = &c.IPPool
+				d.IPv6Gateway = &c.Gateway
+			}
+			continue
+		}
+
+		vlan := spiderpoolv1.Vlan(c.Vlan)
+		if *c.Version == 4 {
+			nicToDetail[*c.Nic] = &spiderpoolv1.IPAllocationDetail{
+				NIC:         *c.Nic,
+				IPv4:        c.Address,
+				IPv4Pool:    &c.IPPool,
+				Vlan:        &vlan,
+				IPv4Gateway: &c.Gateway,
+			}
+		} else {
+			nicToDetail[*c.Nic] = &spiderpoolv1.IPAllocationDetail{
+				NIC:         *c.Nic,
+				IPv6:        c.Address,
+				IPv6Pool:    &c.IPPool,
+				Vlan:        &vlan,
+				IPv6Gateway: &c.Gateway,
+			}
+		}
+	}
+
+	details := []spiderpoolv1.IPAllocationDetail{}
+	for _, d := range nicToDetail {
+		details = append(details, *d)
+	}
+
+	return details
+}
+
+func groupIPDetails(containerID string, details []spiderpoolv1.IPAllocationDetail) map[string][]ippoolmanager.IPAndCID {
+	poolToIPAndCIDs := map[string][]ippoolmanager.IPAndCID{}
+	for _, d := range details {
+		if d.IPv4 != nil {
+			poolToIPAndCIDs[*d.IPv4Pool] = append(poolToIPAndCIDs[*d.IPv4Pool], ippoolmanager.IPAndCID{
+				IP:          strings.Split(*d.IPv4, "/")[0],
+				ContainerID: containerID,
+			})
+		}
+		if d.IPv6 != nil {
+			poolToIPAndCIDs[*d.IPv6Pool] = append(poolToIPAndCIDs[*d.IPv6Pool], ippoolmanager.IPAndCID{
+				IP:          strings.Split(*d.IPv6, "/")[0],
+				ContainerID: containerID,
+			})
+		}
+	}
+
+	return poolToIPAndCIDs
+}
+
+func genIPAssignmentAnnotation(ipConfigs []*models.IPConfig) (map[string]string, error) {
+	nicToValue := map[string]types.AnnoPodAssignedEthxValue{}
+	for _, c := range ipConfigs {
+		if v, ok := nicToValue[*c.Nic]; ok {
+			if *c.Version == 4 {
+				v.IPv4 = *c.Address
+				v.IPv4Pool = c.IPPool
+				v.Vlan = int(c.Vlan)
+			} else {
+				v.IPv6 = *c.Address
+				v.IPv6Pool = c.IPPool
+				v.Vlan = int(c.Vlan)
+			}
+			continue
+		}
+
+		nicToValue[*c.Nic] = types.AnnoPodAssignedEthxValue{
+			NIC: *c.Nic,
+		}
+	}
+
+	podAnnotations := map[string]string{}
+	for nic, anno := range nicToValue {
+		b, err := json.Marshal(anno)
+		if err != nil {
+			return nil, err
+		}
+		podAnnotations[constant.AnnotationPre+"/assigned-"+nic] = string(b)
+	}
+
+	return podAnnotations, nil
+}

--- a/pkg/reservedipmanager/reservedip_manager.go
+++ b/pkg/reservedipmanager/reservedip_manager.go
@@ -14,7 +14,7 @@ import (
 )
 
 type ReservedIPManager interface {
-	GetReservedIPRanges(ctx context.Context, version string) ([]string, error)
+	GetReservedIPRanges(ctx context.Context, version spiderpoolv1.IPVersion) ([]string, error)
 }
 
 type reservedIPManager struct {
@@ -43,9 +43,9 @@ func NewReservedIPManager(c client.Client, mgr ctrl.Manager) (ReservedIPManager,
 	}, nil
 }
 
-func (r *reservedIPManager) GetReservedIPRanges(ctx context.Context, version string) ([]string, error) {
+func (r *reservedIPManager) GetReservedIPRanges(ctx context.Context, version spiderpoolv1.IPVersion) ([]string, error) {
 	var reservedIPs spiderpoolv1.ReservedIPList
-	if err := r.client.List(ctx, &reservedIPs, client.MatchingFields{"spec.ipVersion": version}); err != nil {
+	if err := r.client.List(ctx, &reservedIPs, client.MatchingFields{"spec.ipVersion": string(version)}); err != nil {
 		return nil, err
 	}
 

--- a/pkg/workloadendpointmanager/workloadendpoint_manager.go
+++ b/pkg/workloadendpointmanager/workloadendpoint_manager.go
@@ -8,11 +8,6 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/spidernet-io/spiderpool/pkg/constant"
-	"github.com/spidernet-io/spiderpool/pkg/ippoolmanager"
-	spiderpoolv1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/v1"
-	"github.com/spidernet-io/spiderpool/pkg/logutils"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,12 +15,17 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/spidernet-io/spiderpool/pkg/constant"
+	"github.com/spidernet-io/spiderpool/pkg/ippoolmanager"
+	spiderpoolv1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/v1"
+	"github.com/spidernet-io/spiderpool/pkg/logutils"
 )
 
 type WorkloadEndpointManager interface {
 	RetriveIPAllocation(ctx context.Context, namespace, podName, containerID, nic string, includeHistory bool) (*spiderpoolv1.PodIPAllocation, bool, error)
 	UpdateIPAllocation(ctx context.Context, namespace, podName string, allocation *spiderpoolv1.PodIPAllocation) error
-	ClearCurrentIPAllocation(ctx context.Context, namespace, podName, containerID, nic string) error
+	ClearCurrentIPAllocation(ctx context.Context, namespace, podName, containerID string) error
 	Get(ctx context.Context, namespace, podName string) (*spiderpoolv1.WorkloadEndpoint, error)
 	RemoveFinalizer(ctx context.Context, namespace, podName string) error
 	ListAllHistoricalIPs(ctx context.Context, namespace, podName string) (map[string][]ippoolmanager.IPAndCID, error)
@@ -122,8 +122,20 @@ func (r *workloadEndpointManager) UpdateIPAllocation(ctx context.Context, namesp
 		}
 	} else {
 		if we.Status.Current != nil && we.Status.Current.ContainerID == allocation.ContainerID {
-			we.Status.Current.IPs = append(we.Status.Current.IPs, allocation.IPs...)
-			we.Status.History[0].IPs = append(we.Status.History[0].IPs, allocation.IPs...)
+			var merged bool
+			for i, d := range we.Status.Current.IPs {
+				if d.NIC == allocation.IPs[0].NIC {
+					mergeIPDetails(&we.Status.Current.IPs[i], &allocation.IPs[0])
+					mergeIPDetails(&we.Status.History[0].IPs[i], &allocation.IPs[0])
+					merged = true
+					break
+				}
+			}
+
+			if !merged {
+				we.Status.Current.IPs = append(we.Status.Current.IPs, allocation.IPs...)
+				we.Status.History[0].IPs = append(we.Status.History[0].IPs, allocation.IPs...)
+			}
 		} else {
 			we.Status.Current = allocation
 			we.Status.History = append([]spiderpoolv1.PodIPAllocation{*allocation}, we.Status.History...)
@@ -141,7 +153,34 @@ func (r *workloadEndpointManager) UpdateIPAllocation(ctx context.Context, namesp
 	return nil
 }
 
-func (r *workloadEndpointManager) ClearCurrentIPAllocation(ctx context.Context, namespace, podName, containerID, nic string) error {
+// TODO(iiiceoo): refactor
+func mergeIPDetails(target, delta *spiderpoolv1.IPAllocationDetail) {
+	if target.IPv4 == nil {
+		target.IPv4 = delta.IPv4
+	}
+
+	if target.IPv4Pool == nil {
+		target.IPv4Pool = delta.IPv4Pool
+	}
+
+	if target.IPv4Gateway == nil {
+		target.IPv4Gateway = delta.IPv4Gateway
+	}
+
+	if target.IPv6 == nil {
+		target.IPv6 = delta.IPv6
+	}
+
+	if target.IPv6Pool == nil {
+		target.IPv6Pool = delta.IPv6Pool
+	}
+
+	if target.IPv6Gateway == nil {
+		target.IPv6Gateway = delta.IPv6Gateway
+	}
+}
+
+func (r *workloadEndpointManager) ClearCurrentIPAllocation(ctx context.Context, namespace, podName, containerID string) error {
 	var we spiderpoolv1.WorkloadEndpoint
 	if err := r.client.Get(ctx, apitypes.NamespacedName{Namespace: namespace, Name: podName}, &we); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/test/Makefile
+++ b/test/Makefile
@@ -84,7 +84,7 @@ setup_kind:
 	$(QUIET) kind create cluster \
 		--config $(CLUSTER_DIR)/$(E2E_CLUSTER_NAME)/kind-config.yaml \
 		--name $(E2E_CLUSTER_NAME) --kubeconfig $(E2E_KUBECONFIG)
-	- kubectl taint nodes --all node-role.kubernetes.io/master-
+	- kubectl --kubeconfig $(E2E_KUBECONFIG) taint nodes --all node-role.kubernetes.io/master-
 
 
 .PHONY: setup_spiderpool


### PR DESCRIPTION
- Update SWE incrementally.
- Fix log always shows "Use IP pools from Namespace annotation".
- Refactor filterPoolCandidates() function.
- Validate "ippools" annotation, make sure that the interface of the pod annotation contains that requested by runtime.

Signed-off-by: iiiceoo <ziqian.xue@daocloud.io>