### PR TITLE
discard to retry scale IPPool and all error requeue

### DIFF
--- a/cmd/spiderpool-agent/cmd/crd_manager.go
+++ b/cmd/spiderpool-agent/cmd/crd_manager.go
@@ -9,6 +9,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -37,9 +38,15 @@ func newCRDManager() (ctrl.Manager, error) {
 			&corev1.Pod{},
 			&appsv1.Deployment{},
 			&appsv1.StatefulSet{},
+			&appsv1.ReplicaSet{},
+			&appsv1.DaemonSet{},
+			&batchv1.Job{},
+			&batchv1.CronJob{},
 			&spiderpoolv1.SpiderIPPool{},
 			&spiderpoolv1.SpiderEndpoint{},
-			&spiderpoolv1.SpiderReservedIP{}},
+			&spiderpoolv1.SpiderReservedIP{},
+			&spiderpoolv1.SpiderSubnet{},
+		},
 	})
 
 	if err != nil {

--- a/pkg/ippoolmanager/ippool_webhook.go
+++ b/pkg/ippoolmanager/ippool_webhook.go
@@ -184,14 +184,14 @@ func (im *ipPoolManager) ValidateUpdate(ctx context.Context, oldObj, newObj runt
 		zap.String("IPPoolName", newIPPool.Name),
 		zap.String("Operation", "UPDATE"),
 	)
-	logger.Sugar().Infof("Request old IPPool: %+v", *oldIPPool)
-	logger.Sugar().Infof("Request new IPPool: %+v", *newIPPool)
+	logger.Sugar().Debugf("Request old IPPool: %v", oldIPPool)
+	logger.Sugar().Debugf("Request new IPPool: %v", newIPPool)
 
 	if newIPPool.DeletionTimestamp != nil && controllerutil.ContainsFinalizer(newIPPool, constant.SpiderFinalizer) {
 		return apierrors.NewForbidden(
 			schema.GroupResource{},
 			"",
-			errors.New("cannot update a terminaing IPPool"),
+			errors.New("cannot update a terminating IPPool"),
 		)
 	}
 

--- a/pkg/k8s/apis/spiderpool.spidernet.io/v1/types_string.go
+++ b/pkg/k8s/apis/spiderpool.spidernet.io/v1/types_string.go
@@ -66,6 +66,7 @@ func (in *IPPoolStatus) String() string {
 		`AllocatedIPs:` + fmt.Sprintf("%+v", in.AllocatedIPs) + `,`,
 		`TotalIPCount:` + ValueToStringGenerated(in.TotalIPCount) + `,`,
 		`AllocatedIPCount:` + ValueToStringGenerated(in.AllocatedIPCount) + `,`,
+		`AutoDesiredIPCount:` + ValueToStringGenerated(in.AutoDesiredIPCount) + `,`,
 		`}`,
 	}, "")
 	return s


### PR DESCRIPTION
Signed-off-by: Icarus9913 <icaruswu66@qq.com>

**What this PR does / why we need it**:
1. Remove scale IPPool function retries, and let the error requeue. This will avoid some bad data update.
2. Add client disable cache for SpiderSubnet


