### PR TITLE
feat:Group the routes in IP allocation result by NIC

### DIFF
--- a/api/v1/agent/models/ipam_add_args.go
+++ b/api/v1/agent/models/ipam_add_args.go
@@ -22,6 +22,9 @@ import (
 // swagger:model IpamAddArgs
 type IpamAddArgs struct {
 
+	// clean gateway
+	CleanGateway bool `json:"cleanGateway,omitempty"`
+
 	// container ID
 	// Required: true
 	ContainerID *string `json:"containerID"`

--- a/api/v1/agent/models/route.go
+++ b/api/v1/agent/models/route.go
@@ -29,6 +29,10 @@ type Route struct {
 	// gw
 	// Required: true
 	Gw *string `json:"gw"`
+
+	// if name
+	// Required: true
+	IfName *string `json:"ifName"`
 }
 
 // Validate validates this route
@@ -40,6 +44,10 @@ func (m *Route) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateGw(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateIfName(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -61,6 +69,15 @@ func (m *Route) validateDst(formats strfmt.Registry) error {
 func (m *Route) validateGw(formats strfmt.Registry) error {
 
 	if err := validate.Required("gw", "body", m.Gw); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Route) validateIfName(formats strfmt.Registry) error {
+
+	if err := validate.Required("ifName", "body", m.IfName); err != nil {
 		return err
 	}
 

--- a/api/v1/agent/openapi.yaml
+++ b/api/v1/agent/openapi.yaml
@@ -160,6 +160,8 @@ definitions:
         type: array
         items:
           type: string
+      cleanGateway:
+        type: boolean
     required:
       - podNamespace
       - podName
@@ -224,11 +226,14 @@ definitions:
     description: IPAM CNI types Route
     type: object
     properties:
+      ifName:
+        type: string
       dst:
         type: string
       gw:
         type: string
     required:
+      - ifName
       - dst
       - gw
   IpConfig:

--- a/api/v1/agent/server/embedded_spec.go
+++ b/api/v1/agent/server/embedded_spec.go
@@ -292,6 +292,9 @@ func init() {
         "netNamespace"
       ],
       "properties": {
+        "cleanGateway": {
+          "type": "boolean"
+        },
         "containerID": {
           "type": "string"
         },
@@ -377,6 +380,7 @@ func init() {
       "description": "IPAM CNI types Route",
       "type": "object",
       "required": [
+        "ifName",
         "dst",
         "gw"
       ],
@@ -385,6 +389,9 @@ func init() {
           "type": "string"
         },
         "gw": {
+          "type": "string"
+        },
+        "ifName": {
           "type": "string"
         }
       }
@@ -666,6 +673,9 @@ func init() {
         "netNamespace"
       ],
       "properties": {
+        "cleanGateway": {
+          "type": "boolean"
+        },
         "containerID": {
           "type": "string"
         },
@@ -751,6 +761,7 @@ func init() {
       "description": "IPAM CNI types Route",
       "type": "object",
       "required": [
+        "ifName",
         "dst",
         "gw"
       ],
@@ -759,6 +770,9 @@ func init() {
           "type": "string"
         },
         "gw": {
+          "type": "string"
+        },
+        "ifName": {
           "type": "string"
         }
       }

--- a/charts/spiderpool/crds/spiderpool.spidernet.io_spiderendpoints.yaml
+++ b/charts/spiderpool/crds/spiderpool.spidernet.io_spiderendpoints.yaml
@@ -80,6 +80,8 @@ spec:
                     items:
                       description: TODO
                       properties:
+                        cleanGateway:
+                          type: boolean
                         interface:
                           type: string
                         ipv4:
@@ -134,6 +136,8 @@ spec:
                       items:
                         description: TODO
                         properties:
+                          cleanGateway:
+                            type: boolean
                           interface:
                             type: string
                           ipv4:

--- a/cmd/spiderpool/cmd/cni_types.go
+++ b/cmd/spiderpool/cmd/cni_types.go
@@ -52,6 +52,7 @@ type IPAMConfig struct {
 
 	DefaultIPv4IPPool []string `json:"default_ipv4_ippool"`
 	DefaultIPv6IPPool []string `json:"default_ipv6_ippool"`
+	CleanGateway      bool     `json:"clean_gateway"`
 
 	IpamUnixSocketPath string `json:"ipam_unix_socket_path"`
 }

--- a/cmd/spiderpool/cmd/command_test.go
+++ b/cmd/spiderpool/cmd/command_test.go
@@ -192,7 +192,7 @@ var _ = Describe("spiderpool plugin", Label("unitest", "ipam_plugin_test"), func
 				ipamAddResp := &models.IpamAddResponse{
 					DNS: &models.DNS{
 						Domain:      "local",
-						Nameservers: []string{"10.1.0.1"},
+						Nameservers: []string{"1.2.3.1"},
 						Options:     []string{"somedomain.com"},
 						Search:      []string{"foo"},
 					},
@@ -210,11 +210,12 @@ var _ = Describe("spiderpool plugin", Label("unitest", "ipam_plugin_test"), func
 							Version: new(int64),
 						},
 					},
-					Routes: []*models.Route{{Dst: new(string), Gw: new(string)}},
+					Routes: []*models.Route{{IfName: new(string), Dst: new(string), Gw: new(string)}},
 				}
 				// Routes
+				*ipamAddResp.Routes[0].IfName = "eth0"
 				*ipamAddResp.Routes[0].Dst = "15.5.6.0/24"
-				*ipamAddResp.Routes[0].Gw = "10.1.0.2"
+				*ipamAddResp.Routes[0].Gw = "1.2.3.2"
 
 				// multi nic, ip responses
 				*ipamAddResp.Ips[0].Address = "10.1.0.5/24"
@@ -232,7 +233,7 @@ var _ = Describe("spiderpool plugin", Label("unitest", "ipam_plugin_test"), func
 				expectResult.CNIVersion = cniVersion
 				// DNS
 				expectResult.DNS = types.DNS{
-					Nameservers: []string{"10.1.0.1"},
+					Nameservers: []string{"1.2.3.1"},
 					Domain:      "local",
 					Search:      []string{"foo"},
 					Options:     []string{"somedomain.com"},
@@ -244,7 +245,7 @@ var _ = Describe("spiderpool plugin", Label("unitest", "ipam_plugin_test"), func
 				expectResult.IPs[0].Address = net.IPNet{IP: net.ParseIP("1.2.3.30"), Mask: net.CIDRMask(24, 32)}
 				// Routes
 				_, ipNet, _ := net.ParseCIDR("15.5.6.0/24")
-				expectResult.Routes = []*types.Route{{Dst: *ipNet, GW: net.ParseIP("10.1.0.2")}}
+				expectResult.Routes = []*types.Route{{Dst: *ipNet, GW: net.ParseIP("1.2.3.2")}}
 				//Interfaces
 				expectResult.Interfaces = []*current.Interface{{Name: "eth0"}}
 				return expectResult

--- a/pkg/constant/errors.go
+++ b/pkg/constant/errors.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	ErrInternal          = errors.New("internal server error")
-	ErrWrongInput        = errors.New("wrong input information")
+	ErrWrongInput        = errors.New("wrong input")
 	ErrNotAllocatablePod = errors.New("not allocatable Pod")
 	ErrNoAvailablePool   = errors.New("no available IPPool")
 	ErrIPUsedOut         = errors.New("all IP used out")

--- a/pkg/constant/ip.go
+++ b/pkg/constant/ip.go
@@ -6,7 +6,6 @@ package constant
 import "github.com/spidernet-io/spiderpool/pkg/types"
 
 const (
-	Dual types.IPVersion = 64
 	IPv4 types.IPVersion = 4
 	IPv6 types.IPVersion = 6
 )

--- a/pkg/constant/k8s.go
+++ b/pkg/constant/k8s.go
@@ -61,12 +61,6 @@ const (
 )
 
 const (
-	SingleNICDefaultRoute types.DefaultRouteType = iota
-	MultiNICDefaultRoute
-	MultiNICNotDefaultRoute
-)
-
-const (
 	SpiderpoolAgent        = "spiderpool-agent"
 	SpiderpoolController   = "spiderpool-controller"
 	SpiderpoolAPIGroup     = "spiderpool.spidernet.io"

--- a/pkg/ipam/tools.go
+++ b/pkg/ipam/tools.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -17,88 +18,128 @@ import (
 )
 
 func getPoolFromPodAnnoPools(ctx context.Context, anno, nic string) ([]*ToBeAllocated, error) {
-	// TODO(iiiceoo): Check Pod annotations
 	logger := logutils.FromContext(ctx)
 	logger.Sugar().Infof("Use IPPools from Pod annotation '%s'", constant.AnnoPodIPPools)
 
 	var annoPodIPPools types.AnnoPodIPPoolsValue
+	errPrefix := fmt.Errorf("%w of Pod annotation '%s'", constant.ErrWrongInput, constant.AnnoPodIPPools)
 	err := json.Unmarshal([]byte(anno), &annoPodIPPools)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %v", errPrefix, err)
+	}
+	if len(annoPodIPPools) == 0 {
+		return nil, fmt.Errorf("%w, value requires at least one item", errPrefix)
 	}
 
-	var validIface bool
+	nicSet := map[string]struct{}{}
 	for _, v := range annoPodIPPools {
-		if v.NIC == nic {
-			validIface = true
-			break
+		if v.NIC == "" {
+			return nil, fmt.Errorf("%w, interface must be specified", errPrefix)
 		}
+		if len(v.IPv4Pools) == 0 && len(v.IPv6Pools) == 0 {
+			return nil, fmt.Errorf("%w, at least one pool must be specified", errPrefix)
+		}
+		nicSet[v.NIC] = struct{}{}
 	}
-
-	if !validIface {
-		return nil, fmt.Errorf("the interface of the Pod annotation does not contain that requested by runtime: %w", constant.ErrWrongInput)
+	if len(nicSet) < len(annoPodIPPools) {
+		return nil, fmt.Errorf("%w, duplicate interface", errPrefix)
+	}
+	if _, ok := nicSet[nic]; !ok {
+		return nil, fmt.Errorf("%w, interfaces do not contain that requested by runtime", errPrefix)
 	}
 
 	var tt []*ToBeAllocated
 	for _, v := range annoPodIPPools {
-		var routeType types.DefaultRouteType
-		if v.DefaultRoute {
-			routeType = constant.MultiNICDefaultRoute
-		} else {
-			routeType = constant.MultiNICNotDefaultRoute
+		t := &ToBeAllocated{
+			NIC:          v.NIC,
+			CleanGateway: v.CleanGateway,
 		}
-
-		tt = append(tt, &ToBeAllocated{
-			NIC:              v.NIC,
-			DefaultRouteType: routeType,
-			V4PoolCandidates: v.IPv4Pools,
-			V6PoolCandidates: v.IPv6Pools,
-		})
+		if len(v.IPv4Pools) != 0 {
+			t.PoolCandidates = append(t.PoolCandidates, &PoolCandidate{
+				IPVersion: constant.IPv4,
+				Pools:     v.IPv4Pools,
+			})
+		}
+		if len(v.IPv6Pools) != 0 {
+			t.PoolCandidates = append(t.PoolCandidates, &PoolCandidate{
+				IPVersion: constant.IPv6,
+				Pools:     v.IPv6Pools,
+			})
+		}
+		tt = append(tt, t)
 	}
 
 	return tt, nil
 }
 
-func getPoolFromPodAnnoPool(ctx context.Context, anno, nic string) (*ToBeAllocated, error) {
-	// TODO(iiiceoo): Check Pod annotations
+func getPoolFromPodAnnoPool(ctx context.Context, anno, nic string, cleanGateway bool) (*ToBeAllocated, error) {
 	logger := logutils.FromContext(ctx)
 	logger.Sugar().Infof("Use IPPools from Pod annotation '%s'", constant.AnnoPodIPPool)
 
 	var annoPodIPPool types.AnnoPodIPPoolValue
+	errPrifix := fmt.Errorf("%w of Pod annotation '%s'", constant.ErrWrongInput, constant.AnnoPodIPPool)
 	if err := json.Unmarshal([]byte(anno), &annoPodIPPool); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %v", errPrifix, err)
 	}
 
 	if annoPodIPPool.NIC != nil && *annoPodIPPool.NIC != nic {
-		return nil, fmt.Errorf("the interface of Pod annotation is different from that requested by runtime: %w", constant.ErrWrongInput)
+		return nil, fmt.Errorf("%w, interface is different from that requested by runtime", errPrifix)
 	}
 
-	return &ToBeAllocated{
-		NIC:              nic,
-		DefaultRouteType: constant.SingleNICDefaultRoute,
-		V4PoolCandidates: annoPodIPPool.IPv4Pools,
-		V6PoolCandidates: annoPodIPPool.IPv6Pools,
-	}, nil
+	if len(annoPodIPPool.IPv4Pools) == 0 && len(annoPodIPPool.IPv6Pools) == 0 {
+		return nil, fmt.Errorf("%w, at least one pool must be specified", errPrifix)
+	}
+
+	t := &ToBeAllocated{
+		NIC:          nic,
+		CleanGateway: cleanGateway,
+	}
+	if len(annoPodIPPool.IPv4Pools) != 0 {
+		t.PoolCandidates = append(t.PoolCandidates, &PoolCandidate{
+			IPVersion: constant.IPv4,
+			Pools:     annoPodIPPool.IPv4Pools,
+		})
+	}
+	if len(annoPodIPPool.IPv6Pools) != 0 {
+		t.PoolCandidates = append(t.PoolCandidates, &PoolCandidate{
+			IPVersion: constant.IPv6,
+			Pools:     annoPodIPPool.IPv6Pools,
+		})
+	}
+
+	return t, nil
 }
 
-func getPoolFromNetConf(ctx context.Context, nic string, netConfV4Pool, netConfV6Pool []string) *ToBeAllocated {
+func getPoolFromNetConf(ctx context.Context, nic string, netConfV4Pool, netConfV6Pool []string, cleanGateway bool) *ToBeAllocated {
 	logger := logutils.FromContext(ctx)
 
-	var t *ToBeAllocated
-	if len(netConfV4Pool) != 0 || len(netConfV6Pool) != 0 {
-		logger.Info("Use IPPools from CNI network configuration")
-		t = &ToBeAllocated{
-			NIC:              nic,
-			DefaultRouteType: constant.SingleNICDefaultRoute,
-			V4PoolCandidates: netConfV4Pool,
-			V6PoolCandidates: netConfV6Pool,
-		}
+	if len(netConfV4Pool) == 0 || len(netConfV6Pool) == 0 {
+		return nil
+	}
+
+	logger.Info("Use IPPools from CNI network configuration")
+	t := &ToBeAllocated{
+		NIC:          nic,
+		CleanGateway: cleanGateway,
+	}
+	if len(netConfV4Pool) != 0 {
+		t.PoolCandidates = append(t.PoolCandidates, &PoolCandidate{
+			IPVersion: constant.IPv4,
+			Pools:     netConfV4Pool,
+		})
+	}
+	if len(netConfV6Pool) != 0 {
+		t.PoolCandidates = append(t.PoolCandidates, &PoolCandidate{
+			IPVersion: constant.IPv6,
+			Pools:     netConfV6Pool,
+		})
 	}
 
 	return t
 }
 
 func getCustomRoutes(ctx context.Context, pod *corev1.Pod) ([]*models.Route, error) {
+	// TODO(iiiceoo): Check Pod annotations, use pkg ip
 	anno, ok := pod.Annotations[constant.AnnoPodRoutes]
 	if !ok {
 		return nil, nil
@@ -111,4 +152,28 @@ func getCustomRoutes(ctx context.Context, pod *corev1.Pod) ([]*models.Route, err
 	}
 
 	return convertAnnoPodRoutesToOAIRoutes(annoPodRoutes), nil
+}
+
+// TODO(iiiceoo): Refactor
+func groupCustomRoutesByGW(ctx context.Context, customRoutes *[]*models.Route, ip *models.IPConfig) ([]*models.Route, error) {
+	if len(*customRoutes) == 0 {
+		return nil, nil
+	}
+
+	_, ipNet, err := net.ParseCIDR(*ip.Address)
+	if err != nil {
+		return nil, err
+	}
+
+	var routes []*models.Route
+	for i := 0; i < len(*customRoutes); i++ {
+		if ipNet.Contains(net.ParseIP(*(*customRoutes)[i].Gw)) {
+			*(*customRoutes)[i].IfName = *ip.Nic
+			routes = append(routes, (*customRoutes)[i])
+			*customRoutes = append((*customRoutes)[:i], (*customRoutes)[i+1:]...)
+			i--
+		}
+	}
+
+	return routes, nil
 }

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -11,18 +11,26 @@ import (
 )
 
 type ToBeAllocated struct {
-	IPVersion        types.IPVersion
-	NIC              string
-	DefaultRouteType types.DefaultRouteType
-	V4PoolCandidates []string
-	V6PoolCandidates []string
+	NIC            string
+	CleanGateway   bool
+	PoolCandidates []*PoolCandidate
+}
+
+type PoolCandidate struct {
+	IPVersion types.IPVersion
+	Pools     []string
 }
 
 func (t *ToBeAllocated) String() string {
 	return fmt.Sprintf("%+v", *t)
 }
 
+func (c *PoolCandidate) String() string {
+	return fmt.Sprintf("%+v", *c)
+}
+
 type AllocationResult struct {
-	IP     *models.IPConfig
-	Routes []*models.Route
+	IP           *models.IPConfig
+	Routes       []*models.Route
+	CleanGateway bool
 }

--- a/pkg/k8s/apis/v1/workloadendpoint_types.go
+++ b/pkg/k8s/apis/v1/workloadendpoint_types.go
@@ -66,6 +66,9 @@ type IPAllocationDetail struct {
 	IPv6Gateway *string `json:"ipv6Gateway,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	CleanGateway *bool `json:"cleanGateway,omitempty"`
+
+	// +kubebuilder:validation:Optional
 	Routes []Route `json:"routes,omitempty"`
 }
 

--- a/pkg/k8s/apis/v1/zz_generated.deepcopy.go
+++ b/pkg/k8s/apis/v1/zz_generated.deepcopy.go
@@ -51,6 +51,11 @@ func (in *IPAllocationDetail) DeepCopyInto(out *IPAllocationDetail) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.CleanGateway != nil {
+		in, out := &in.CleanGateway, &out.CleanGateway
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Routes != nil {
 		in, out := &in.Routes, &out.Routes
 		*out = make([]Route, len(*in))

--- a/pkg/types/k8s.go
+++ b/pkg/types/k8s.go
@@ -5,8 +5,6 @@ package types
 
 type PodStatus string
 
-type DefaultRouteType int
-
 type AnnoPodIPPoolValue struct {
 	NIC       *string  `json:"interface,omitempty"`
 	IPv4Pools []string `json:"ipv4pools,omitempty"`
@@ -19,7 +17,7 @@ type AnnoIPPoolItem struct {
 	NIC          string   `json:"interface"`
 	IPv4Pools    []string `json:"ipv4pools,omitempty"`
 	IPv6Pools    []string `json:"ipv6pools,omitempty"`
-	DefaultRoute bool     `json:"defaultRoute"`
+	CleanGateway bool     `json:"cleanGateway"`
 }
 
 type AnnoPodRoutesValue []AnnoRouteItem

--- a/test/e2e/annotation/annotation_test.go
+++ b/test/e2e/annotation/annotation_test.go
@@ -211,11 +211,11 @@ var _ = Describe("test annotation", Label("annotation"), func() {
 	Context("annotation priority", func() {
 		var nic, podIppoolAnnoStr, podIppoolsAnnoStr string
 		var v4PoolNameList, v6PoolNameList []string
-		var defaultRouteBool bool
+		var cleanGateway bool
 		var err error
 		BeforeEach(func() {
 			nic = "eth0"
-			defaultRouteBool = false
+			cleanGateway = false
 			if frame.Info.IpV4Enabled {
 				v4PoolNameList, err = common.BatchCreateIppoolWithSpecifiedIPNumber(frame, 1, 200, true)
 				Expect(err).NotTo(HaveOccurred(), "Failed to create v4 pool")
@@ -257,7 +257,7 @@ var _ = Describe("test annotation", Label("annotation"), func() {
 			podIppoolsAnno := types.AnnoPodIPPoolsValue{
 				types.AnnoIPPoolItem{
 					NIC:          nic,
-					DefaultRoute: defaultRouteBool,
+					CleanGateway: cleanGateway,
 				},
 			}
 			if frame.Info.IpV4Enabled {


### PR DESCRIPTION
- Add verification to some annotations of Pod that are responsible for IP pool selection.
- Add 'CleanGateway' field in SpiderEndpoint to mark the default gateway effectiveness in multi-NIC case.
- Group custom routes specified in Pod annotation by NIC.

Signed-off-by: iiiceoo <ziqian.xue@daocloud.io>
