### PR TITLE
fix spiderpool-agent oom

### DIFF
--- a/cmd/spiderpool-agent/cmd/config.go
+++ b/cmd/spiderpool-agent/cmd/config.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/yaml.v3"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	"github.com/spidernet-io/spiderpool/api/v1/agent/client"
 	"github.com/spidernet-io/spiderpool/api/v1/agent/server"
 	"github.com/spidernet-io/spiderpool/pkg/constant"
 	"github.com/spidernet-io/spiderpool/pkg/ipam"
@@ -129,6 +130,9 @@ type AgentContext struct {
 	HttpServer        *server.Server
 	UnixServer        *server.Server
 	MetricsHttpServer *http.Server
+
+	// client
+	unixClient *client.SpiderpoolAgentAPI
 
 	// probe
 	IsStartupProbe atomic.Bool

--- a/cmd/spiderpool-agent/cmd/daemon.go
+++ b/cmd/spiderpool-agent/cmd/daemon.go
@@ -206,6 +206,13 @@ func DaemonMain() {
 	logger.Info("Begin to initialize spiderpool-agent metrics http server")
 	initAgentMetricsServer(agentContext.InnerCtx)
 
+	// new unix client
+	spiderpoolAgentAPI, err := NewAgentOpenAPIUnixClient(agentContext.Cfg.IpamUnixSocketPath)
+	if nil != err {
+		logger.Fatal(err.Error())
+	}
+	agentContext.unixClient = spiderpoolAgentAPI
+
 	// TODO (Icarus9913): improve k8s StartupProbe
 	logger.Info("Set spiderpool-agent Startup probe ready")
 	agentContext.IsStartupProbe.Store(true)

--- a/cmd/spiderpool-agent/cmd/runtime_status.go
+++ b/cmd/spiderpool-agent/cmd/runtime_status.go
@@ -36,13 +36,7 @@ type _httpGetAgentReadiness struct {
 
 // Handle handles GET requests for k8s readiness probe.
 func (g *_httpGetAgentReadiness) Handle(params runtime.GetRuntimeReadinessParams) middleware.Responder {
-	unixClient, err := NewAgentOpenAPIUnixClient(g.Cfg.IpamUnixSocketPath)
-	if nil != err {
-		logger.Error(err.Error())
-		return runtime.NewGetRuntimeReadinessInternalServerError()
-	}
-
-	_, err = unixClient.Connectivity.GetIpamHealthy(connectivity.NewGetIpamHealthyParams())
+	_, err := g.unixClient.Connectivity.GetIpamHealthy(connectivity.NewGetIpamHealthyParams())
 	if nil != err {
 		logger.Error(err.Error())
 		return runtime.NewGetRuntimeReadinessInternalServerError()
@@ -57,13 +51,7 @@ type _httpGetAgentLiveness struct {
 
 // Handle handles GET requests for k8s liveness probe.
 func (g *_httpGetAgentLiveness) Handle(params runtime.GetRuntimeLivenessParams) middleware.Responder {
-	unixClient, err := NewAgentOpenAPIUnixClient(g.Cfg.IpamUnixSocketPath)
-	if nil != err {
-		logger.Error(err.Error())
-		return runtime.NewGetRuntimeLivenessInternalServerError()
-	}
-
-	_, err = unixClient.Connectivity.GetIpamHealthy(connectivity.NewGetIpamHealthyParams())
+	_, err := g.unixClient.Connectivity.GetIpamHealthy(connectivity.NewGetIpamHealthyParams())
 	if nil != err {
 		logger.Error(err.Error())
 		return runtime.NewGetRuntimeLivenessInternalServerError()

--- a/cmd/spiderpool-controller/cmd/config.go
+++ b/cmd/spiderpool-controller/cmd/config.go
@@ -160,6 +160,9 @@ type ControllerContext struct {
 	HttpServer        *server.Server
 	MetricsHttpServer *http.Server
 
+	// webhook http client
+	webhookClient *http.Client
+
 	// probe
 	IsStartupProbe atomic.Bool
 }

--- a/cmd/spiderpool-controller/cmd/daemon.go
+++ b/cmd/spiderpool-controller/cmd/daemon.go
@@ -175,6 +175,7 @@ func DaemonMain() {
 	controllerContext.IsStartupProbe.Store(true)
 
 	// the webhook must be ready or we can't work
+	controllerContext.webhookClient = newWebhookHealthCheckClient()
 	checkWebhookReady()
 
 	// set up informers
@@ -421,7 +422,7 @@ func checkWebhookReady() {
 			logger.Fatal("out of the max wait duration for webhook ready in process starting phase")
 		}
 
-		err := WebhookHealthyCheck(controllerContext.Cfg.WebhookPort)
+		err := WebhookHealthyCheck(controllerContext.webhookClient, controllerContext.Cfg.WebhookPort)
 		if nil != err {
 			logger.Error(err.Error())
 

--- a/cmd/spiderpool-controller/cmd/runtime_status.go
+++ b/cmd/spiderpool-controller/cmd/runtime_status.go
@@ -35,7 +35,7 @@ type _httpGetControllerReadiness struct {
 
 // Handle handles GET requests for k8s readiness probe.
 func (g *_httpGetControllerReadiness) Handle(params runtime.GetRuntimeReadinessParams) middleware.Responder {
-	if err := WebhookHealthyCheck(g.Cfg.WebhookPort); err != nil {
+	if err := WebhookHealthyCheck(g.webhookClient, g.Cfg.WebhookPort); err != nil {
 		logger.Sugar().Errorf("failed to check spiderpool controller readiness probe, error: %v", err)
 		return runtime.NewGetRuntimeReadinessInternalServerError()
 	}
@@ -49,7 +49,7 @@ type _httpGetControllerLiveness struct {
 
 // Handle handles GET requests for k8s liveness probe.
 func (g *_httpGetControllerLiveness) Handle(params runtime.GetRuntimeLivenessParams) middleware.Responder {
-	if err := WebhookHealthyCheck(g.Cfg.WebhookPort); err != nil {
+	if err := WebhookHealthyCheck(g.webhookClient, g.Cfg.WebhookPort); err != nil {
 		logger.Sugar().Errorf("failed to check spiderpool controller liveness probe, error: %v", err)
 		return runtime.NewGetRuntimeLivenessInternalServerError()
 	}


### PR DESCRIPTION
Signed-off-by: Icarus9913 <icaruswu66@qq.com>


**What this PR does / why we need it**:
fix spiderpool-agent OOM

**Which issue(s) this PR fixes**:
https://github.com/spidernet-io/spiderpool/issues/917

With the previous sources codes, we'll new a golang http client every liveness probe. And we do not disable 'KeepAlive' and set 'Timeout' for this http client. 
After checking the golang source codes, the golang will use 'KeepAlive' by default.
Once a http client sends a request it will start 2 goroutines 'readLoop' and 'writeLoop', and the server endpoint will start 1 goroutine to handle with the 'tcp/udp' connection. 
Here's the source codes:
https://github.com/golang/go/blob/e09bbaec69a8ff960110e13eabb3bef5331ecb0c/src/net/http/server.go#L3072
https://github.com/golang/go/blob/e09bbaec69a8ff960110e13eabb3bef5331ecb0c/src/net/http/server.go#L1903-L2018

We can just reuse the http client and without 'KeepAlive', which means after every request the client endpoint will drop the 2 goroutines