### PR TITLE
E2E: add test case L00008 && A00009 for spiderpool

### DIFF
--- a/test/e2e/reclaim/reclaim_test.go
+++ b/test/e2e/reclaim/reclaim_test.go
@@ -64,7 +64,7 @@ var _ = Describe("test ip with reclaim ip case", Label("reclaim"), func() {
 			for {
 				select {
 				case <-ctx.Done():
-					Fail("IPs allocated during their validity period are recorded in the ippool.")
+					Fail("IPs allocated during their validity period are not recorded in the ippool.")
 				default:
 					podList, err := frame.GetJobPodList(jd)
 					Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/reliability/reliability_test.go
+++ b/test/e2e/reliability/reliability_test.go
@@ -97,7 +97,7 @@ var _ = Describe("test reliability", Label("reliability"), Serial, func() {
 		Entry("Successfully run a pod during the API-server is restarting",
 			Label("R00003"), "apiserver", map[string]string{"component": "kube-apiserver"}, time.Second*90),
 		Entry("Successfully run a pod during the coreDns is restarting",
-			Label("R00005"), "coredns", map[string]string{"k8s-app": "kube-dns"}, time.Second*90),
+			Label("R00005"), "coredns", map[string]string{"k8s-app": "kube-dns"}, time.Minute*2),
 		Entry("Successfully run a pod during the Spiderpool agent is restarting",
 			Label("R00004", "G00008"), constant.SpiderpoolAgent, map[string]string{"app.kubernetes.io/component": constant.SpiderpoolAgent}, time.Second*90),
 		Entry("Successfully run a pod during the Spiderpool controller is restarting",

--- a/test/e2e/reservedip/reservedip_suite_test.go
+++ b/test/e2e/reservedip/reservedip_suite_test.go
@@ -3,8 +3,9 @@
 package reservedip_test
 
 import (
-	spiderpool "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v1"
 	"testing"
+
+	spiderpool "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/test/e2e/reservedip/reservedip_test.go
+++ b/test/e2e/reservedip/reservedip_test.go
@@ -68,6 +68,7 @@ var _ = Describe("test reservedIP", Label("reservedIP"), func() {
 
 	It("S00001: an IP who is set in ReservedIP CRD, should not be assigned to a pod; S00003: Failed to set same IP in excludeIPs when an IP is assigned to a pod",
 		Label("S00001", "smoke", "S00003"), func() {
+			const deployOriginialNum = int(1)
 
 			if frame.Info.IpV4Enabled {
 				v4ReservedIpName, v4ReservedIpObj = common.GenerateExampleV4ReservedIpObject(iPv4PoolObj.Spec.IPs)
@@ -86,7 +87,7 @@ var _ = Describe("test reservedIP", Label("reservedIP"), func() {
 			podIppoolAnnoStr := common.GeneratePodIPPoolAnnotations(frame, nic, v4PoolNameList, v6PoolNameList)
 
 			// Generate Deployment yaml and annotation
-			deployObject := common.GenerateExampleDeploymentYaml(DeployName, nsName, int32(1))
+			deployObject := common.GenerateExampleDeploymentYaml(DeployName, nsName, int32(deployOriginialNum))
 			deployObject.Spec.Template.Annotations = map[string]string{constant.AnnoPodIPPool: podIppoolAnnoStr}
 			GinkgoWriter.Printf("Try to create Deployment: %v/%v with annotation %v = %v \n", nsName, DeployName, constant.AnnoPodIPPool, podIppoolAnnoStr)
 


### PR DESCRIPTION
Signed-off-by: ty-dc [tao.yang@daocloud.io](mailto:tao.yang@daocloud.io)

What type of PR is this?
/issue-bug pr/release/none-required

What this PR does / why we need it:
- add e2e case L00008 for spiderpool
   - Successfully restarted statefulSet/pod with matching podSelector, ip remains the same
- add e2e case A00009 for spiderpool
   - Modify the annotated IPPool for a specified Deployment pod; Modify the annotated IPPool for a specified StatefulSet pod

Which issue(s) this PR fixes:
#684 