### PR TITLE
Chopped indexe in node，namespace，pod manager

### DIFF
--- a/pkg/namespacemanager/namespace_manager.go
+++ b/pkg/namespacemanager/namespace_manager.go
@@ -33,13 +33,6 @@ func NewNamespaceManager(mgr ctrl.Manager) (NamespaceManager, error) {
 		return nil, errors.New("runtime manager must be specified")
 	}
 
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Namespace{}, metav1.ObjectNameField, func(raw client.Object) []string {
-		namespace := raw.(*corev1.Namespace)
-		return []string{namespace.Name}
-	}); err != nil {
-		return nil, err
-	}
-
 	return &namespaceManager{
 		client:     mgr.GetClient(),
 		runtimeMgr: mgr,

--- a/pkg/nodemanager/node_manager.go
+++ b/pkg/nodemanager/node_manager.go
@@ -26,26 +26,19 @@ func NewNodeManager(mgr ctrl.Manager) (NodeManager, error) {
 	if mgr == nil {
 		return nil, errors.New("runtime manager must be specified")
 	}
-
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Node{}, metav1.ObjectNameField, func(raw client.Object) []string {
-		node := raw.(*corev1.Node)
-		return []string{node.Name}
-	}); err != nil {
-		return nil, err
-	}
-
 	return &nodeManager{
 		client:     mgr.GetClient(),
 		runtimeMgr: mgr,
 	}, nil
 }
 
+// MatchLabelSelector will check whether the node matches the labelSelector or not
 func (r *nodeManager) MatchLabelSelector(ctx context.Context, nodeName string, labelSelector *metav1.LabelSelector) (bool, error) {
 	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
 	if err != nil {
 		return false, err
 	}
-
+	// Get the matches' node from client
 	var nodes corev1.NodeList
 	err = r.client.List(
 		ctx,

--- a/pkg/podmanager/pod_manager.go
+++ b/pkg/podmanager/pod_manager.go
@@ -41,13 +41,6 @@ func NewPodManager(mgr ctrl.Manager, maxConflictRetrys int, conflictRetryUnitTim
 		return nil, errors.New("runtime manager must be specified")
 	}
 
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Pod{}, metav1.ObjectNameField, func(raw client.Object) []string {
-		pod := raw.(*corev1.Pod)
-		return []string{pod.Name}
-	}); err != nil {
-		return nil, err
-	}
-
 	return &podManager{
 		client:                mgr.GetClient(),
 		runtimeMgr:            mgr,


### PR DESCRIPTION
Remove the Add Index section of NewManager.

In the previous Pr, all the resources that need to be operated are added to the disabled array, so now the client will obtain information directly from the API Server, which initially supports the field selector for Name and Namespace fields.
Thus, the extra index is no longer needed.

@iiiceoo 