### PR TITLE
Fixed CI failure caused by node not ready

### DIFF
--- a/test/e2e/reliability/reliability_test.go
+++ b/test/e2e/reliability/reliability_test.go
@@ -125,10 +125,10 @@ var _ = Describe("test reliability", Label("reliability"), Serial, func() {
 			GinkgoWriter.Printf("get nodeMap is：%v\n", nodeMap)
 
 			// send cmd to reboot node and check node until ready
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Minute*2)
 			defer cancel()
-			readyok, err := common.RestartNodeUntilReady(frame, nodeMap, time.Second*30, ctx)
-			Eventually(readyok).Should(BeTrue())
+			readyok, err := common.RestartNodeUntilReady(frame, nodeMap, time.Minute, ctx)
+			Eventually(readyok).Should(BeTrue(), "timeout to wait node ready\n")
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// check pod ready and ip assign ok
@@ -146,6 +146,6 @@ var _ = Describe("test reliability", Label("reliability"), Serial, func() {
 			Expect(errdel).NotTo(HaveOccurred(), "failed to delete Deployment %v/%v \n", podName, namespace)
 
 		},
-		Entry("pod Replicas is 2", Label("R00006"), int32(2)),
+		Entry("pod Replicas is 2", Serial, Label("R00006"), int32(2)),
 	)
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
ci failure when restart node

**Which issue(s) this PR fixes**:
this pr fixed various CI failures caused by restarting the host without ready
related issue link:
#474 ,
#458, related logs:
 https://github.com/spidernet-io/spiderpool/runs/7512876703?check_suite_focus=true#step:22:1250
