### PR TITLE
feat:Add webhook of SpiderSubnet

### DIFF
--- a/.github/.spelling
+++ b/.github/.spelling
@@ -11,6 +11,9 @@ workloadendpoint
 workloadendpoints
 reservedip
 reservedips
+spidersubnet
+spidersubnets
+spidersubnetlist
 spiderippool
 spiderippools
 spiderippoollist

--- a/charts/spiderpool/README.md
+++ b/charts/spiderpool/README.md
@@ -136,6 +136,7 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 | `feature.enableIPv6`                      | enable ipv6                                                              | `false`  |
 | `feature.networkMode`                     | the network mode                                                         | `legacy` |
 | `feature.enableStatefulSet`               | the network mode                                                         | `true`   |
+| `feature.enableSpiderSubnet`              | SpiderSubnet feature gate.                                               | `false`  |
 | `feature.gc.enabled`                      | enable retrieve IP in spiderippool CR                                    | `true`   |
 | `feature.gc.GcDeletingTimeOutPod.enabled` | enable retrieve IP for the pod who times out of deleting graceful period | `true`   |
 | `feature.gc.GcDeletingTimeOutPod.delay`   | the gc delay seconds after the pod times out of deleting graceful period | `0`      |

--- a/charts/spiderpool/templates/configmap.yaml
+++ b/charts/spiderpool/templates/configmap.yaml
@@ -19,6 +19,7 @@ data:
     enableIPv4: {{ .Values.feature.enableIPv4 }}
     enableIPv6: {{ .Values.feature.enableIPv6 }}
     enableStatefulSet: {{ .Values.feature.enableStatefulSet }}
+    enableSpiderSubnet: {{ .Values.feature.enableSpiderSubnet }}
     {{- if ( and .Values.feature.enableIPv4 .Values.clusterDefaultPool.installIPv4IPPool ) }}
     clusterDefaultIPv4IPPool: [{{ .Values.clusterDefaultPool.ipv4IPPoolName }}]
     {{- else}}

--- a/charts/spiderpool/templates/role.yaml
+++ b/charts/spiderpool/templates/role.yaml
@@ -97,3 +97,23 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - spiderpool.spidernet.io
+  resources:
+  - spidersubnets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - spiderpool.spidernet.io
+  resources:
+  - spidersubnets/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/charts/spiderpool/templates/webhook.yaml
+++ b/charts/spiderpool/templates/webhook.yaml
@@ -15,6 +15,30 @@ webhooks:
     service:
       name: {{ .Values.spiderpoolController.name | trunc 63 | trimSuffix "-" }}
       namespace: {{ .Release.Namespace }}
+      path: /mutate-spiderpool-spidernet-io-v1-spidersubnet
+      port: {{ .Values.spiderpoolController.webhookPort }}
+    {{- if (eq .Values.spiderpoolController.tls.method "provided") }}
+    caBundle: {{ .Values.spiderpoolController.tls.provided.tlsCa | required "missing spiderpoolController.tls.provided.tlsCa" }}
+    {{- end }}
+  failurePolicy: Fail
+  name: spidersubnet.spiderpool.spidernet.io
+  rules:
+  - apiGroups:
+    - spiderpool.spidernet.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - spidersubnets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ .Values.spiderpoolController.name | trunc 63 | trimSuffix "-" }}
+      namespace: {{ .Release.Namespace }}
       path: /mutate-spiderpool-spidernet-io-v1-spiderippool
       port: {{ .Values.spiderpoolController.webhookPort }}
     {{- if (eq .Values.spiderpoolController.tls.method "provided") }}
@@ -68,6 +92,31 @@ metadata:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Values.spiderpoolController.name | trunc 63 | trimSuffix "-" }}-server-certs
     {{- end }}
 webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ .Values.spiderpoolController.name | trunc 63 | trimSuffix "-" }}
+      namespace: {{ .Release.Namespace }}
+      path: /validate-spiderpool-spidernet-io-v1-spidersubnet
+      port: {{ .Values.spiderpoolController.webhookPort }}
+    {{- if (eq .Values.spiderpoolController.tls.method "provided") }}
+    caBundle: {{ .Values.spiderpoolController.tls.provided.tlsCa | required "missing spiderpoolController.tls.provided.tlsCa" }}
+    {{- end }}
+  failurePolicy: Fail
+  name: spidersubnet.spiderpool.spidernet.io
+  rules:
+  - apiGroups:
+    - spiderpool.spidernet.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - spidersubnets
+  sideEffects: None
 - admissionReviewVersions:
   - v1
   clientConfig:

--- a/charts/spiderpool/values.yaml
+++ b/charts/spiderpool/values.yaml
@@ -46,6 +46,9 @@ feature:
   ## @param feature.enableStatefulSet the network mode
   enableStatefulSet: true
 
+  ## @param feature.enableSpiderSubnet SpiderSubnet feature gate.
+  enableSpiderSubnet: false
+
   gc:
     ## @param feature.gc.enabled enable retrieve IP in spiderippool CR
     enabled: true

--- a/cmd/spiderpool-agent/cmd/config.go
+++ b/cmd/spiderpool-agent/cmd/config.go
@@ -89,6 +89,7 @@ type Config struct {
 	ClusterDefaultIPv6IPPool []string `yaml:"clusterDefaultIPv6IPPool"`
 	NetworkMode              string   `yaml:"networkMode"`
 	EnableStatefulSet        bool     `yaml:"enableStatefulSet"`
+	EnableSpiderSubnet       bool     `yaml:"enableSpiderSubnet"`
 }
 
 type AgentContext struct {

--- a/cmd/spiderpool-controller/cmd/config.go
+++ b/cmd/spiderpool-controller/cmd/config.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spidernet-io/spiderpool/pkg/podmanager"
 	"github.com/spidernet-io/spiderpool/pkg/reservedipmanager"
 	"github.com/spidernet-io/spiderpool/pkg/statefulsetmanager"
+	"github.com/spidernet-io/spiderpool/pkg/subnetmanager"
 	"github.com/spidernet-io/spiderpool/pkg/workloadendpointmanager"
 )
 
@@ -105,7 +106,8 @@ type Config struct {
 	LeaseRetryGap      int
 
 	// configmap
-	EnableStatefulSet bool `yaml:"enableStatefulSet"`
+	EnableStatefulSet  bool `yaml:"enableStatefulSet"`
+	EnableSpiderSubnet bool `yaml:"enableSpiderSubnet"`
 }
 
 type ControllerContext struct {
@@ -125,6 +127,7 @@ type ControllerContext struct {
 	RIPManager    reservedipmanager.ReservedIPManager
 	NodeManager   nodemanager.NodeManager
 	NSManager     namespacemanager.NamespaceManager
+	SubnetManager subnetmanager.SubnetManager
 	IPPoolManager ippoolmanager.IPPoolManager
 	PodManager    podmanager.PodManager
 	GCManager     gcmanager.GCManager

--- a/cmd/spiderpool-controller/cmd/daemon.go
+++ b/cmd/spiderpool-controller/cmd/daemon.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spidernet-io/spiderpool/pkg/podmanager"
 	"github.com/spidernet-io/spiderpool/pkg/reservedipmanager"
 	"github.com/spidernet-io/spiderpool/pkg/statefulsetmanager"
+	"github.com/spidernet-io/spiderpool/pkg/subnetmanager"
 	"github.com/spidernet-io/spiderpool/pkg/workloadendpointmanager"
 )
 
@@ -230,6 +231,23 @@ func initControllerServiceManagers(ctx context.Context) {
 		logger.Fatal(err.Error())
 	}
 	controllerContext.StsManager = statefulSetManager
+
+	if controllerContext.Cfg.EnableSpiderSubnet {
+		logger.Info("Begin to initialize Subnet Manager")
+		subnetManager, err := subnetmanager.NewSubnetManager(controllerContext.CRDManager, controllerContext.Cfg.EnableSpiderSubnet)
+		if err != nil {
+			logger.Fatal(err.Error())
+		}
+		controllerContext.SubnetManager = subnetManager
+
+		logger.Info("Begin to set up Subnet webhook")
+		err = controllerContext.SubnetManager.SetupWebhook()
+		if err != nil {
+			logger.Fatal(err.Error())
+		}
+	} else {
+		logger.Info("Feature SpiderSubnet is disabled")
+	}
 
 	logger.Info("Begin to initialize IPPool Manager")
 	poolSize := controllerContext.Cfg.IPPoolMaxAllocatedIPs

--- a/pkg/constant/k8s.go
+++ b/pkg/constant/k8s.go
@@ -69,6 +69,7 @@ const (
 	SpiderIPPoolKind       = "SpiderIPPool"
 	SpiderEndpointKind     = "SpiderEndpoint"
 	SpiderReservedIPKind   = "SpiderReservedIP"
+	SpiderSubnetKind       = "SpiderSubnet"
 )
 
 const (

--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -40,6 +40,22 @@ func ParseIP(version types.IPVersion, s string, isCIDR bool) (*net.IPNet, error)
 	}
 }
 
+// ContainsIP reports whether the subnet parsed from the subnet string
+// includes the IP address parsed from the IP string. Both must belong
+// to the same IP version.
+func ContainsIP(version types.IPVersion, subnet string, ip string) (bool, error) {
+	ipNet, err := ParseCIDR(version, subnet)
+	if err != nil {
+		return false, err
+	}
+	address, err := ParseIP(version, ip, false)
+	if err != nil {
+		return false, err
+	}
+
+	return ipNet.Contains(address.IP), nil
+}
+
 // IsIP reports whether IP string is a IP address of the specified IP version.
 func IsIP(version types.IPVersion, s string) error {
 	if err := IsIPVersion(version); err != nil {

--- a/pkg/ip/utils.go
+++ b/pkg/ip/utils.go
@@ -1,0 +1,24 @@
+// Copyright 2022 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+
+package ip
+
+import (
+	"net"
+
+	"github.com/spidernet-io/spiderpool/pkg/types"
+)
+
+func AssembleTotalIPs(ipVersion types.IPVersion, ipRanges, excludeIPRanges []string) ([]net.IP, error) {
+	ips, err := ParseIPRanges(ipVersion, ipRanges)
+	if nil != err {
+		return nil, err
+	}
+	excludeIPs, err := ParseIPRanges(ipVersion, excludeIPRanges)
+	if nil != err {
+		return nil, err
+	}
+	totalIPs := IPsDiffSet(ips, excludeIPs)
+
+	return totalIPs, nil
+}

--- a/pkg/ippoolmanager/ippool_informer.go
+++ b/pkg/ippoolmanager/ippool_informer.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spidernet-io/spiderpool/pkg/constant"
 	"github.com/spidernet-io/spiderpool/pkg/election"
+	spiderpoolip "github.com/spidernet-io/spiderpool/pkg/ip"
 	spiderpoolv1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v1"
 	crdclientset "github.com/spidernet-io/spiderpool/pkg/k8s/client/clientset/versioned"
 	"github.com/spidernet-io/spiderpool/pkg/k8s/client/informers/externalversions"
@@ -162,7 +163,7 @@ func (im *ipPoolManager) updateSpiderIPPool(ctx context.Context, oldSpiderIPPool
 		// the original object in a threadsafe manner.
 		spiderIPPool := currentSpiderIPPool.DeepCopy()
 
-		totalIPs, err := assembleTotalIPs(spiderIPPool)
+		totalIPs, err := spiderpoolip.AssembleTotalIPs(*spiderIPPool.Spec.IPVersion, spiderIPPool.Spec.IPs, spiderIPPool.Spec.ExcludeIPs)
 		if nil != err {
 			return fmt.Errorf("failed to calculate SpiderIPPool '%s' total IP count, error: %v", currentSpiderIPPool.Name, err)
 		}

--- a/pkg/ippoolmanager/ippool_manager.go
+++ b/pkg/ippoolmanager/ippool_manager.go
@@ -191,7 +191,7 @@ func (im *ipPoolManager) genRandomIP(ctx context.Context, ipPool *spiderpoolv1.S
 		return nil, err
 	}
 
-	totalIPs, err := assembleTotalIPs(ipPool)
+	totalIPs, err := spiderpoolip.AssembleTotalIPs(*ipPool.Spec.IPVersion, ipPool.Spec.IPs, ipPool.Spec.ExcludeIPs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ippoolmanager/utils.go
+++ b/pkg/ippoolmanager/utils.go
@@ -11,23 +11,6 @@ import (
 	spiderpoolv1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v1"
 )
 
-// AssembleTotalIP will calculate an IPPool CR object usable IPs number,
-// it summaries the IPPool IPs then subtracts ExcludeIPs.
-// notice: this method would not filter ReservedIP CR object data!
-func assembleTotalIPs(ipPool *spiderpoolv1.SpiderIPPool) ([]net.IP, error) {
-	ips, err := spiderpoolip.ParseIPRanges(*ipPool.Spec.IPVersion, ipPool.Spec.IPs)
-	if nil != err {
-		return nil, err
-	}
-	excludeIPs, err := spiderpoolip.ParseIPRanges(*ipPool.Spec.IPVersion, ipPool.Spec.ExcludeIPs)
-	if nil != err {
-		return nil, err
-	}
-	totalIPs := spiderpoolip.IPsDiffSet(ips, excludeIPs)
-
-	return totalIPs, nil
-}
-
 func genResIPConfig(allocateIP net.IP, poolSpec *spiderpoolv1.IPPoolSpec, nic, poolName string) (*models.IPConfig, error) {
 	ipNet, err := spiderpoolip.ParseIP(*poolSpec.IPVersion, poolSpec.Subnet, true)
 	if err != nil {

--- a/pkg/k8s/apis/spiderpool.spidernet.io/v1/rbac.go
+++ b/pkg/k8s/apis/spiderpool.spidernet.io/v1/rbac.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Authors of spidernet-io
 // SPDX-License-Identifier: Apache-2.0
 
+// +kubebuilder:rbac:groups=spiderpool.spidernet.io,resources=spidersubnets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=spiderpool.spidernet.io,resources=spidersubnets/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=spiderpool.spidernet.io,resources=spiderippools,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=spiderpool.spidernet.io,resources=spiderippools/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=spiderpool.spidernet.io,resources=spiderendpoints,verbs=get;list;watch;create;update;patch;delete

--- a/pkg/reservedipmanager/reservedip_webhook.go
+++ b/pkg/reservedipmanager/reservedip_webhook.go
@@ -6,15 +6,17 @@ package reservedipmanager
 import (
 	"context"
 	"fmt"
-	spiderpoolv1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v1"
 
 	"go.uber.org/zap"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/spidernet-io/spiderpool/pkg/constant"
 	spiderpoolip "github.com/spidernet-io/spiderpool/pkg/ip"
+	spiderpoolv1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v1"
 	"github.com/spidernet-io/spiderpool/pkg/logutils"
 	"github.com/spidernet-io/spiderpool/pkg/types"
 )
@@ -39,39 +41,50 @@ var _ webhook.CustomDefaulter = (*reservedIPManager)(nil)
 func (rm *reservedIPManager) Default(ctx context.Context, obj runtime.Object) error {
 	rIP, ok := obj.(*spiderpoolv1.SpiderReservedIP)
 	if !ok {
-		return fmt.Errorf("mutating webhook of ReservedIP got an object with mismatched type: %+v", obj.GetObjectKind().GroupVersionKind())
+		return apierrors.NewBadRequest(fmt.Sprintf("mutating webhook of ReservedIP got an object with mismatched GVK: %+v", obj.GetObjectKind().GroupVersionKind()))
 	}
 
 	logger := webhookLogger.Named("Mutating").With(
-		zap.String("ReservedIPNamespace", rIP.Namespace),
 		zap.String("ReservedIPName", rIP.Name),
 		zap.String("Operation", "DEFAULT"),
 	)
+	logger.Info("Start to mutate ReservedIP")
 	logger.Sugar().Debugf("Request ReservedIP: %+v", *rIP)
 
 	if rIP.DeletionTimestamp != nil {
-		return nil
-	}
-
-	if rIP.Spec.IPVersion != nil {
+		logger.Info("Deleting ReservedIP, noting to mutate")
 		return nil
 	}
 
 	if len(rIP.Spec.IPs) == 0 {
+		logger.Error("Empty 'spec.ips', noting to mutate")
 		return nil
 	}
 
-	var version types.IPVersion
-	if spiderpoolip.IsIPv4IPRange(rIP.Spec.IPs[0]) {
-		version = constant.IPv4
-	} else if spiderpoolip.IsIPv6IPRange(rIP.Spec.IPs[0]) {
-		version = constant.IPv6
-	}
+	if rIP.Spec.IPVersion == nil {
+		var version types.IPVersion
+		if spiderpoolip.IsIPv4IPRange(rIP.Spec.IPs[0]) {
+			version = constant.IPv4
+		} else if spiderpoolip.IsIPv6IPRange(rIP.Spec.IPs[0]) {
+			version = constant.IPv6
+		} else {
+			logger.Error("Invalid 'spec.ipVersion', noting to mutate")
+			return nil
+		}
 
-	if version == constant.IPv4 || version == constant.IPv6 {
 		rIP.Spec.IPVersion = new(types.IPVersion)
 		*rIP.Spec.IPVersion = version
-		logger.Sugar().Infof("Set ipVersion '%s'", version)
+		logger.Sugar().Infof("Set 'spec.ipVersion' to %d", version)
+	}
+
+	if len(rIP.Spec.IPs) > 1 {
+		mergedIPs, err := spiderpoolip.MergeIPRanges(*rIP.Spec.IPVersion, rIP.Spec.IPs)
+		if err != nil {
+			logger.Sugar().Errorf("Failed to merge 'spec.ips': %v", err)
+		} else {
+			rIP.Spec.IPs = mergedIPs
+			logger.Sugar().Debugf("Merge 'spec.ips':\n%v\n\nto:\n\n%v", rIP.Spec.IPs, mergedIPs)
+		}
 	}
 
 	return nil
@@ -83,7 +96,7 @@ var _ webhook.CustomValidator = (*reservedIPManager)(nil)
 func (rm *reservedIPManager) ValidateCreate(ctx context.Context, obj runtime.Object) error {
 	rIP, ok := obj.(*spiderpoolv1.SpiderReservedIP)
 	if !ok {
-		return fmt.Errorf("validating webhook of ReservedIP got an object with mismatched type: %+v", obj.GetObjectKind().GroupVersionKind())
+		return apierrors.NewBadRequest(fmt.Sprintf("validating webhook of ReservedIP got an object with mismatched GVK: %+v", obj.GetObjectKind().GroupVersionKind()))
 	}
 
 	logger := webhookLogger.Named("Validating").With(
@@ -93,9 +106,13 @@ func (rm *reservedIPManager) ValidateCreate(ctx context.Context, obj runtime.Obj
 	)
 	logger.Sugar().Debugf("Request ReservedIP: %+v", *rIP)
 
-	if err := rm.validateCreateReservedIP(ctx, rIP); err != nil {
-		logger.Sugar().Errorf("Failed to validate: %v", err)
-		return err
+	if errs := rm.validateCreateReservedIP(ctx, rIP); len(errs) != 0 {
+		logger.Sugar().Errorf("Failed to create ReservedIP: %v", errs.ToAggregate().Error())
+		return apierrors.NewInvalid(
+			schema.GroupKind{Group: constant.SpiderpoolAPIGroup, Kind: constant.SpiderReservedIPKind},
+			rIP.Name,
+			errs,
+		)
 	}
 
 	return nil
@@ -106,7 +123,7 @@ func (rm *reservedIPManager) ValidateUpdate(ctx context.Context, oldObj, newObj 
 	oldRIP, _ := oldObj.(*spiderpoolv1.SpiderReservedIP)
 	newRIP, ok := newObj.(*spiderpoolv1.SpiderReservedIP)
 	if !ok {
-		return fmt.Errorf("validating webhook of ReservedIP got an object with mismatched type: %+v", newObj.GetObjectKind().GroupVersionKind())
+		return apierrors.NewBadRequest(fmt.Sprintf("validating webhook of ReservedIP got an object with mismatched GVK: %+v", newObj.GetObjectKind().GroupVersionKind()))
 	}
 
 	logger := webhookLogger.Named("Validating").With(
@@ -117,9 +134,13 @@ func (rm *reservedIPManager) ValidateUpdate(ctx context.Context, oldObj, newObj 
 	logger.Sugar().Debugf("Request old ReservedIP: %+v", *oldRIP)
 	logger.Sugar().Debugf("Request new ReservedIP: %+v", *newRIP)
 
-	if err := rm.validateUpdateReservedIP(ctx, oldRIP, newRIP); err != nil {
-		logger.Sugar().Errorf("Failed to validate: %v", err)
-		return err
+	if errs := rm.validateUpdateReservedIP(ctx, oldRIP, newRIP); len(errs) != 0 {
+		logger.Sugar().Errorf("Failed to update ReservedIP: %v", errs.ToAggregate().Error())
+		return apierrors.NewInvalid(
+			schema.GroupKind{Group: constant.SpiderpoolAPIGroup, Kind: constant.SpiderReservedIPKind},
+			newRIP.Name,
+			errs,
+		)
 	}
 
 	return nil

--- a/pkg/subnetmanager/subnet_manager.go
+++ b/pkg/subnetmanager/subnet_manager.go
@@ -1,0 +1,57 @@
+// Copyright 2022 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+
+package subnetmanager
+
+import (
+	"context"
+	"errors"
+
+	apitypes "k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	spiderpoolv1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v1"
+)
+
+type SubnetManager interface {
+	SetupWebhook() error
+	GetSubnetByName(ctx context.Context, subnetName string) (*spiderpoolv1.SpiderSubnet, error)
+	ListSubnets(ctx context.Context, opts ...client.ListOption) (*spiderpoolv1.SpiderSubnetList, error)
+}
+
+type subnetManager struct {
+	client             client.Client
+	runtimeMgr         ctrl.Manager
+	enableSpiderSubnet bool
+}
+
+func NewSubnetManager(mgr ctrl.Manager, enableSpiderSubnet bool) (SubnetManager, error) {
+	if mgr == nil {
+		return nil, errors.New("k8s manager must be specified")
+	}
+
+	return &subnetManager{
+		client:             mgr.GetClient(),
+		runtimeMgr:         mgr,
+		enableSpiderSubnet: enableSpiderSubnet,
+	}, nil
+}
+
+func (sm *subnetManager) GetSubnetByName(ctx context.Context, subnetName string) (*spiderpoolv1.SpiderSubnet, error) {
+	var subnet spiderpoolv1.SpiderSubnet
+	if err := sm.client.Get(ctx, apitypes.NamespacedName{Name: subnetName}, &subnet); err != nil {
+		return nil, err
+	}
+
+	return &subnet, nil
+}
+
+func (sm *subnetManager) ListSubnets(ctx context.Context, opts ...client.ListOption) (*spiderpoolv1.SpiderSubnetList, error) {
+	subnetList := &spiderpoolv1.SpiderSubnetList{}
+	if err := sm.client.List(ctx, subnetList, opts...); err != nil {
+		return nil, err
+	}
+
+	return subnetList, nil
+}

--- a/pkg/subnetmanager/subnet_validate.go
+++ b/pkg/subnetmanager/subnet_validate.go
@@ -1,0 +1,305 @@
+// Copyright 2022 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+
+package subnetmanager
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/spidernet-io/spiderpool/pkg/constant"
+	spiderpoolip "github.com/spidernet-io/spiderpool/pkg/ip"
+	"github.com/spidernet-io/spiderpool/pkg/ippoolmanager"
+	spiderpoolv1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v1"
+	"github.com/spidernet-io/spiderpool/pkg/types"
+)
+
+var (
+	ipVersionField  *field.Path = field.NewPath("spec").Child("ipVersion")
+	subnetField     *field.Path = field.NewPath("spec").Child("subnet")
+	ipsField        *field.Path = field.NewPath("spec").Child("ips")
+	excludeIPsField *field.Path = field.NewPath("spec").Child("excludeIPs")
+	gatewayField    *field.Path = field.NewPath("spec").Child("gateway")
+	routesField     *field.Path = field.NewPath("spec").Child("routes")
+)
+
+func (sm *subnetManager) validateCreateSubnet(ctx context.Context, subnet *spiderpoolv1.SpiderSubnet) field.ErrorList {
+	var errs field.ErrorList
+	if err := sm.validateSubnetSpec(ctx, subnet); err != nil {
+		errs = append(errs, err)
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	return errs
+}
+
+func (sm *subnetManager) validateUpdateSubnet(ctx context.Context, oldSubnet, newSubnet *spiderpoolv1.SpiderSubnet) field.ErrorList {
+	if err := sm.validateSubnetShouldNotBeChanged(ctx, oldSubnet, newSubnet); err != nil {
+		return field.ErrorList{err}
+	}
+
+	if err := sm.validateSubnetSpec(ctx, newSubnet); err != nil {
+		return field.ErrorList{err}
+	}
+
+	var errs field.ErrorList
+	if err := sm.validateSubnetIPInUse(ctx, oldSubnet, newSubnet); err != nil {
+		errs = append(errs, err)
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	return errs
+}
+
+func (sm *subnetManager) validateDeleteSubnet(ctx context.Context, subnet *spiderpoolv1.SpiderSubnet) field.ErrorList {
+	var errs field.ErrorList
+	if err := sm.validateSubnetIPPoolInUse(ctx, subnet); err != nil {
+		errs = append(errs, err)
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	return errs
+}
+
+func (sm *subnetManager) validateSubnetShouldNotBeChanged(ctx context.Context, oldSubnet, newSubnet *spiderpoolv1.SpiderSubnet) *field.Error {
+	if newSubnet.Spec.IPVersion != oldSubnet.Spec.IPVersion {
+		return field.Forbidden(
+			ipVersionField,
+			"is not changeable",
+		)
+	}
+
+	if newSubnet.Spec.Subnet != oldSubnet.Spec.Subnet {
+		return field.Forbidden(
+			subnetField,
+			"is not changeable",
+		)
+	}
+
+	return nil
+}
+
+func (sm *subnetManager) validateSubnetSpec(ctx context.Context, subnet *spiderpoolv1.SpiderSubnet) *field.Error {
+	if err := sm.validateSubnetIPVersion(ctx, subnet.Spec.IPVersion); err != nil {
+		return err
+	}
+	if err := sm.validateSubnetSubnet(ctx, *subnet.Spec.IPVersion, subnet.Name, subnet.Spec.Subnet); err != nil {
+		return err
+	}
+	if err := sm.validateSubnetAvailableIP(ctx, subnet); err != nil {
+		return err
+	}
+	if err := sm.validateSubnetGateway(ctx, *subnet.Spec.IPVersion, subnet.Spec.Subnet, subnet.Spec.Gateway); err != nil {
+		return err
+	}
+	if err := sm.validateSubnetRoutes(ctx, *subnet.Spec.IPVersion, subnet.Spec.Subnet, subnet.Spec.Routes); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (sm *subnetManager) validateSubnetIPInUse(ctx context.Context, oldSubnet, newSubnet *spiderpoolv1.SpiderSubnet) *field.Error {
+	if err := sm.validateSubnetIPs(ctx, *newSubnet.Spec.IPVersion, newSubnet.Spec.Subnet, newSubnet.Spec.IPs); err != nil {
+		return err
+	}
+	if err := sm.validateSubnetExcludeIPs(ctx, *newSubnet.Spec.IPVersion, newSubnet.Spec.Subnet, newSubnet.Spec.ExcludeIPs); err != nil {
+		return err
+	}
+
+	oldTotalIPs, _ := spiderpoolip.AssembleTotalIPs(*oldSubnet.Spec.IPVersion, oldSubnet.Spec.IPs, oldSubnet.Spec.ExcludeIPs)
+	newTotalIPs, _ := spiderpoolip.AssembleTotalIPs(*newSubnet.Spec.IPVersion, newSubnet.Spec.IPs, newSubnet.Spec.ExcludeIPs)
+	reducedIPs := spiderpoolip.IPsDiffSet(oldTotalIPs, newTotalIPs)
+	reduceIPRanges, _ := spiderpoolip.ConvertIPsToIPRanges(*newSubnet.Spec.IPVersion, reducedIPs)
+	freeIPs, err := spiderpoolip.ParseIPRanges(*newSubnet.Spec.IPVersion, newSubnet.Status.FreeIPs)
+	if err != nil {
+		return field.InternalError(ipsField, err)
+	}
+
+	if len(spiderpoolip.IPsDiffSet(reducedIPs, freeIPs)) > 0 {
+		return field.Forbidden(
+			ipsField,
+			fmt.Sprintf("removes some IP ranges %s that is being used, total IP addresses of an Subnet are jointly determined by 'spec.ips' and 'spec.excludeIPs'", reduceIPRanges),
+		)
+	}
+
+	return nil
+}
+
+func (sm *subnetManager) validateSubnetIPPoolInUse(ctx context.Context, subnet *spiderpoolv1.SpiderSubnet) *field.Error {
+	if err := sm.validateSubnetIPs(ctx, *subnet.Spec.IPVersion, subnet.Spec.Subnet, subnet.Spec.IPs); err != nil {
+		return err
+	}
+	if err := sm.validateSubnetExcludeIPs(ctx, *subnet.Spec.IPVersion, subnet.Spec.Subnet, subnet.Spec.ExcludeIPs); err != nil {
+		return err
+	}
+
+	totalIPs, _ := spiderpoolip.AssembleTotalIPs(*subnet.Spec.IPVersion, subnet.Spec.IPs, subnet.Spec.ExcludeIPs)
+	freeIPs, err := spiderpoolip.ParseIPRanges(*subnet.Spec.IPVersion, subnet.Status.FreeIPs)
+	if err != nil {
+		return field.InternalError(ipsField, err)
+	}
+
+	if len(spiderpoolip.IPsDiffSet(totalIPs, freeIPs)) != 0 {
+		return field.Forbidden(
+			ipsField,
+			"removes a Subnet that is still used by some IPPools",
+		)
+	}
+
+	return nil
+}
+
+func (sm *subnetManager) validateSubnetIPVersion(ctx context.Context, version *types.IPVersion) *field.Error {
+	if version == nil {
+		return field.Invalid(
+			ipVersionField,
+			version,
+			"is not generated correctly, 'spec.subnet' may be invalid",
+		)
+	}
+
+	if *version != constant.IPv4 && *version != constant.IPv6 {
+		return field.NotSupported(
+			ipVersionField,
+			version,
+			[]string{strconv.FormatInt(constant.IPv4, 10),
+				strconv.FormatInt(constant.IPv6, 10),
+			},
+		)
+	}
+
+	return nil
+}
+
+func (sm *subnetManager) validateSubnetSubnet(ctx context.Context, version types.IPVersion, subnetName, subnet string) *field.Error {
+	subnetList, err := sm.ListSubnets(ctx)
+	if err != nil {
+		return field.InternalError(subnetField, err)
+	}
+
+	for _, s := range subnetList.Items {
+		if s.Name == subnetName || *s.Spec.IPVersion != version {
+			continue
+		}
+
+		overlap, err := spiderpoolip.IsCIDROverlap(version, subnet, s.Spec.Subnet)
+		if err != nil {
+			return field.Invalid(
+				subnetField,
+				subnet,
+				err.Error(),
+			)
+		}
+
+		if overlap {
+			return field.Invalid(
+				subnetField,
+				subnet,
+				fmt.Sprintf("overlaps with Subnet %s which 'spec.subnet' is %s", s.Name, s.Spec.Subnet),
+			)
+		}
+	}
+
+	return nil
+}
+
+func (sm *subnetManager) validateSubnetAvailableIP(ctx context.Context, subnet *spiderpoolv1.SpiderSubnet) *field.Error {
+	if err := sm.validateSubnetIPs(ctx, *subnet.Spec.IPVersion, subnet.Spec.Subnet, subnet.Spec.IPs); err != nil {
+		return err
+	}
+	if err := sm.validateSubnetExcludeIPs(ctx, *subnet.Spec.IPVersion, subnet.Spec.Subnet, subnet.Spec.ExcludeIPs); err != nil {
+		return err
+	}
+
+	subnetList, err := sm.ListSubnets(ctx)
+	if err != nil {
+		return field.InternalError(ipsField, err)
+	}
+
+	newIPs, _ := spiderpoolip.AssembleTotalIPs(*subnet.Spec.IPVersion, subnet.Spec.IPs, subnet.Spec.ExcludeIPs)
+	for _, s := range subnetList.Items {
+		if s.Name == subnet.Name || s.Spec.Subnet != subnet.Spec.Subnet {
+			continue
+		}
+
+		existIPs, err := spiderpoolip.AssembleTotalIPs(*s.Spec.IPVersion, s.Spec.IPs, s.Spec.ExcludeIPs)
+		if err != nil {
+			return field.InternalError(ipsField, err)
+		}
+		if len(newIPs) > len(spiderpoolip.IPsDiffSet(newIPs, existIPs)) {
+			return field.Forbidden(
+				ipsField,
+				fmt.Sprintf("overlaps with Subnet %s, total IP addresses of an Subnet are jointly determined by 'spec.ips' and 'spec.excludeIPs'", s.Name),
+			)
+		}
+	}
+
+	return nil
+}
+
+func (sm *subnetManager) validateSubnetIPs(ctx context.Context, version types.IPVersion, subnet string, ips []string) *field.Error {
+	n := len(ips)
+	if n == 0 {
+		return field.Required(
+			ipsField,
+			"requires at least one item",
+		)
+	}
+
+	for i, r := range ips {
+		if err := ippoolmanager.ValidateContainsIPRange(ctx, ipsField.Index(i), version, subnet, r); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (sm *subnetManager) validateSubnetExcludeIPs(ctx context.Context, version types.IPVersion, subnet string, excludeIPs []string) *field.Error {
+	for i, r := range excludeIPs {
+		if err := ippoolmanager.ValidateContainsIPRange(ctx, excludeIPsField.Index(i), version, subnet, r); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (sm *subnetManager) validateSubnetGateway(ctx context.Context, version types.IPVersion, subnet string, gateway *string) *field.Error {
+	if gateway != nil {
+		return ippoolmanager.ValidateContainsIP(ctx, gatewayField, version, subnet, *gateway)
+	}
+
+	return nil
+}
+
+func (sm *subnetManager) validateSubnetRoutes(ctx context.Context, version types.IPVersion, subnet string, routes []spiderpoolv1.Route) *field.Error {
+	for i, r := range routes {
+		if err := spiderpoolip.IsCIDR(version, r.Dst); err != nil {
+			return field.Invalid(
+				routesField.Index(i).Child("dst"),
+				r.Dst,
+				err.Error(),
+			)
+		}
+
+		if err := ippoolmanager.ValidateContainsIP(ctx, routesField.Index(i).Child("gw"), version, subnet, r.Gw); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/subnetmanager/subnet_webhook.go
+++ b/pkg/subnetmanager/subnet_webhook.go
@@ -1,0 +1,173 @@
+// Copyright 2022 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+
+package subnetmanager
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/spidernet-io/spiderpool/pkg/constant"
+	spiderpoolip "github.com/spidernet-io/spiderpool/pkg/ip"
+	spiderpoolv1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v1"
+	"github.com/spidernet-io/spiderpool/pkg/logutils"
+	"github.com/spidernet-io/spiderpool/pkg/types"
+)
+
+var webhookLogger *zap.Logger
+
+func (sm *subnetManager) SetupWebhook() error {
+	webhookLogger = logutils.Logger.Named("Subnet-Webhook")
+
+	return ctrl.NewWebhookManagedBy(sm.runtimeMgr).
+		For(&spiderpoolv1.SpiderSubnet{}).
+		WithDefaulter(sm).
+		WithValidator(sm).
+		Complete()
+}
+
+var _ webhook.CustomDefaulter = (*subnetManager)(nil)
+
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the type
+func (sm *subnetManager) Default(ctx context.Context, obj runtime.Object) error {
+	subnet, ok := obj.(*spiderpoolv1.SpiderSubnet)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("mutating webhook of Subnet got an object with mismatched GVK: %+v", obj.GetObjectKind().GroupVersionKind()))
+	}
+
+	logger := webhookLogger.Named("Mutating").With(
+		zap.String("SubnetName", subnet.Name),
+		zap.String("Operation", "DEFAULT"),
+	)
+	logger.Info("Start to mutate Subnet")
+	logger.Sugar().Debugf("Request Subnet: %+v", *subnet)
+
+	if subnet.DeletionTimestamp != nil {
+		logger.Info("Deleting Subnet, noting to mutate")
+		return nil
+	}
+
+	if subnet.Spec.IPVersion == nil {
+		var version types.IPVersion
+		if spiderpoolip.IsIPv4CIDR(subnet.Spec.Subnet) {
+			version = constant.IPv4
+		} else if spiderpoolip.IsIPv6CIDR(subnet.Spec.Subnet) {
+			version = constant.IPv6
+		} else {
+			logger.Error("Invalid 'spec.ipVersion', noting to mutate")
+			return nil
+		}
+
+		subnet.Spec.IPVersion = new(types.IPVersion)
+		*subnet.Spec.IPVersion = version
+		logger.Sugar().Infof("Set 'spec.ipVersion' to %d", version)
+	}
+
+	if len(subnet.Spec.IPs) > 1 {
+		mergedIPs, err := spiderpoolip.MergeIPRanges(*subnet.Spec.IPVersion, subnet.Spec.IPs)
+		if err != nil {
+			logger.Sugar().Errorf("Failed to merge 'spec.ips': %v", err)
+		} else {
+			subnet.Spec.IPs = mergedIPs
+			logger.Sugar().Debugf("Merge 'spec.ips':\n%v\n\nto:\n\n%v", subnet.Spec.IPs, mergedIPs)
+		}
+	}
+
+	if len(subnet.Spec.ExcludeIPs) > 1 {
+		mergedExcludeIPs, err := spiderpoolip.MergeIPRanges(*subnet.Spec.IPVersion, subnet.Spec.ExcludeIPs)
+		if err != nil {
+			logger.Sugar().Errorf("Failed to merge 'spec.excludeIPs': %v", err)
+		} else {
+			subnet.Spec.ExcludeIPs = mergedExcludeIPs
+			logger.Sugar().Debugf("Merge 'spec.excludeIPs':\n%v\n\nto:\n\n%v", subnet.Spec.ExcludeIPs, mergedExcludeIPs)
+		}
+	}
+
+	return nil
+}
+
+var _ webhook.CustomValidator = (*subnetManager)(nil)
+
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type
+func (sm *subnetManager) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+	subnet, ok := obj.(*spiderpoolv1.SpiderSubnet)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("validating webhook of Subnet got an object with mismatched GVK: %+v", obj.GetObjectKind().GroupVersionKind()))
+	}
+
+	logger := webhookLogger.Named("Validating").With(
+		zap.String("SubnetName", subnet.Name),
+		zap.String("Operation", "CREATE"),
+	)
+	logger.Sugar().Debugf("Request Subnet: %+v", *subnet)
+
+	if errs := sm.validateCreateSubnet(ctx, subnet); len(errs) != 0 {
+		logger.Sugar().Errorf("Failed to create Subnet: %v", errs.ToAggregate().Error())
+		return apierrors.NewInvalid(
+			schema.GroupKind{Group: constant.SpiderpoolAPIGroup, Kind: constant.SpiderSubnetKind},
+			subnet.Name,
+			errs,
+		)
+	}
+
+	return nil
+}
+
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
+func (sm *subnetManager) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
+	oldSubnet, _ := oldObj.(*spiderpoolv1.SpiderSubnet)
+	newSubnet, ok := newObj.(*spiderpoolv1.SpiderSubnet)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("validating webhook of Subnet got an object with mismatched GVK: %+v", newObj.GetObjectKind().GroupVersionKind()))
+	}
+
+	logger := webhookLogger.Named("Validating").With(
+		zap.String("SubnetName", newSubnet.Name),
+		zap.String("Operation", "UPDATE"),
+	)
+	logger.Sugar().Debugf("Request old Subnet: %+v", *oldSubnet)
+	logger.Sugar().Debugf("Request new Subnet: %+v", *newSubnet)
+
+	if errs := sm.validateUpdateSubnet(ctx, oldSubnet, newSubnet); len(errs) != 0 {
+		logger.Sugar().Errorf("Failed to update Subnet: %v", errs.ToAggregate().Error())
+		return apierrors.NewInvalid(
+			schema.GroupKind{Group: constant.SpiderpoolAPIGroup, Kind: constant.SpiderSubnetKind},
+			newSubnet.Name,
+			errs,
+		)
+	}
+
+	return nil
+}
+
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type
+func (sm *subnetManager) ValidateDelete(ctx context.Context, obj runtime.Object) error {
+	subnet, ok := obj.(*spiderpoolv1.SpiderSubnet)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("validating webhook of Subnet got an object with mismatched GVK: %+v", obj.GetObjectKind().GroupVersionKind()))
+	}
+
+	logger := webhookLogger.Named("Validating").With(
+		zap.String("SubnetName", subnet.Name),
+		zap.String("Operation", "DELETE"),
+	)
+	logger.Sugar().Debugf("Request Subnet: %+v", *subnet)
+
+	if errs := sm.validateDeleteSubnet(ctx, subnet); len(errs) != 0 {
+		logger.Sugar().Errorf("Failed to delete Subnet: %v", errs.ToAggregate().Error())
+		return apierrors.NewInvalid(
+			schema.GroupKind{Group: constant.SpiderpoolAPIGroup, Kind: constant.SpiderSubnetKind},
+			subnet.Name,
+			errs,
+		)
+	}
+
+	return nil
+}


### PR DESCRIPTION
- Add SubnetManager to provide standard Get and List methods for SpiderSubnet.
- Provides basic field verification when creating SpiderSubnet CR.
- Merge the 'ips' and 'excludeIPs' field of SpiderSubnet, SpiderIPPool and SpiderReservedIP, when its CR is created or updated.

Signed-off-by: iiiceoo <ziqian.xue@daocloud.io>
