### PR TITLE
fix: ipv6 address validity issue

### DIFF
--- a/test/e2e/annotation/annotation_test.go
+++ b/test/e2e/annotation/annotation_test.go
@@ -486,11 +486,13 @@ var _ = Describe("test annotation", Label("annotation"), func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to exec command %v\n", command)
 		}
 		if frame.Info.IpV6Enabled {
-			command := fmt.Sprintf("ip -6 r | grep 'default via %s'", ipv6Gw)
+			command := "ip -6 r | grep 'default via'| awk '{print $3}' "
 			ctx, cancel := context.WithTimeout(context.Background(), common.ExecCommandTimeout)
 			defer cancel()
-			_, err := frame.ExecCommandInPod(podName, nsName, command, ctx)
+			out, err := frame.ExecCommandInPod(podName, nsName, command, ctx)
 			Expect(err).NotTo(HaveOccurred(), "failed to exec command %v\n", command)
+			effectiveIpv6GwStr := strings.TrimSpace(string(out))
+			Expect(common.ContrastIpv6ToIntValues(effectiveIpv6GwStr, ipv6Gw)).NotTo(HaveOccurred())
 		}
 
 		// delete pod

--- a/test/e2e/common/spiderpool.go
+++ b/test/e2e/common/spiderpool.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	v1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v1"
@@ -461,9 +460,6 @@ func GenerateExampleIpv6poolObject(ipNum int) (string, *v1.SpiderIPPool) {
 	*v6Ipversion = constant.IPv6
 	var v6PoolName string = "v6pool-" + tools.RandomName()
 	var randomNumber string = GenerateString(4, true)
-	if randomNumber[0:1] == "0" {
-		randomNumber = randomNumber[1:(strings.Count(randomNumber, "") - 1)]
-	}
 
 	iPv6PoolObj := &v1.SpiderIPPool{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/common/spiderpool.go
+++ b/test/e2e/common/spiderpool.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	v1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v1"
@@ -420,15 +421,11 @@ func GenerateExampleIpv4poolObject(ipNum int) (string, *v1.SpiderIPPool) {
 	}
 	var v4Ipversion = new(types.IPVersion)
 	*v4Ipversion = constant.IPv4
-
-	var iPv4PoolObj *v1.SpiderIPPool
-	// Generate ipv4pool name
 	var v4PoolName string = "v4pool-" + tools.RandomName()
-	// Generate random number
 	var randomNumber1 string = GenerateRandomNumber(255)
 	var randomNumber2 string = GenerateRandomNumber(255)
 
-	iPv4PoolObj = &v1.SpiderIPPool{
+	iPv4PoolObj := &v1.SpiderIPPool{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: v4PoolName,
 		},
@@ -462,11 +459,11 @@ func GenerateExampleIpv6poolObject(ipNum int) (string, *v1.SpiderIPPool) {
 
 	var v6Ipversion = new(types.IPVersion)
 	*v6Ipversion = constant.IPv6
-
-	// Generate ipv6pool name
 	var v6PoolName string = "v6pool-" + tools.RandomName()
-	// Generate random number
 	var randomNumber string = GenerateString(4, true)
+	if randomNumber[0:1] == "0" {
+		randomNumber = randomNumber[1:(strings.Count(randomNumber, "") - 1)]
+	}
 
 	iPv6PoolObj := &v1.SpiderIPPool{
 		ObjectMeta: metav1.ObjectMeta{
@@ -486,7 +483,7 @@ func GenerateExampleIpv6poolObject(ipNum int) (string, *v1.SpiderIPPool) {
 	if ipNum == 1 {
 		iPv6PoolObj.Spec.IPs = []string{fmt.Sprintf("fd00:%s::2", randomNumber)}
 	} else {
-		bStr := fmt.Sprintf("%x", ipNum+1)
+		bStr := strconv.FormatInt(int64(ipNum+1), 16)
 		iPv6PoolObj.Spec.IPs = []string{fmt.Sprintf("fd00:%s::2-fd00:%s::%s", randomNumber, randomNumber, bStr)}
 	}
 	return v6PoolName, iPv6PoolObj

--- a/test/e2e/common/tools.go
+++ b/test/e2e/common/tools.go
@@ -4,8 +4,11 @@ package common
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"math/big"
 	"math/rand"
+	"net"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -90,4 +93,27 @@ func ExecCommand(ctx context.Context, cmd *exec.Cmd) (string, error) {
 		}
 		time.Sleep(time.Second)
 	}
+}
+
+func Ipv6ToInt(ip net.IP) (*big.Int, error) {
+	if ip == nil {
+		return nil, errors.New("invalid ipv6")
+	}
+	return big.NewInt(0).SetBytes(ip.To16()), nil
+}
+
+func ContrastIpv6ToIntValues(ip1, ip2 string) error {
+	if ip1 == "" || ip2 == "" {
+		return errors.New("invalid value")
+	}
+
+	netIp1 := net.ParseIP(ip1)
+	netIp2 := net.ParseIP(ip2)
+	bigInt1, _ := Ipv6ToInt(netIp1)
+	bigInt2, _ := Ipv6ToInt(netIp2)
+
+	if res := bigInt1.Cmp(bigInt2); res != 0 {
+		return errors.New("both Mismatch")
+	}
+	return nil
 }

--- a/test/e2e/common/tools.go
+++ b/test/e2e/common/tools.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/big"
 	"math/rand"
 	"net"
 	"os/exec"
@@ -18,6 +17,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 	frame "github.com/spidernet-io/e2eframework/framework"
+	"github.com/spidernet-io/spiderpool/pkg/ip"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -95,13 +95,6 @@ func ExecCommand(ctx context.Context, cmd *exec.Cmd) (string, error) {
 	}
 }
 
-func Ipv6ToInt(ip net.IP) (*big.Int, error) {
-	if ip == nil {
-		return nil, errors.New("invalid ipv6")
-	}
-	return big.NewInt(0).SetBytes(ip.To16()), nil
-}
-
 func ContrastIpv6ToIntValues(ip1, ip2 string) error {
 	if ip1 == "" || ip2 == "" {
 		return errors.New("invalid value")
@@ -109,10 +102,8 @@ func ContrastIpv6ToIntValues(ip1, ip2 string) error {
 
 	netIp1 := net.ParseIP(ip1)
 	netIp2 := net.ParseIP(ip2)
-	bigInt1, _ := Ipv6ToInt(netIp1)
-	bigInt2, _ := Ipv6ToInt(netIp2)
 
-	if res := bigInt1.Cmp(bigInt2); res != 0 {
+	if res := ip.Cmp(netIp1, netIp2); res != 0 {
 		return errors.New("both Mismatch")
 	}
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
- Fix: When the ipv6 address is `fd00:015d::1`, but in the pod it is` fd00:15d::1`, 
- in this case, using "ip -6 r | grep 'default via fd00:015d::1'" does not retrieve the content, so os/exec will return an error when executed


**Which issue(s) this PR fixes**:
#860 
#850 

**Special notes for your reviewer**:

**make sure your commit is signed off**
