### PR TITLE
fix:IP leakage caused by too many conflicts when update ippool in high concurrency case

### DIFF
--- a/cmd/spiderpool-agent/cmd/config.go
+++ b/cmd/spiderpool-agent/cmd/config.go
@@ -48,11 +48,13 @@ var envInfo = []envConf{
 	{"SPIDERPOOL_HEALTH_PORT", "5710", true, &agentContext.Cfg.HttpPort, nil, nil},
 	{"SPIDERPOOL_METRIC_HTTP_PORT", "5711", true, &agentContext.Cfg.MetricHttpPort, nil, nil},
 	{"SPIDERPOOL_UPDATE_CR_MAX_RETRYS", "3", false, nil, nil, &agentContext.Cfg.UpdateCRMaxRetrys},
-	{"SPIDERPOOL_UPDATE_CR_RETRY_UNIT_TIME", "500", false, nil, nil, &agentContext.Cfg.UpdateCRRetryUnitTime},
-	{"SPIDERPOOL_WORKLOADENDPOINT_MAX_HISTORY_RECORDS", "100", false, nil, nil, &agentContext.Cfg.WorkloadEndpointMaxHistoryRecords},
-	{"SPIDERPOOL_IPPOOL_MAX_ALLOCATED_IPS", "5000", false, nil, nil, &agentContext.Cfg.IPPoolMaxAllocatedIPs},
+	{"SPIDERPOOL_UPDATE_CR_RETRY_UNIT_TIME", "200", false, nil, nil, &agentContext.Cfg.UpdateCRRetryUnitTime},
+	{"SPIDERPOOL_WORKLOADENDPOINT_MAX_HISTORY_RECORDS", "100", true, nil, nil, &agentContext.Cfg.WorkloadEndpointMaxHistoryRecords},
+	{"SPIDERPOOL_IPPOOL_MAX_ALLOCATED_IPS", "5000", true, nil, nil, &agentContext.Cfg.IPPoolMaxAllocatedIPs},
 	{"SPIDERPOOL_GOPS_LISTEN_PORT", "5712", false, &agentContext.Cfg.GopsListenPort, nil, nil},
 	{"SPIDERPOOL_PYROSCOPE_PUSH_SERVER_ADDRESS", "", false, &agentContext.Cfg.PyroscopeAddress, nil, nil},
+	{"SPIDERPOOL_LIMITER_MAX_QUEUE_SIZE", "1000", true, nil, nil, &agentContext.Cfg.LimiterMaxQueueSize},
+	{"SPIDERPOOL_LIMITER_MAX_WAIT_TIME", "15", true, nil, nil, &agentContext.Cfg.LimiterMaxWaitTime},
 }
 
 type Config struct {
@@ -72,6 +74,9 @@ type Config struct {
 	UpdateCRRetryUnitTime             int
 	WorkloadEndpointMaxHistoryRecords int
 	IPPoolMaxAllocatedIPs             int
+
+	LimiterMaxQueueSize int
+	LimiterMaxWaitTime  int
 
 	// configmap
 	IpamUnixSocketPath       string   `yaml:"ipamUnixSocketPath"`

--- a/cmd/spiderpool-agent/cmd/crd_manager.go
+++ b/cmd/spiderpool-agent/cmd/crd_manager.go
@@ -6,13 +6,15 @@ package cmd
 import (
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
-
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	spiderpoolv1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/v1"
 )
@@ -29,7 +31,17 @@ func newCRDManager() (ctrl.Manager, error) {
 		Scheme:                 scheme,
 		MetricsBindAddress:     "0",
 		HealthProbeBindAddress: "0",
+		ClientDisableCacheFor: []client.Object{
+			&corev1.Node{},
+			&corev1.Namespace{},
+			&corev1.Pod{},
+			&appsv1.Deployment{},
+			&appsv1.StatefulSet{},
+			&spiderpoolv1.IPPool{},
+			&spiderpoolv1.WorkloadEndpoint{},
+			&spiderpoolv1.ReservedIP{}},
 	})
+
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/spiderpool-controller/cmd/crd_manager.go
+++ b/cmd/spiderpool-controller/cmd/crd_manager.go
@@ -7,17 +7,20 @@ import (
 	"path"
 	"strconv"
 
-	spiderpoolv1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/v1"
-	"github.com/spidernet-io/spiderpool/pkg/webhook"
-
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	spiderpoolv1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/v1"
+	"github.com/spidernet-io/spiderpool/pkg/webhook"
 )
 
 var scheme = runtime.NewScheme()
@@ -39,6 +42,15 @@ func newCRDManager() (ctrl.Manager, error) {
 		CertDir:                path.Dir(controllerContext.Cfg.TlsServerCertPath),
 		MetricsBindAddress:     "0",
 		HealthProbeBindAddress: "0",
+		ClientDisableCacheFor: []client.Object{
+			&corev1.Node{},
+			&corev1.Namespace{},
+			&corev1.Pod{},
+			&appsv1.Deployment{},
+			&appsv1.StatefulSet{},
+			&spiderpoolv1.IPPool{},
+			&spiderpoolv1.WorkloadEndpoint{},
+			&spiderpoolv1.ReservedIP{}},
 	})
 	if nil != err {
 		return nil, err

--- a/cmd/spiderpool-controller/cmd/daemon.go
+++ b/cmd/spiderpool-controller/cmd/daemon.go
@@ -153,15 +153,17 @@ func WatchSignal(sigCh chan os.Signal) {
 
 func initControllerServiceManagers(ctx context.Context) {
 	logger.Debug("Begin to initialize WorkloadEndpoint Manager")
+	retrys := controllerContext.Cfg.UpdateCRMaxRetrys
+	unitTime := time.Duration(controllerContext.Cfg.UpdateCRRetryUnitTime) * time.Millisecond
 	historySize := controllerContext.Cfg.WorkloadEndpointMaxHistoryRecords
-	wepManager, err := workloadendpointmanager.NewWorkloadEndpointManager(controllerContext.CRDManager.GetClient(), controllerContext.CRDManager, historySize)
+	wepManager, err := workloadendpointmanager.NewWorkloadEndpointManager(controllerContext.CRDManager.GetClient(), controllerContext.CRDManager, historySize, retrys, unitTime)
 	if err != nil {
 		logger.Fatal(err.Error())
 	}
 	controllerContext.WEPManager = wepManager
 
 	logger.Debug("Begin to initialize ReservedIP Manager")
-	rIPManager, err := reservedipmanager.NewReservedIPManager(controllerContext.CRDManager.GetClient(), controllerContext.CRDManager)
+	rIPManager, err := reservedipmanager.NewReservedIPManager(controllerContext.CRDManager.GetClient())
 	if err != nil {
 		logger.Fatal(err.Error())
 	}
@@ -182,8 +184,6 @@ func initControllerServiceManagers(ctx context.Context) {
 	controllerContext.NSManager = nsManager
 
 	logger.Debug("Begin to initialize Pod Manager")
-	retrys := controllerContext.Cfg.UpdateCRMaxRetrys
-	unitTime := time.Duration(controllerContext.Cfg.UpdateCRRetryUnitTime) * time.Millisecond
 	podManager, err := podmanager.NewPodManager(controllerContext.CRDManager.GetClient(), controllerContext.CRDManager, retrys, unitTime)
 	if err != nil {
 		logger.Fatal(err.Error())

--- a/cmd/spiderpool/cmd/command_add.go
+++ b/cmd/spiderpool/cmd/command_add.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spidernet-io/spiderpool/api/v1/agent/client/daemonset"
 	"github.com/spidernet-io/spiderpool/api/v1/agent/models"
 	"github.com/spidernet-io/spiderpool/cmd/spiderpool-agent/cmd"
+	"github.com/spidernet-io/spiderpool/pkg/constant"
 	"github.com/spidernet-io/spiderpool/pkg/ip"
 	"github.com/spidernet-io/spiderpool/pkg/logutils"
 
@@ -180,7 +181,7 @@ func assembleResult(cniVersion, IfName string, ipamResponse *daemonset.PostIpamI
 			netInterfaces = append(netInterfaces, nic)
 
 			// record ips
-			if *ipconfig.Version == 4 {
+			if *ipconfig.Version == constant.IPv4 {
 				var v4ip current.IPConfig
 				nicIndex := tmpIndex
 

--- a/cmd/spiderpool/cmd/command_test.go
+++ b/cmd/spiderpool/cmd/command_test.go
@@ -218,11 +218,11 @@ var _ = Describe("spiderpool plugin", Label("unitest", "ipam_plugin_test"), func
 				// multi nic, ip responses
 				*ipamAddResp.Ips[0].Address = "10.1.0.5/24"
 				*ipamAddResp.Ips[0].Nic = "eth1"
-				*ipamAddResp.Ips[0].Version = 4
+				*ipamAddResp.Ips[0].Version = constant.IPv4
 
 				*ipamAddResp.Ips[1].Address = "1.2.3.30/24"
 				*ipamAddResp.Ips[1].Nic = "eth0"
-				*ipamAddResp.Ips[1].Version = 4
+				*ipamAddResp.Ips[1].Version = constant.IPv4
 
 				return ipamAddResp
 			}, func() *current.Result {
@@ -273,7 +273,7 @@ var _ = Describe("spiderpool plugin", Label("unitest", "ipam_plugin_test"), func
 
 				*ipamAddResp.Ips[0].Address = "10.1.0.6/24"
 				*ipamAddResp.Ips[0].Nic = ifname
-				*ipamAddResp.Ips[0].Version = 4
+				*ipamAddResp.Ips[0].Version = constant.IPv4
 
 				return ipamAddResp
 			}, func() *current.Result {
@@ -316,7 +316,7 @@ var _ = Describe("spiderpool plugin", Label("unitest", "ipam_plugin_test"), func
 
 				*ipamAddResp.Ips[0].Address = "10.1.0.7/24"
 				*ipamAddResp.Ips[0].Nic = ifname
-				*ipamAddResp.Ips[0].Version = 4
+				*ipamAddResp.Ips[0].Version = constant.IPv4
 
 				return ipamAddResp
 			}, func() *current.Result {

--- a/pkg/constant/ip.go
+++ b/pkg/constant/ip.go
@@ -1,0 +1,9 @@
+// Copyright 2022 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+
+package constant
+
+const (
+	IPv4 int64 = 4
+	IPv6 int64 = 6
+)

--- a/pkg/constant/k8s.go
+++ b/pkg/constant/k8s.go
@@ -60,7 +60,7 @@ const (
 
 const SpiderWorkloadEndpointFinalizer = "spiderpool.spidernet.io"
 
-const QualifiedK8sObjNameFmt string = "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
+const QualifiedK8sObjNameFmt = "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
 
 const SpiderIPGarbageCollect = "ip-gc"
 const SpiderIPGarbageCollectElectorLockName = AnnotationPre + "-" + SpiderIPGarbageCollect + "-" + resourcelock.LeasesResourceLock

--- a/pkg/limiter/queue.go
+++ b/pkg/limiter/queue.go
@@ -200,13 +200,13 @@ func (q *queue) checkin() (shuttingDown bool) {
 
 	addOrFinish := make(chan empty)
 	if len(q.elements) != 0 {
-		go func() {
+		go func(e *e) {
 			select {
-			case <-time.After(time.Until(q.elements[0].finalCheckinTime)):
+			case <-time.After(time.Until(e.finalCheckinTime)):
 				q.cond.Broadcast()
 			case <-addOrFinish:
 			}
-		}()
+		}(q.elements[0])
 	}
 
 	// Waiting here avoids too frequent polling by conductor when there are


### PR DESCRIPTION
fix:IP leakage caused by too many conflicts when update ippool in high concurrency case
- Introduce a limiter to reduce IPAM concurrency of a single node.
- Refactor function UpdateIPAllocation.
- Do not create Informer for IPPool, Endpoint and ReservedIP. Use API Server clinet to read and write CR to ensure data consistency. These changes also apply to Node, NS and Pod.
- Update annotations with 'fresh' Pod.
    
Signed-off-by: iiiceoo <ziqian.xue@daocloud.io>