### PR TITLE
IP GC podEntry improvement

### DIFF
--- a/pkg/gcmanager/pod_cache.go
+++ b/pkg/gcmanager/pod_cache.go
@@ -80,7 +80,7 @@ func (p *PodDatabase) ListAllPodEntries() []PodEntry {
 	p.RLock()
 	defer p.RUnlock()
 
-	var podEntryList []PodEntry
+	podEntryList := make([]PodEntry, 0, len(p.pods))
 	for podID := range p.pods {
 		podEntryList = append(podEntryList, p.pods[podID])
 	}


### PR DESCRIPTION
Init slice capacity firstly to avoid expansion. This change will improve performance and decrease the lock holding duration.

Signed-off-by: Icarus9913 <icaruswu66@qq.com>
