### PR TITLE
ci: change apache/skywalking-eyes to tag version

### DIFF
--- a/.github/workflows/lint-license.yaml
+++ b/.github/workflows/lint-license.yaml
@@ -50,4 +50,4 @@ jobs:
 
       - name: Check License Header
         id: checklicense
-        uses: apache/skywalking-eyes@main
+        uses: apache/skywalking-eyes@v0.3.0


### PR DESCRIPTION
Signed-off-by: weizhou.lan@daocloud.io <weizhou.lan@daocloud.io>

fix CI issue: https://github.com/spidernet-io/spiderpool/runs/7249093688?check_suite_focus=true

