### PR TITLE
fix issue 718

### DIFF
--- a/test/e2e/affinity/affinity_test.go
+++ b/test/e2e/affinity/affinity_test.go
@@ -36,6 +36,8 @@ var _ = Describe("test Affinity", Label("affinity"), func() {
 		)
 
 		BeforeEach(func() {
+			v4PoolNameList = []string{}
+			v6PoolNameList = []string{}
 			// Init matching and non-matching namespaces name and create its
 			matchedNamespace = "matched-ns-" + tools.RandomName()
 			unmatchedNamespace = "unmatched-ns-" + tools.RandomName()


### PR DESCRIPTION
Fixed : #718 
failed to run pod who is bound to an ippool set with matched NodeAffinity NamespaceAffinity and PodAffinity

when ippool name not existed  in the podList of the podIPPoolAnnotations，it will return error.
