### PR TITLE
E2E: case D00002 edit ippool route and gateway

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/sasha-s/go-deadlock v0.3.1
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/pflag v1.0.5
-	github.com/spidernet-io/e2eframework v0.0.0-20220826063012-eed49c4da208
+	github.com/spidernet-io/e2eframework v0.0.0-20220829113343-79f40a405cae
 	go.opentelemetry.io/otel v1.9.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.31.0
 	go.opentelemetry.io/otel/metric v0.31.0

--- a/go.sum
+++ b/go.sum
@@ -625,8 +625,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/spf13/viper v1.10.1 h1:nuJZuYpG7gTj/XqiUwg8bA0cp1+M2mC3J4g5luUYBKk=
 github.com/spf13/viper v1.10.1/go.mod h1:IGlFPqhNAPKRxohIzWpI5QEy4kuI7tcl5WvR+8qy1rU=
-github.com/spidernet-io/e2eframework v0.0.0-20220826063012-eed49c4da208 h1:jxfzJLSlfyHN5AxpC6P1LKy8EwMYOIu1gBFKSk/JHz8=
-github.com/spidernet-io/e2eframework v0.0.0-20220826063012-eed49c4da208/go.mod h1:A+M+Oqf+vMPuztTqlYQojr4twRvjDP5WHPswwU3JATY=
+github.com/spidernet-io/e2eframework v0.0.0-20220829113343-79f40a405cae h1:3JAg+eRZe2Ldbxjgmop111HAvJBks2E/4Z2eUkQbq0E=
+github.com/spidernet-io/e2eframework v0.0.0-20220829113343-79f40a405cae/go.mod h1:A+M+Oqf+vMPuztTqlYQojr4twRvjDP5WHPswwU3JATY=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/test/e2e/ippoolcr/ippoolcr_test.go
+++ b/test/e2e/ippoolcr/ippoolcr_test.go
@@ -5,7 +5,9 @@ package ippoolcr_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	spiderpoolv1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v1"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -36,7 +38,7 @@ var _ = Describe("test ippool CR", Label("ippoolCR"), func() {
 
 	Context("test ippool CR", func() {
 		var v4PoolName, v4PoolName1, v6PoolName, v6PoolName1, nic, podAnnoStr, deployName string
-		var v4PoolObj, v4PoolObj1, v6PoolObj, v6PoolObj1 *spiderpoolv1.SpiderIPPool
+		var v4PoolObj, v4PoolObj1, v6PoolObj, v6PoolObj1, v4Pool, v6Pool *spiderpoolv1.SpiderIPPool
 		var v4PoolNameList, v6PoolNameList []string
 		var disable = new(bool)
 
@@ -45,23 +47,33 @@ var _ = Describe("test ippool CR", Label("ippoolCR"), func() {
 				v4PoolName, v4PoolObj = common.GenerateExampleIpv4poolObject(5)
 				Expect(v4PoolObj.Spec.IPs).NotTo(BeNil())
 				// create ipv4 pool
-				createIPPool(v4PoolObj)
+				GinkgoWriter.Printf("Create v4 ippool %v\n", v4PoolObj.Name)
+				Expect(common.CreateIppool(frame, v4PoolObj)).To(Succeed())
+				GinkgoWriter.Printf("Succeeded to create v4 ippool %v \n", v4PoolObj.Name)
 				v4PoolNameList = append(v4PoolNameList, v4PoolName)
 			}
 			if frame.Info.IpV6Enabled {
 				v6PoolName, v6PoolObj = common.GenerateExampleIpv6poolObject(5)
 				Expect(v6PoolObj.Spec.IPs).NotTo(BeNil())
 				// create ipv6 pool
-				createIPPool(v6PoolObj)
+				GinkgoWriter.Printf("Create v6 ippool %v\n", v6PoolObj.Name)
+				Expect(common.CreateIppool(frame, v6PoolObj)).To(Succeed())
+				GinkgoWriter.Printf("Succeeded to create v6 ippool %v \n", v6PoolObj.Name)
 				v6PoolNameList = append(v6PoolNameList, v6PoolName)
 			}
 			DeferCleanup(func() {
 				// delete ippool
 				if frame.Info.IpV4Enabled {
-					deleteIPPoolUntilFinish(v4PoolName)
+					ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+					defer cancel()
+					GinkgoWriter.Printf("Delete ippool %v\n", v4PoolName)
+					Expect(common.DeleteIPPoolUntilFinish(frame, v4PoolName, ctx)).To(Succeed())
 				}
 				if frame.Info.IpV6Enabled {
-					deleteIPPoolUntilFinish(v6PoolName)
+					ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+					defer cancel()
+					GinkgoWriter.Printf("Delete ippool %v\n", v6PoolName)
+					Expect(common.DeleteIPPoolUntilFinish(frame, v6PoolName, ctx)).To(Succeed())
 				}
 			})
 		})
@@ -176,6 +188,157 @@ var _ = Describe("test ippool CR", Label("ippoolCR"), func() {
 			Expect(common.WaitIPReclaimedFinish(frame, v4PoolNameList, v6PoolNameList, podList, time.Minute)).To(Succeed())
 			GinkgoWriter.Println("Pod IP is successfully released")
 		})
+
+		It("add a route with `routes` and `gateway` fields in the ippool spec", Label("D00002", "D00003"), func() {
+			podName := "pod" + tools.RandomName()
+			annoPodIPPool := types.AnnoPodIPPoolValue{}
+			var v4Gateway, v6Gateway, v4Dst, v6Dst, v4Via, v6Via string
+			var v4InvalidGateway, v6InvalidGateway string
+
+			num1 := common.GenerateRandomNumber(255)
+			num2 := common.GenerateRandomNumber(255)
+			num3 := common.GenerateRandomNumber(255)
+			num4 := common.GenerateRandomNumber(255)
+			v4InvalidGateway = fmt.Sprintf("%s.%s.%s.%s", num1, num2, num3, num4)
+			v4Dst = fmt.Sprintf("%s.%s.0.0/16", num3, num4)
+
+			num1 = common.GenerateRandomNumber(9999)
+			num2 = common.GenerateRandomNumber(9999)
+			num3 = common.GenerateRandomNumber(9999)
+			num4 = common.GenerateRandomNumber(9999)
+			v6InvalidGateway = fmt.Sprintf("%s:%s:%s::%s", num1, num2, num3, num4)
+			v6Dst = fmt.Sprintf("%s:%s::/32", num3, num4)
+
+			if frame.Info.IpV4Enabled {
+				annoPodIPPool.IPv4Pools = []string{v4PoolName}
+				v4Gateway = strings.Split(v4PoolObj.Spec.Subnet, "0/")[0] + "1"
+				v4Via = strings.Split(v4PoolObj.Spec.Subnet, "0/")[0] + "254"
+			}
+			if frame.Info.IpV6Enabled {
+				annoPodIPPool.IPv6Pools = []string{v6PoolName}
+				v6Gateway = strings.Split(v6PoolObj.Spec.Subnet, "/")[0] + "1"
+				v6Via = strings.Split(v6PoolObj.Spec.Subnet, "/")[0] + "fe"
+			}
+
+			// update ippool
+			if frame.Info.IpV4Enabled {
+				By("update v4 pool: invalid `gateway` and valid `route`")
+				// get ipv4 pool
+				v4Pool = common.GetIppoolByName(frame, v4PoolName)
+				Expect(v4Pool).NotTo(BeNil())
+
+				v4Pool.Spec.Gateway = &v4InvalidGateway
+				route := spiderpoolv1.Route{
+					Dst: v4Dst,
+					Gw:  v4Via,
+				}
+				v4Pool.Spec.Routes = []spiderpoolv1.Route{route}
+				// update v4 ippool
+				Expect(frame.UpdateResource(v4Pool)).NotTo(Succeed(), "error: we expect failed to update v4 ippool: %v with invalid gateway: %v, and valid route: %+v\n", v4PoolName, v4InvalidGateway, route)
+
+				By("update v4 pool: valid `gateway` and invalid `route`")
+				// get ipv4 pool
+				v4Pool = common.GetIppoolByName(frame, v4PoolName)
+				Expect(v4Pool).NotTo(BeNil())
+
+				v4Pool.Spec.Gateway = &v4Gateway
+				route = spiderpoolv1.Route{
+					Dst: v4Dst,
+					Gw:  v4InvalidGateway,
+				}
+				v4Pool.Spec.Routes = []spiderpoolv1.Route{route}
+				// update v4 ippool
+				Expect(frame.UpdateResource(v4Pool)).NotTo(Succeed(), "error: we expect failed to update v4 ippool: %v with valid gateway: %v, and invalid route: %+v\n", v4PoolName, v4InvalidGateway, route)
+
+				By("update v4 pool: valid `gateway` and `route`")
+				// get ipv4 pool
+				v4Pool = common.GetIppoolByName(frame, v4PoolName)
+				Expect(v4Pool).NotTo(BeNil())
+
+				v4Pool.Spec.Gateway = &v4Gateway
+				route = spiderpoolv1.Route{
+					Dst: v4Dst,
+					Gw:  v4Via,
+				}
+				v4Pool.Spec.Routes = []spiderpoolv1.Route{route}
+				// update v4 ippool
+				Expect(frame.UpdateResource(v4Pool)).To(Succeed(), "failed to update v4 ippool: %v with valid gateway: %v, and route: %+v\n", v4PoolName, v4Gateway, route)
+			}
+			if frame.Info.IpV6Enabled {
+				By("update v6 pool: invalid `gateway` and valid `route`")
+				// get ipv6 pool
+				v6Pool = common.GetIppoolByName(frame, v6PoolName)
+				Expect(v6Pool).NotTo(BeNil())
+
+				v6PoolObj.Spec.Gateway = &v6InvalidGateway
+				route := spiderpoolv1.Route{
+					Dst: v6Dst,
+					Gw:  v6Via,
+				}
+				v6PoolObj.Spec.Routes = []spiderpoolv1.Route{route}
+				// update v6 ippool
+				Expect(frame.UpdateResource(v6PoolObj)).NotTo(Succeed(), "error: we expect failed to update v6 ippool: %v with invalid gateway: %v, and valid route: %+v\n", v6PoolName, v6InvalidGateway, route)
+
+				By("update v6 pool: valid `gateway` and invalid `route`")
+				// get ipv6 pool
+				v6Pool = common.GetIppoolByName(frame, v6PoolName)
+				Expect(v6Pool).NotTo(BeNil())
+
+				v6PoolObj.Spec.Gateway = &v6Gateway
+				route = spiderpoolv1.Route{
+					Dst: v6Dst,
+					Gw:  v6InvalidGateway,
+				}
+				v6PoolObj.Spec.Routes = []spiderpoolv1.Route{route}
+				// update v6 ippool
+				Expect(frame.UpdateResource(v6PoolObj)).NotTo(Succeed(), "error: we expect failed to update v6 ippool: %v with valid gateway: %v, and invalid route: %+v\n", v6PoolName, v6InvalidGateway, route)
+
+				By("update v6 pool: valid `gateway` and `route`")
+				// get ipv6 pool
+				v6Pool = common.GetIppoolByName(frame, v6PoolName)
+				Expect(v6Pool).NotTo(BeNil())
+
+				v6Pool.Spec.Gateway = &v6Gateway
+				route = spiderpoolv1.Route{
+					Dst: v6Dst,
+					Gw:  v6Via,
+				}
+				v6Pool.Spec.Routes = []spiderpoolv1.Route{route}
+				// update v6 ippool
+				Expect(frame.UpdateResource(v6Pool)).To(Succeed(), "failed to update v6 ippool: %v with valid gateway: %v, and route: %+v\n", v6PoolName, v6Gateway, route)
+			}
+
+			// create pod
+			common.CreatePodWithAnnoPodIPPool(frame, podName, nsName, annoPodIPPool)
+
+			// check whether the route information is effective
+			GinkgoWriter.Println("check whether the route information is effective")
+			if frame.Info.IpV4Enabled {
+				ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+				defer cancel()
+				checkGatewayCommand := fmt.Sprintf("ip r | grep 'default via %s'", v4Gateway)
+				checkRouteCommand := fmt.Sprintf("ip r | grep '%s via %s'", v4Dst, v4Via)
+				_, err := frame.ExecCommandInPod(podName, nsName, checkGatewayCommand, ctx)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = frame.ExecCommandInPod(podName, nsName, checkRouteCommand, ctx)
+				Expect(err).NotTo(HaveOccurred())
+			}
+			if frame.Info.IpV6Enabled {
+				ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+				defer cancel()
+				checkGatewayCommand := fmt.Sprintf("ip -6 r | grep 'default via %s'", v6Gateway)
+				checkRouteCommand := fmt.Sprintf("ip -6 r | grep '%s via %s'", v6Dst, v6Via)
+				_, err := frame.ExecCommandInPod(podName, nsName, checkGatewayCommand, ctx)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = frame.ExecCommandInPod(podName, nsName, checkRouteCommand, ctx)
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			// delete pod
+			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			defer cancel()
+			Expect(frame.DeletePodUntilFinish(podName, nsName, ctx)).To(Succeed())
+		})
 	})
 
 	Context("create and delete batch of ippool", func() {
@@ -220,16 +383,3 @@ var _ = Describe("test ippool CR", Label("ippoolCR"), func() {
 			})
 	})
 })
-
-func deleteIPPoolUntilFinish(poolName string) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-	GinkgoWriter.Printf("Delete ippool %v\n", poolName)
-	Expect(common.DeleteIPPoolUntilFinish(frame, poolName, ctx)).To(Succeed())
-}
-
-func createIPPool(IPPoolObj *spiderpoolv1.SpiderIPPool) {
-	GinkgoWriter.Printf("Create ippool %v\n", IPPoolObj.Name)
-	Expect(common.CreateIppool(frame, IPPoolObj)).To(Succeed())
-	GinkgoWriter.Printf("Succeeded to create ippool %v \n", IPPoolObj.Name)
-}

--- a/vendor/github.com/spidernet-io/e2eframework/framework/kind.go
+++ b/vendor/github.com/spidernet-io/e2eframework/framework/kind.go
@@ -2,4 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 package framework
 
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
 // operate node container, like shutdown, ssh to login
+func (f *Framework) ExecKubectl(command string, ctx context.Context) ([]byte, error) {
+	args := fmt.Sprintf("kubectl --kubeconfig %s %s", f.Info.KubeConfigPath, command)
+	return exec.CommandContext(ctx, "sh", "-c", args).CombinedOutput()
+}
+
+func (f *Framework) ExecCommandInPod(podName, nameSpace, command string, ctx context.Context) ([]byte, error) {
+	command = fmt.Sprintf("exec %s -n %s -- %s", podName, nameSpace, command)
+	return f.ExecKubectl(command, ctx)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -371,7 +371,7 @@ github.com/spf13/viper/internal/encoding/hcl
 github.com/spf13/viper/internal/encoding/json
 github.com/spf13/viper/internal/encoding/toml
 github.com/spf13/viper/internal/encoding/yaml
-# github.com/spidernet-io/e2eframework v0.0.0-20220826063012-eed49c4da208
+# github.com/spidernet-io/e2eframework v0.0.0-20220829113343-79f40a405cae
 ## explicit; go 1.17
 github.com/spidernet-io/e2eframework/framework
 github.com/spidernet-io/e2eframework/tools


### PR DESCRIPTION
**What this PR does / why we need it**:
 case D00002: Add a route with `routes` and `gateway` fields in the ippool spec, which only takes effect on the new pod and does not on the old pods
 case D00003:  Failed to add wrong IPPool gateway and route to an IPPool CR
