### PR TITLE
E2E：Add case on CIDR IP leakage

### DIFF
--- a/test/doc/cidr.md
+++ b/test/doc/cidr.md
@@ -7,3 +7,5 @@
 | I00003  | Automatically create ippool, and create, scale, restart, and delete a controller |          |       | Done   |       |
 | I00004  | Automatically create multiple ippools that can not use the same network segment and use IPs other than excludeIPs |          |       | Done   |       |
 | I00005  | If routes and gateway are modified for CIDR, how the manually created ippools are affected? |          |       |        |       |
+| I00006  | Multiple automatic creation and recycling of ippools, eventually the free IPs in the subnet should be restored to its initial state |          |       |        |       |
+| I00007  | Multiple manual creation and recycling of ippools, eventually the free IPs in the subnet should be restored to its initial state |          |       |        |       |


### PR DESCRIPTION
Signed-off-by: ty-dc [tao.yang@daocloud.io](mailto:tao.yang@daocloud.io)

What type of PR is this?
pr/release/none-required

What this PR does / why we need it:
add cidr case
- Multiple automatic creation and recycling of ippools, eventually the free IPs in the subnet should be restored to its initial state
- Multiple manual creation and recycling of ippools, eventually the free IPs in the subnet should be restored to its initial state

Which issue(s) this PR fixes:
