### PR TITLE
fix:Missing resource type when cleaning SpiderEndpoint CRs in cleanCRD.sh

### DIFF
--- a/tools/scripts/cleanCRD.sh
+++ b/tools/scripts/cleanCRD.sh
@@ -5,11 +5,11 @@
 
 kubectl get spiderippools | sed '1 d' | awk '{print $1}' | xargs -n 1 -i kubectl patch spiderippools {} --patch '{"metadata": {"finalizers": null}}' --type=merge
 
-kubectl get spidersubnet | sed '1 d' | awk '{print $1}' | xargs -n 1 -i kubectl patch spidersubnet {} --patch '{"metadata": {"finalizers": null}}' --type=merge
+kubectl get spidersubnets | sed '1 d' | awk '{print $1}' | xargs -n 1 -i kubectl patch spidersubnets {} --patch '{"metadata": {"finalizers": null}}' --type=merge
 
 ALL_EP_INFO=`kubectl get spiderendpoints -A | sed '1 d'`
 while read namespace epName other ; do
-  kubectl patch -n $namespace $epName --patch '{"metadata": {"finalizers": null}}' --type=merge
+  kubectl patch -n $namespace spiderendpoints $epName --patch '{"metadata": {"finalizers": null}}' --type=merge
 done <<< "$ALL_EP_INFO"
 
 kubectl delete crd spiderendpoints.spiderpool.spidernet.io


### PR DESCRIPTION
Signed-off-by: iiiceoo <ziqian.xue@daocloud.io>
