### PR TITLE
E2E: Reduced e2e running time

### DIFF
--- a/test/e2e/performance/performance_test.go
+++ b/test/e2e/performance/performance_test.go
@@ -60,6 +60,12 @@ var _ = Describe("performance test case", Serial, Label("performance"), func() {
 		})
 		DescribeTable("time cost for creating, rebuilding, deleting deployment pod in batches",
 			func(controllerType string, replicas int32, overtimeCheck time.Duration) {
+
+				// Improved e2e execution efficiency, performance tests run on Dual-stacks only
+				if !frame.Info.IpV6Enabled || !frame.Info.IpV4Enabled {
+					Skip("Test conditions（Dual-stack） are not met")
+				}
+
 				// pod annotation
 				podAnno := types.AnnoPodIPPoolValue{
 					NIC: &nic,


### PR DESCRIPTION
Signed-off-by: ty-dc <tao.yang@daocloud.io>

What this PR does / why we need it:
Reduced e2e running time
