### PR TITLE
fix the log dir

### DIFF
--- a/.github/workflows/auto-nightly-ci.yaml
+++ b/.github/workflows/auto-nightly-ci.yaml
@@ -257,6 +257,7 @@ jobs:
         run: |
           echo ${{ github.event.inputs.labels }}
           RESULT=0
+          sudo mkdir -p /var/log/spidernet # fix the permission defined issue
           make e2e_test -e E2E_CLUSTER_NAME=${{ steps.prepare.outputs.clusterName }}  \
               -e E2E_GINKGO_LABELS=${{ needs.get_ref.outputs.e2e_labels }} \
               -e E2E_TIMEOUT=${{ env.E2E_TIME_OUT }} \
@@ -349,6 +350,7 @@ jobs:
         run: |
           echo ${{ github.event.inputs.labels }}
           RESULT=0
+          sudo mkdir -p /var/log/spidernet # fix the permission defined issue
           make e2e_test -e E2E_CLUSTER_NAME=${{ steps.prepare.outputs.clusterName }}  \
               -e E2E_GINKGO_LABELS=${{ needs.get_ref.outputs.e2e_labels }} \
               -e E2E_TIMEOUT=${{ env.E2E_TIME_OUT }}  \
@@ -418,6 +420,7 @@ jobs:
         run: |
           echo ${{ github.event.inputs.labels }}
           RESULT=0
+          sudo mkdir -p /var/log/spidernet # fix the permission defined issue
           make e2e_test -e E2E_CLUSTER_NAME=${{ steps.prepare.outputs.clusterName }}  \
               -e E2E_GINKGO_LABELS=${{ needs.get_ref.outputs.e2e_labels }} \
               -e E2E_TIMEOUT=${{ env.E2E_TIME_OUT }}  \

--- a/.github/workflows/auto-pr-ci.yaml
+++ b/.github/workflows/auto-pr-ci.yaml
@@ -275,6 +275,7 @@ jobs:
         run: |
           echo ${{ github.event.inputs.labels }}
           RESULT=0
+          sudo mkdir -p /var/log/spidernet # fix the permission defined issue
           make e2e_test -e E2E_CLUSTER_NAME=${{ steps.prepare.outputs.clusterName }}  \
               -e E2E_GINKGO_LABELS=${{ needs.get_ref.outputs.e2e_labels }} \
               -e E2E_TIMEOUT=${{ env.E2E_TIME_OUT }} \
@@ -367,6 +368,7 @@ jobs:
         run: |
           echo ${{ github.event.inputs.labels }}
           RESULT=0
+          sudo mkdir -p /var/log/spidernet # fix the permission defined issue
           make e2e_test -e E2E_CLUSTER_NAME=${{ steps.prepare.outputs.clusterName }}  \
               -e E2E_GINKGO_LABELS=${{ needs.get_ref.outputs.e2e_labels }} \
               -e E2E_TIMEOUT=${{ env.E2E_TIME_OUT }}  \
@@ -436,6 +438,7 @@ jobs:
         run: |
           echo ${{ github.event.inputs.labels }}
           RESULT=0
+          sudo mkdir -p /var/log/spidernet # fix the permission defined issue
           make e2e_test -e E2E_CLUSTER_NAME=${{ steps.prepare.outputs.clusterName }}  \
               -e E2E_GINKGO_LABELS=${{ needs.get_ref.outputs.e2e_labels }} \
               -e E2E_TIMEOUT=${{ env.E2E_TIME_OUT }}  \

--- a/.github/workflows/lint-golang.yaml
+++ b/.github/workflows/lint-golang.yaml
@@ -203,6 +203,7 @@ jobs:
         id: unitest
         continue-on-error: true
         run: |
+          sudo mkdir -p /var/log/spidernet # fix the permission defined issue
           make unitest-tests
 
       - name: Upload Coverage Artifact

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,97 @@
-# About
+# Spiderpool
 
-spiderpool
+## Introduction
+
+The Spiderpool is an IP Address Management (IPAM) CNI plugin that assigns IP addresses for kubernetes clusters.
+
+Currently, it is under developing stage, not ready for production environment yet.
+
+Any Container Network Interface (CNI) plugin supporting third-party IPAM plugins can use the Spiderpool,
+such as [MacVLAN CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/macvlan),
+[VLAN CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/vlan), [IPVLAN CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/ipvlan) etc.
+The Spiderpool also supports
+[Multus CNI](https://github.com/k8snetworkplumbingwg/multus-cni)
+case to assign IP for multiple interfaces.
+More CNIs will be tested for integration with Spiderpool.
+
+## Why Spiderpool
+
+Most overlay CNIs, like
+[Cilium](https://github.com/cilium/cilium)
+and [Calico](https://github.com/projectcalico/calico),
+have a good implementation of IPAM, so the Spiderpool is not intentionally designed for these cases, but may be integrated with them.
+
+The Spiderpool is specifically designed to use with underlay network, where administrators can accurately manage each IP.
+
+Currently, the community already has some IPAM plugins such as [whereabout](https://github.com/k8snetworkplumbingwg/whereabouts), [kube-ipam](https://github.com/cloudnativer/kube-ipam),
+[static](https://github.com/containernetworking/plugins/tree/main/plugins/ipam/static),
+[dhcp](https://github.com/containernetworking/plugins/tree/main/plugins/ipam/dhcp), and [host-local](https://github.com/containernetworking/plugins/tree/main/plugins/ipam/host-local),
+but few of them could help solve complex underlay-network issues, so we decide to develop the Spiderpool.
+
+BTW, there are also some CNI plugins that could work in the underlay mode, such as [kube-ovn](https://github.com/kubeovn/kube-ovn) and [coil](https://github.com/cybozu-go/coil).
+But the Spiderpool provides lots of different features. See [Features](#features) for details.
+
+## Features
+
+The Spiderpool provides a large number of different features as follows.
+
+* Based on CRD storage, all operation could be done with kubernetes API-server.
+
+* Support for assigning IP addresses with three options: IPv4-only, IPv6-only, and dual-stack.
+
+* Support for working on the clusters with three options: IPv4-only, IPv6-only, and dual-stack.
+
+* Support for creating multiple ippools.
+  Different namespaces and applications could monopolize or share an ippool.
+
+* An application could specify multiple backup ippool resources in case IP addresses in an ippool are out of use. Therefore, you neither need to scale up the IP resources in a fixed ippool, nor need to modify the application yaml to change an ippool.
+
+* Support to bind a range of IP addresses to a single application. No need to hard code an IP list in a deployment yaml, which is not easy to modify. With Spiderpool, you only need to set the selector field of ippool and scale up or down the IP resource of an ippool dynamically.
+
+* Support for always assigning the same IP address to a StatefulSet pod.
+
+* Different pods in a single controller could get IP addresses from
+  different subnets for an application deployed in different subnets or zones.
+
+* Administrator could safely edit ippool resources, where the Spiderpool will help validate the modification and prevent from data race.
+
+* Collect resources in real time, especially for solving IP leakage or slow collection, which may make new pod fail to assign IP addresses.
+
+* Support ranges of CNI plugin that supports third-party IPAM plugins. Especially, the Spiderpool could help much for CNI like [spiderflat](https://github.com/spidernet-io/spiderflat),
+  [macvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/macvlan),
+  [vlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/vlan),
+  [ipvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/ipvlan),
+  [sriov CNI](https://github.com/k8snetworkplumbingwg/sriov-cni),
+  [ovs CNI](https://github.com/k8snetworkplumbingwg/ovs-cni).
+
+* Especially support for [Multus CNI](https://github.com/k8snetworkplumbingwg/multus-cni) case to assign IP for multiple interfaces.
+
+* Have a good performance for assigning and collecting IP.
+
+* Support to reserve IP that will not be assigned to any pod.
+
+* Included metrics for looking into IP usage and issues.
+
+* By CIDR Manager, it could automatically scale up and down the IP address of the ippool, to distribute IP resource more reasonable between ippool.
+
+* Support for both ARM64 and ARM64.
+
+## Components
+
+Refer to [architecture](concepts/arch) for components.
+
+## Installation
+
+Refer to [installation](usage/install).
+
+## Quick Start
+
+Refer to [demo](usage/demo).
+
+## Development
+
+[Development guide](develop/pullrequest) is a reference point for development helper commands.
+
+## License
+
+Spiderpool is licensed under the Apache License, Version 2.0.

--- a/docs/concepts/arch.md
+++ b/docs/concepts/arch.md
@@ -1,4 +1,4 @@
-# architect
+# Architect
 
 ## architecture
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -29,3 +29,35 @@ markdown_extensions:
   - fenced_code
   - tables
   - attr_list
+
+nav:
+  - Usage:
+      - usage/demo.md
+      - usage/install.md
+      - usage/config.md
+      - usage/cli.md
+      - usage/statefulset.md
+      - usage/reserved-ip.md
+      - usage/select-ippool.md
+      - usage/metrics.md
+      - usage/annotation.md
+      - usage/advance.md
+      - usage/qa.md
+  - Concepts:
+      - concepts/arch.md
+      - concepts/allocation.md
+      - concepts/gc.md
+      - concepts/ippool.md
+      - concepts/reservedip.md
+      - concepts/workloadendpoint.md
+      - concepts/roadmap.md
+  - Reference:
+      - cmdref/spiderpoolctl.md
+      - cmdref/spiderpool-controller.md
+      - cmdref/spiderpool-agent.md
+  - Development:
+      - develop/pullrequest.md
+      - develop/release.md
+      - develop/swagger_openapi.md
+      - develop/test.md
+      - develop/changelog.md

--- a/docs/usage/config.md
+++ b/docs/usage/config.md
@@ -19,7 +19,7 @@ There is an example of IPAM configuration.
             "mtu":1500,
             "ipam":{
                 "type":"spiderpool",
-                "log_file_path":"/var/run/spidernet/spiderpool.log",
+                "log_file_path":"/var/log/spidernet/spiderpool.log",
                 "log_file_max_size":"100M",
                 "log_file_max_age":"30d",
                 "log_file_max_count":7,
@@ -30,7 +30,7 @@ There is an example of IPAM configuration.
 }
 ```
 
-- `log_file_path` (string, optional): Path to log file  of IPAM plugin, default to `"/var/run/spidernet/spiderpool.log"`.
+- `log_file_path` (string, optional): Path to log file  of IPAM plugin, default to `"/var/log/spidernet/spiderpool.log"`.
 - `log_file_max_size` (string, optional): Max size of each rotated file, default to `"100M"`.
 - `log_file_max_age` (string, optional): Max age of each rotated file, default to `"30d"`.
 - `log_file_max_count` (string, optional): Max number of rotated file, default to `"7"`.

--- a/pkg/logutils/log.go
+++ b/pkg/logutils/log.go
@@ -9,11 +9,12 @@ import (
 	"os"
 	"path/filepath"
 
+	"strings"
+
 	"github.com/spidernet-io/spiderpool/pkg/constant"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"gopkg.in/natefinch/lumberjack.v2"
-	"strings"
 )
 
 // Pre-define log instance with default info level.
@@ -40,7 +41,7 @@ type FileOutputOption struct {
 }
 
 const (
-	DefaultLogFilePath = "/tmp/cni.log"
+	DefaultLogFilePath = "/var/log/spidernet/spiderpool.log"
 	// MaxSize    = 100 // MB
 	DefaultLogFileMaxSize int = 100
 	// MaxAge     = 30 // days (no limit)
@@ -145,7 +146,7 @@ func NewLoggerWithOption(format LogFormat, outputMode LogMode, fileOutputOption 
 
 		err := os.MkdirAll(filepath.Dir(fileOutputOption.Filename), 0755)
 		if nil != err {
-			return nil, fmt.Errorf("Failed to create path for CNI log file: %v", filepath.Dir(fileOutputOption.Filename))
+			return nil, fmt.Errorf("Failed to create path %v for CNI log file: %v", filepath.Dir(fileOutputOption.Filename), err)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

the default the log dir should be the `/var/log/spidernet/spiderpool.log`.

Fix :
Some code use the /tmp/cni.log
Some docs use the /var/run/spidernet/spiderpool.log

**Which issue(s) this PR fixes**:

https://github.com/spidernet-io/spiderpool/issues/524

**Special notes for your reviewer**:

**make sure your commit is signed off**
