### PR TITLE
E2E: case G00005, G00007 a dirty IP record in the IPPool shoud be auto clean by Spiderpool

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The Spiderpool provides a large number of different features as follows.
 
 * Included metrics for looking into IP usage and issues.
 
-* By CidrManager, it could automatically creat new ippool for application who needs fixed IP address, and retrieve the ippool when application is deleted. That could reduce the administrator workload.
+* By CidrManager, it could automatically create new ippool for application who needs fixed IP address, and retrieve the ippool when application is deleted. That could reduce the administrator workload.
 
 * Support for both ARM64 and ARM64.
 

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/sasha-s/go-deadlock v0.3.1
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/pflag v1.0.5
-	github.com/spidernet-io/e2eframework v0.0.0-20220705081904-a8d957907f2a
+	github.com/spidernet-io/e2eframework v0.0.0-20220727033754-246f7669d0ab
 	go.uber.org/atomic v1.7.0
 	go.uber.org/zap v1.21.0
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b

--- a/go.sum
+++ b/go.sum
@@ -616,8 +616,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/spf13/viper v1.10.1 h1:nuJZuYpG7gTj/XqiUwg8bA0cp1+M2mC3J4g5luUYBKk=
 github.com/spf13/viper v1.10.1/go.mod h1:IGlFPqhNAPKRxohIzWpI5QEy4kuI7tcl5WvR+8qy1rU=
-github.com/spidernet-io/e2eframework v0.0.0-20220705081904-a8d957907f2a h1:Xpg1k9rm/CCsw8q7M1PEQA5n76yS1uMbJ4AdCoL2vqY=
-github.com/spidernet-io/e2eframework v0.0.0-20220705081904-a8d957907f2a/go.mod h1:zOEkUq/hYFQVITm75Mk2RbttoOfVwE8yZpkJJo5NE30=
+github.com/spidernet-io/e2eframework v0.0.0-20220727033754-246f7669d0ab h1:Otm74/fD92b42xDnqiUcn2jXdNCDLYmhCfDN1vnMeRk=
+github.com/spidernet-io/e2eframework v0.0.0-20220727033754-246f7669d0ab/go.mod h1:A+M+Oqf+vMPuztTqlYQojr4twRvjDP5WHPswwU3JATY=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/test/e2e/assignip/assignip_test.go
+++ b/test/e2e/assignip/assignip_test.go
@@ -49,7 +49,7 @@ var _ = Describe("test pod", Label("assignip"), func() {
 		// create pod
 		GinkgoWriter.Printf("create pod %v/%v with annotationLength= %v \n", namespace, testName, annotationLength)
 		podYaml := common.GenerateExamplePodYaml(testName, namespace)
-		podYaml.Annotations = map[string]string{annotationKeyName: common.GenerateString(annotationLength)}
+		podYaml.Annotations = map[string]string{annotationKeyName: common.GenerateString(annotationLength, false)}
 		Expect(podYaml).NotTo(BeNil())
 
 		pod, _, _ := common.CreatePodUntilReady(frame, podYaml, testName, namespace, time.Second*30)

--- a/test/e2e/common/pod.go
+++ b/test/e2e/common/pod.go
@@ -58,14 +58,15 @@ func CreatePodUntilReady(frame *e2e.Framework, podYaml *corev1.Pod, podName, nam
 
 	GinkgoWriter.Printf("pod: %v/%v, ips: %+v \n", namespace, podName, pod.Status.PodIPs)
 
+	var ok bool
 	if frame.Info.IpV4Enabled {
-		podIPv4, ok := tools.CheckPodIpv4IPReady(pod)
+		podIPv4, ok = tools.CheckPodIpv4IPReady(pod)
 		Expect(ok).NotTo(BeFalse(), "failed to get ipv4 ip")
 		Expect(podIPv4).NotTo(BeEmpty(), "podIPv4 is a empty string")
 		GinkgoWriter.Println("succeeded to check pod ipv4 ip")
 	}
 	if frame.Info.IpV6Enabled {
-		podIPv6, ok := tools.CheckPodIpv6IPReady(pod)
+		podIPv6, ok = tools.CheckPodIpv6IPReady(pod)
 		Expect(ok).NotTo(BeFalse(), "failed to get ipv6 ip")
 		Expect(podIPv6).NotTo(BeEmpty(), "podIPv6 is a empty string")
 		GinkgoWriter.Println("succeeded to check pod ipv6 ip")

--- a/test/e2e/common/tools.go
+++ b/test/e2e/common/tools.go
@@ -16,8 +16,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func GenerateString(lenNum int) string {
-	var chars = []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0"}
+func GenerateString(lenNum int, isHex bool) string {
+	var chars []string
+	chars = []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0"}
+	if isHex {
+		chars = []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"}
+	}
 	str := strings.Builder{}
 	length := len(chars)
 	rand.Seed(time.Now().UnixNano())

--- a/test/e2e/ippool/job_pod_test.go
+++ b/test/e2e/ippool/job_pod_test.go
@@ -88,12 +88,11 @@ var _ = Describe("test ip with Job case", Label("Job"), func() {
 
 			// wait job finished
 			GinkgoWriter.Printf("wait job finished \n")
-			ctx1, cancel1 := context.WithTimeout(context.Background(), 30*time.Second)
+			ctx1, cancel1 := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel1()
 			jb, ok1, e3 := frame.WaitJobFinished(jdName, nsName, ctx1)
-			GinkgoWriter.Printf("job finished status:%v \n", ok1)
-			GinkgoWriter.Printf("jb is:%+v\n", *jb)
-			GinkgoWriter.Printf("err is: %v\n", e3)
+			Expect(e3).NotTo(HaveOccurred(), "failed to wait job finished: %v\n", e3)
+			Expect(jb).NotTo(BeNil())
 
 			switch behavior {
 			case common.JobTypeFail:
@@ -104,8 +103,6 @@ var _ = Describe("test ip with Job case", Label("Job"), func() {
 				Fail("input error")
 			}
 
-			Expect(e3).NotTo(HaveOccurred())
-			Expect(jb).NotTo(BeNil())
 			GinkgoWriter.Printf("job %v is finished \n job conditions:\n %v \n", jb, jb.Status.Conditions)
 
 			// TODO(weiyang) check ip release

--- a/test/e2e/reclaim/reclaim_test.go
+++ b/test/e2e/reclaim/reclaim_test.go
@@ -3,6 +3,8 @@
 package reclaim_test
 
 import (
+	"encoding/json"
+	"fmt"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -14,6 +16,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spidernet-io/e2eframework/tools"
+	"github.com/spidernet-io/spiderpool/pkg/constant"
+	spiderpool "github.com/spidernet-io/spiderpool/pkg/k8s/apis/v1"
+	"github.com/spidernet-io/spiderpool/pkg/types"
 	"github.com/spidernet-io/spiderpool/test/e2e/common"
 )
 
@@ -188,6 +193,270 @@ var _ = Describe("test ip with reclaim ip case", Label("reclaim"), func() {
 			Expect(ok3).To(BeTrue())
 			Expect(err3).NotTo(HaveOccurred())
 		})
+
+	Context("test the reclaim of dirty IP record in the IPPool", func() {
+		var v4poolName, v6poolName string
+		var v4poolNameList, v6poolNameList []string
+		var v4poolObj, v6poolObj *spiderpool.IPPool
+		var (
+			podIPv4Record, podIPv6Record     = new(spiderpool.PoolIPAllocation), new(spiderpool.PoolIPAllocation)
+			dirtyIPv4Record, dirtyIPv6Record = new(spiderpool.PoolIPAllocation), new(spiderpool.PoolIPAllocation)
+		)
+		var dirtyIPv4, dirtyIPv6 string
+		var dirtyPodName, dirtyContainerID string
+
+		BeforeEach(func() {
+			// generate dirty ip, pod name and dirty containerID
+			GinkgoWriter.Println("generate dirty ip")
+			randomNum1 := common.GenerateRandomNumber(255)
+			randomNum2 := common.GenerateRandomNumber(255)
+			dirtyIPv4 = fmt.Sprintf("192.168.%s.%s", randomNum1, randomNum2)
+			GinkgoWriter.Printf("dirtyIPv4:%v\n", dirtyIPv4)
+
+			randomNum1 = common.GenerateRandomNumber(9999)
+			randomNum2 = common.GenerateRandomNumber(9999)
+			dirtyIPv6 = fmt.Sprintf("fe00:%s::%s", randomNum1, randomNum2)
+			GinkgoWriter.Printf("dirtyIPv6:%v\n", dirtyIPv6)
+
+			GinkgoWriter.Println("generate dirty pod name")
+			dirtyPodName = "dirtyPod-" + tools.RandomName()
+			GinkgoWriter.Printf("dirtyPodName:%v\n", dirtyPodName)
+
+			GinkgoWriter.Println("generate dirty containerID")
+			dirtyContainerID = common.GenerateString(64, true)
+			GinkgoWriter.Printf("dirtyContainerID:%v\n", dirtyContainerID)
+
+			// create ippool
+			if frame.Info.IpV4Enabled {
+				GinkgoWriter.Println("create ipv4 pool")
+				v4poolName, v4poolObj = common.GenerateExampleIpv4poolObject(1)
+				v4poolNameList = []string{v4poolName}
+				Expect(common.CreateIppool(frame, v4poolObj)).To(Succeed())
+				GinkgoWriter.Printf("succeed to create ipv4 pool %v\n", v4poolName)
+			}
+			if frame.Info.IpV6Enabled {
+				GinkgoWriter.Println("create ipv6 pool")
+				v6poolName, v6poolObj = common.GenerateExampleIpv6poolObject(1)
+				v6poolNameList = []string{v6poolName}
+				Expect(common.CreateIppool(frame, v6poolObj)).To(Succeed())
+				GinkgoWriter.Printf("succeed to create ipv6 pool %v\n", v6poolName)
+			}
+
+			DeferCleanup(func() {
+				// delete ippool
+				if frame.Info.IpV4Enabled {
+					GinkgoWriter.Println("delete ipv4 pool")
+					ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+					defer cancel()
+					Expect(common.DeleteIPPoolUntilFinish(frame, v4poolName, ctx)).To(Succeed())
+					GinkgoWriter.Printf("succeed to delete ipv4 pool %v\n", v4poolName)
+				}
+				if frame.Info.IpV6Enabled {
+					GinkgoWriter.Println("delete ipv6 pool")
+					ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+					defer cancel()
+					Expect(common.DeleteIPPoolUntilFinish(frame, v6poolName, ctx)).To(Succeed())
+					GinkgoWriter.Printf("succeed to delete ipv6 pool %v\n", v6poolName)
+				}
+			})
+		})
+		DescribeTable("dirty IP record in the IPPool should be auto clean by Spiderpool", func(dirtyField string) {
+			// generate podYaml
+			GinkgoWriter.Println("generate pod yaml")
+			podYaml := common.GenerateExamplePodYaml(podName, namespace)
+			Expect(podYaml).NotTo(BeNil())
+
+			podAnnoIPPoolValue := types.AnnoPodIPPoolValue{}
+
+			if frame.Info.IpV4Enabled {
+				podAnnoIPPoolValue.IPv4Pools = []string{v4poolName}
+			}
+			if frame.Info.IpV6Enabled {
+				podAnnoIPPoolValue.IPv6Pools = []string{v6poolName}
+			}
+
+			b, err := json.Marshal(podAnnoIPPoolValue)
+			Expect(err).NotTo(HaveOccurred(), "failed to marshal podAnnoIPPoolValue")
+			Expect(b).NotTo(BeNil())
+			podAnnoStr := string(b)
+			podYaml.Annotations = map[string]string{
+				constant.AnnoPodIPPool: podAnnoStr,
+			}
+			GinkgoWriter.Printf("succeed to generate podYaml: %v \n", podYaml)
+
+			// create pod
+			GinkgoWriter.Printf("create pod %v/%v until ready\n", namespace, podName)
+			pod, podIPv4, podIPv6 := common.CreatePodUntilReady(frame, podYaml, podName, namespace, time.Minute)
+			Expect(pod).NotTo(BeNil(), "create pod failed\n")
+			GinkgoWriter.Printf("podIPv4: %v\n", podIPv4)
+			GinkgoWriter.Printf("podIPv6: %v\n", podIPv6)
+
+			// check pod ip in ippool
+			GinkgoWriter.Printf("check pod %v/%v ip in ippool\n", namespace, podName)
+			podList := &corev1.PodList{
+				Items: []corev1.Pod{
+					*pod,
+				},
+			}
+			allRecorded, _, _, err := common.CheckPodIpRecordInIppool(frame, v4poolNameList, v6poolNameList, podList)
+			Expect(allRecorded).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+			GinkgoWriter.Printf("succeed to check pod %v/%v ip in ippool\n", namespace, podName)
+
+			// get pod ip record in ippool
+			if frame.Info.IpV4Enabled {
+				GinkgoWriter.Printf("get pod=%v/%v ip=%v record in ipv4 pool=%v\n", namespace, podName, podIPv4, v4poolName)
+				v4poolObj = common.GetIppoolByName(frame, v4poolName)
+				*podIPv4Record = v4poolObj.Status.AllocatedIPs[podIPv4]
+				GinkgoWriter.Printf("the pod ip record in ipv4 pool is %v\n", *podIPv4Record)
+			}
+			if frame.Info.IpV6Enabled {
+				GinkgoWriter.Printf("get pod=%v/%v ip=%v record in ipv6 pool=%v\n", namespace, podName, podIPv6, v6poolName)
+				v6poolObj = common.GetIppoolByName(frame, v6poolName)
+				*podIPv6Record = v6poolObj.Status.AllocatedIPs[podIPv6]
+				GinkgoWriter.Printf("the pod ip record in ipv6 pool is %v\n", *podIPv6Record)
+			}
+
+			GinkgoWriter.Println("add dirty data to ippool")
+			if frame.Info.IpV4Enabled {
+				dirtyIPv4Record = podIPv4Record
+
+				switch dirtyField {
+				case "pod":
+					dirtyIPv4Record.Pod = dirtyPodName
+					allocatedIPCount := *v4poolObj.Status.AllocatedIPCount
+					allocatedIPCount++
+					GinkgoWriter.Printf("allocatedIPCount: %v\n", allocatedIPCount)
+					v4poolObj.Status.AllocatedIPCount = pointer.Int64Ptr(allocatedIPCount)
+				case "containerID":
+					dirtyIPv4Record.ContainerID = dirtyContainerID
+					allocatedIPCount := *v4poolObj.Status.AllocatedIPCount
+					allocatedIPCount++
+					GinkgoWriter.Printf("allocatedIPCount: %v\n", allocatedIPCount)
+					v4poolObj.Status.AllocatedIPCount = pointer.Int64Ptr(allocatedIPCount)
+				default:
+					Fail("invalid parameter\n")
+				}
+
+				v4poolObj.Status.AllocatedIPs[dirtyIPv4] = *dirtyIPv4Record
+
+				// update ipv4 pool
+				GinkgoWriter.Printf("update ippool %v for adding dirty record: %+v \n", v4poolName, *dirtyIPv4Record)
+				Expect(frame.UpdateResourceStatus(v4poolObj)).To(Succeed(), "failed to update ipv4 pool %v\n", v4poolName)
+				GinkgoWriter.Printf("ipv4 pool %+v\n", v4poolObj)
+
+				// check if dirty data added successfully
+				v4poolObj = common.GetIppoolByName(frame, v4poolName)
+				record, ok := v4poolObj.Status.AllocatedIPs[dirtyIPv4]
+				Expect(ok).To(BeTrue())
+				Expect(record).To(Equal(*dirtyIPv4Record))
+
+			}
+			if frame.Info.IpV6Enabled {
+				dirtyIPv6Record = podIPv6Record
+
+				switch dirtyField {
+				case "pod":
+					dirtyIPv6Record.Pod = dirtyPodName
+					allocatedIPCount := *v6poolObj.Status.AllocatedIPCount
+					allocatedIPCount++
+					GinkgoWriter.Printf("allocatedIPCount: %v\n", allocatedIPCount)
+					v6poolObj.Status.AllocatedIPCount = pointer.Int64Ptr(allocatedIPCount)
+				case "containerID":
+					dirtyIPv6Record.ContainerID = dirtyContainerID
+					allocatedIPCount := *v6poolObj.Status.AllocatedIPCount
+					allocatedIPCount++
+					GinkgoWriter.Printf("allocatedIPCount: %v\n", allocatedIPCount)
+					v6poolObj.Status.AllocatedIPCount = pointer.Int64Ptr(allocatedIPCount)
+				default:
+					Fail("invalid parameter\n")
+				}
+
+				v6poolObj.Status.AllocatedIPs[dirtyIPv6] = *dirtyIPv6Record
+
+				// update ipv6 pool
+				GinkgoWriter.Printf("update ippool %v for adding dirty record: %+v \n", v6poolName, *dirtyIPv6Record)
+				Expect(frame.UpdateResourceStatus(v6poolObj)).To(Succeed(), "failed to update ipv6 pool %v\n", v6poolName)
+				GinkgoWriter.Printf("ipv6 pool %+v\n", v6poolObj)
+
+				// check if dirty data added successfully
+				v6poolObj = common.GetIppoolByName(frame, v6poolName)
+				record, ok := v6poolObj.Status.AllocatedIPs[dirtyIPv6]
+				Expect(ok).To(BeTrue())
+				Expect(record).To(Equal(*dirtyIPv6Record))
+
+			}
+
+			// restart spiderpool controller to trigger gc
+			GinkgoWriter.Println("restart spiderpool controller")
+			spiderpoolControllerPodList, err := frame.GetPodListByLabel(map[string]string{"app.kubernetes.io/component": "spiderpoolcontroller"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(spiderpoolControllerPodList).NotTo(BeNil(), "failed to get spiderpool controller podList\n")
+			spiderpoolControllerPodList, err = frame.DeletePodListUntilReady(spiderpoolControllerPodList, time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(spiderpoolControllerPodList).NotTo(BeNil(), "failed to get spiderpool controller podList after restart\n")
+			GinkgoWriter.Println("succeed to restart spiderpool controller pods")
+
+			// check the real pod ip should be recorded in spiderpool, the dirty ip record should be reclaimed from spiderpool
+			GinkgoWriter.Printf("check if the pod %v/%v ip recorded in ippool, check if the dirty ip record reclaimed from ippool\n", namespace, podName)
+			if frame.Info.IpV4Enabled {
+				// check if dirty data reclaimed successfully
+				ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+				defer cancel()
+			LOOPV4:
+				for {
+					select {
+					default:
+						v4poolObj = common.GetIppoolByName(frame, v4poolName)
+						_, ok := v4poolObj.Status.AllocatedIPs[dirtyIPv4]
+						if !ok {
+							GinkgoWriter.Printf("succeed to reclaim the dirty ip %v record from ippool %v\n", dirtyIPv4, v4poolName)
+							break LOOPV4
+						}
+						time.Sleep(time.Second)
+					case <-ctx.Done():
+						Fail("timeout to wait reclaim the dirty data from ippool\n")
+					}
+				}
+			}
+			if frame.Info.IpV6Enabled {
+				// check if dirty data reclaimed successfully
+				ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+				defer cancel()
+			LOOPV6:
+				for {
+					select {
+					default:
+						v6poolObj = common.GetIppoolByName(frame, v6poolName)
+						_, ok := v6poolObj.Status.AllocatedIPs[dirtyIPv6]
+						if !ok {
+							GinkgoWriter.Printf("succeed to reclaim the dirty ip %v record from ippool %v\n", dirtyIPv6, v6poolName)
+							break LOOPV6
+						}
+						time.Sleep(time.Second)
+					case <-ctx.Done():
+						Fail("timeout to wait reclaim the dirty data from ippool\n")
+					}
+				}
+			}
+
+			// check pod ip in ippool
+			allRecorded, _, _, err = common.CheckPodIpRecordInIppool(frame, v4poolNameList, v6poolNameList, podList)
+			Expect(allRecorded).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+			GinkgoWriter.Printf("succeed to check pod %v/%v ip in ippool\n", namespace, podName)
+
+			// delete pod
+			GinkgoWriter.Printf("delete pod %v/%v\n", namespace, podName)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			defer cancel()
+			Expect(frame.DeletePodUntilFinish(podName, namespace, ctx)).To(Succeed(), "timeout to delete pod %v/%v\n", namespace, podName)
+			GinkgoWriter.Printf("succeed to delete pod %v/%v\n", namespace, podName)
+		},
+			Entry("a dirty IP record (pod name is wrong) in the IPPool should be auto clean by Spiderpool", Serial, Label("G00005"), "pod"),
+			Entry("a dirty IP record (containerID is wrong) in the IPPool should be auto clean by Spiderpool", Serial, Label("G00007"), "containerID"),
+		)
+	})
 })
 
 func createPod(podName, namespace string, duration time.Duration) (pod *corev1.Pod, podIPv4, podIPv6 string) {

--- a/vendor/github.com/spidernet-io/e2eframework/framework/framework.go
+++ b/vendor/github.com/spidernet-io/e2eframework/framework/framework.go
@@ -235,6 +235,12 @@ func (f *Framework) UpdateResource(obj client.Object, opts ...client.UpdateOptio
 	return f.KClient.Update(ctx5, obj, opts...)
 }
 
+func (f *Framework) UpdateResourceStatus(obj client.Object, opts ...client.UpdateOption) error {
+	ctx, cancel := context.WithTimeout(context.Background(), f.Config.ApiOperateTimeout)
+	defer cancel()
+	return f.KClient.Status().Update(ctx, obj, opts...)
+}
+
 func initClusterInfo() error {
 
 	for _, v := range envConfigList {

--- a/vendor/github.com/spidernet-io/e2eframework/framework/serviceaccounts.go
+++ b/vendor/github.com/spidernet-io/e2eframework/framework/serviceaccounts.go
@@ -1,0 +1,47 @@
+// Copyright 2022 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+package framework
+
+import (
+	"context"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+)
+
+func (f *Framework) GetServiceAccount(saName, namespace string) (*corev1.ServiceAccount, error) {
+	if saName == "" || namespace == "" {
+		return nil, ErrWrongInput
+	}
+
+	key := client.ObjectKey{
+		Namespace: namespace,
+		Name:      saName,
+	}
+	existing := &corev1.ServiceAccount{}
+	e := f.GetResource(key, existing)
+	if e != nil {
+		return nil, e
+	}
+	return existing, e
+}
+
+func (f *Framework) CheckServiceAccountReady(saName, namespace string, timeOut time.Duration) error {
+	if saName == "" || namespace == "" {
+		return ErrWrongInput
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeOut)
+	defer cancel()
+	for {
+		select {
+		default:
+			as, _ := f.GetServiceAccount(saName, namespace)
+			if as != nil {
+				return nil
+			}
+			time.Sleep(time.Second)
+		case <-ctx.Done():
+			return ErrTimeOut
+		}
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -367,7 +367,7 @@ github.com/spf13/viper/internal/encoding/hcl
 github.com/spf13/viper/internal/encoding/json
 github.com/spf13/viper/internal/encoding/toml
 github.com/spf13/viper/internal/encoding/yaml
-# github.com/spidernet-io/e2eframework v0.0.0-20220705081904-a8d957907f2a
+# github.com/spidernet-io/e2eframework v0.0.0-20220727033754-246f7669d0ab
 ## explicit; go 1.17
 github.com/spidernet-io/e2eframework/framework
 github.com/spidernet-io/e2eframework/tools


### PR DESCRIPTION
**What this PR does / why we need it**:
case G00005: a dirty IP record (pod name is wrong) in the IPPool should be auto clean by Spiderpool 
case G00007: a dirty IP record (pod name is right but container ID is wrong) in the IPPool should be auto clean by Spiderpool

fixed:
#534
#535 