### PR TITLE
E2E: Reduce test time and allow only performance tests to be run in dual stacks.

### DIFF
--- a/.github/workflows/auto-pr-ci.yaml
+++ b/.github/workflows/auto-pr-ci.yaml
@@ -372,9 +372,15 @@ jobs:
         continue-on-error: true
         run: |
           echo ${{ github.event.inputs.labels }}
+          LABELS=
+          if [ -n "${{ needs.get_ref.outputs.e2e_labels }}" ]; then
+              LABELS=" ${{ needs.get_ref.outputs.e2e_labels }}  && !performance "
+          else
+              LABELS=" !performance "
+          fi
           RESULT=0
           make e2e_test -e E2E_CLUSTER_NAME=${{ steps.prepare.outputs.clusterName }}  \
-              -e E2E_GINKGO_LABELS=${{ needs.get_ref.outputs.e2e_labels }} \
+              -e E2E_GINKGO_LABELS="${LABELS}" \
               -e E2E_TIMEOUT=${{ env.E2E_TIME_OUT }}  \
               -e E2E_IP_FAMILY=ipv4 -e PYROSCOPE_LOCAL_PORT="" || RESULT=1
           if ((RESULT==0)) ; then
@@ -441,9 +447,15 @@ jobs:
         continue-on-error: true
         run: |
           echo ${{ github.event.inputs.labels }}
+          LABELS=
+          if [ -n "${{ needs.get_ref.outputs.e2e_labels }}" ]; then
+              LABELS=" ${{ needs.get_ref.outputs.e2e_labels }}  && !performance "
+          else
+              LABELS=" !performance "
+          fi
           RESULT=0
           make e2e_test -e E2E_CLUSTER_NAME=${{ steps.prepare.outputs.clusterName }}  \
-              -e E2E_GINKGO_LABELS=${{ needs.get_ref.outputs.e2e_labels }} \
+              -e E2E_GINKGO_LABELS="${LABELS}" \
               -e E2E_TIMEOUT=${{ env.E2E_TIME_OUT }}  \
               -e E2E_IP_FAMILY=ipv6 -e PYROSCOPE_LOCAL_PORT="" || RESULT=1
           if ((RESULT==0)) ; then


### PR DESCRIPTION
Signed-off-by: ty-dc <tao.yang@daocloud.io>

What type of PR is this?
/kind  pr/release/none-required

What this PR does / why we need it:

- Reduce test time and allow only performance tests to be run in dual stacks.

Which issue(s) this PR fixes:
Fixes #

Additional documentation e.g.,  development documentation, usage docs, etc.:
```
None
```
