### PR TITLE
separate controller to v4/v6 to accelerate auto-ippool event

### DIFF
--- a/cmd/spiderpool-controller/cmd/config.go
+++ b/cmd/spiderpool-controller/cmd/config.go
@@ -82,7 +82,9 @@ var envInfo = []envConf{
 	{"VERSION", "", false, &controllerContext.Cfg.AppVersion, nil, nil},
 	{"SPIDERPOOL_ENABLE_SUBNET_DELETE_STALE_IPPOOL", "false", true, nil, &controllerContext.Cfg.EnableSubnetDeleteStaleIPPool, nil},
 	{"SPIDERPOOL_AUTO_IPPOOL_HANDLER_MAX_WORKQUEUE_LENGTH", "10000", true, nil, nil, &controllerContext.Cfg.IPPoolInformerMaxWorkQueueLength},
-	{"SPIDERPOOL_AUTO_IPPOOL_SCALE_RETRY_DELAY_DURATION", "10", true, nil, nil, &controllerContext.Cfg.IPPoolWorkQueueRequeueDelayDuration},
+	{"SPIDERPOOL_AUTO_IPPOOL_SCALE_RETRY_DELAY_DURATION", "5", true, nil, nil, &controllerContext.Cfg.IPPoolWorkQueueRequeueDelayDuration},
+	{"SPIDERPOOL_IPPOOL_INFORMER_WORKERS", "3", true, nil, nil, &controllerContext.Cfg.IPPoolInformerWorkers},
+	{"SPIDERPOOL_WORKQUEUE_MAX_RETRIES", "500", true, nil, nil, &controllerContext.Cfg.WorkQueueMaxRetries},
 }
 
 type Config struct {
@@ -118,6 +120,8 @@ type Config struct {
 	SubnetResyncPeriod               int
 	SubnetInformerWorkers            int
 	SubnetInformerMaxWorkqueueLength int
+	WorkQueueMaxRetries              int
+	IPPoolInformerWorkers            int
 
 	// if IPPoolWorkQueueRequeueDelayDuration is negative number, we would not requeue it
 	IPPoolWorkQueueRequeueDelayDuration int

--- a/cmd/spiderpool-controller/cmd/daemon.go
+++ b/cmd/spiderpool-controller/cmd/daemon.go
@@ -290,6 +290,8 @@ func initControllerServiceManagers(ctx context.Context) {
 		LeaderRetryElectGap:           time.Duration(controllerContext.Cfg.LeaseRetryGap) * time.Second,
 		MaxWorkQueueLength:            controllerContext.Cfg.IPPoolInformerMaxWorkQueueLength,
 		WorkQueueRequeueDelayDuration: time.Duration(controllerContext.Cfg.IPPoolWorkQueueRequeueDelayDuration) * time.Second,
+		WorkerNum:                     controllerContext.Cfg.IPPoolInformerWorkers,
+		WorkQueueMaxRetries:           controllerContext.Cfg.WorkQueueMaxRetries,
 	}, controllerContext.CRDManager, controllerContext.RIPManager)
 	if err != nil {
 		logger.Fatal(err.Error())

--- a/pkg/ippoolmanager/config.go
+++ b/pkg/ippoolmanager/config.go
@@ -19,4 +19,6 @@ type IPPoolManagerConfig struct {
 	LeaderRetryElectGap           time.Duration
 	MaxWorkQueueLength            int
 	WorkQueueRequeueDelayDuration time.Duration
+	WorkerNum                     int
+	WorkQueueMaxRetries           int
 }

--- a/pkg/ippoolmanager/ippool_validate.go
+++ b/pkg/ippoolmanager/ippool_validate.go
@@ -216,10 +216,13 @@ func (im *ipPoolManager) validateIPPoolAvailableIPs(ctx context.Context, ipPool 
 		if err != nil {
 			return field.InternalError(ipsField, err)
 		}
-		if len(newIPs) > len(spiderpoolip.IPsDiffSet(newIPs, existIPs)) {
+
+		overlapIPs := spiderpoolip.IPsIntersectionSet(newIPs, existIPs)
+		if len(overlapIPs) > 0 {
+			overlapRanges, _ := spiderpoolip.ConvertIPsToIPRanges(*pool.Spec.IPVersion, overlapIPs)
 			return field.Forbidden(
 				ipsField,
-				fmt.Sprintf("overlap with IPPool %s, total IP addresses of an IPPool are jointly determined by 'spec.ips' and 'spec.excludeIPs'", pool.Name),
+				fmt.Sprintf("overlap with IPPool %s in IP ranges %v, total IP addresses of an IPPool are jointly determined by 'spec.ips' and 'spec.excludeIPs'", pool.Name, overlapRanges),
 			)
 		}
 	}

--- a/pkg/ippoolmanager/types/interface.go
+++ b/pkg/ippoolmanager/types/interface.go
@@ -16,6 +16,7 @@ import (
 	crdclientset "github.com/spidernet-io/spiderpool/pkg/k8s/client/clientset/versioned"
 	subnetmanagertypes "github.com/spidernet-io/spiderpool/pkg/subnetmanager/types"
 	"github.com/spidernet-io/spiderpool/pkg/types"
+	spiderpooltypes "github.com/spidernet-io/spiderpool/pkg/types"
 )
 
 type ScaleAction bool
@@ -41,6 +42,6 @@ type IPPoolManager interface {
 	ScaleIPPoolWithIPs(ctx context.Context, pool *spiderpoolv1.SpiderIPPool, ipRanges []string, action ScaleAction, desiredIPNum int) error
 	DeleteIPPool(ctx context.Context, pool *spiderpoolv1.SpiderIPPool) error
 	UpdateDesiredIPNumber(ctx context.Context, pool *spiderpoolv1.SpiderIPPool, ipNum int) error
-	GetAutoPoolRateLimitQueue() workqueue.RateLimitingInterface
+	GetAutoPoolRateLimitQueue(ipVersion spiderpooltypes.IPVersion) workqueue.RateLimitingInterface
 	GetAutoPoolMaxWorkQueueLength() int
 }

--- a/pkg/reservedipmanager/reservedip_manager.go
+++ b/pkg/reservedipmanager/reservedip_manager.go
@@ -6,22 +6,18 @@ package reservedipmanager
 import (
 	"context"
 	"errors"
-	"net"
 
 	apitypes "k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	spiderpoolip "github.com/spidernet-io/spiderpool/pkg/ip"
 	spiderpoolv1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v1"
-	"github.com/spidernet-io/spiderpool/pkg/types"
 )
 
 type ReservedIPManager interface {
 	SetupWebhook() error
 	GetReservedIPByName(ctx context.Context, rIPName string) (*spiderpoolv1.SpiderReservedIP, error)
 	ListReservedIPs(ctx context.Context, opts ...client.ListOption) (*spiderpoolv1.SpiderReservedIPList, error)
-	GetReservedIPsByIPVersion(ctx context.Context, version types.IPVersion, rIPList *spiderpoolv1.SpiderReservedIPList) ([]net.IP, error)
 }
 
 type reservedIPManager struct {
@@ -61,21 +57,4 @@ func (rm *reservedIPManager) ListReservedIPs(ctx context.Context, opts ...client
 	}
 
 	return &rIPList, nil
-}
-
-func (rm *reservedIPManager) GetReservedIPsByIPVersion(ctx context.Context, version types.IPVersion, rIPList *spiderpoolv1.SpiderReservedIPList) ([]net.IP, error) {
-	var ips []net.IP
-	for _, r := range rIPList.Items {
-		if *r.Spec.IPVersion != version {
-			continue
-		}
-
-		rIPs, err := spiderpoolip.ParseIPRanges(version, r.Spec.IPs)
-		if err != nil {
-			return nil, err
-		}
-		ips = append(ips, rIPs...)
-	}
-
-	return ips, nil
 }

--- a/pkg/reservedipmanager/utils.go
+++ b/pkg/reservedipmanager/utils.go
@@ -1,0 +1,29 @@
+// Copyright 2022 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+
+package reservedipmanager
+
+import (
+	"net"
+
+	spiderpoolip "github.com/spidernet-io/spiderpool/pkg/ip"
+	spiderpoolv1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v1"
+	spiderpooltypes "github.com/spidernet-io/spiderpool/pkg/types"
+)
+
+func GetReservedIPsByIPVersion(version spiderpooltypes.IPVersion, rIPList *spiderpoolv1.SpiderReservedIPList) ([]net.IP, error) {
+	var ips []net.IP
+	for _, r := range rIPList.Items {
+		if *r.Spec.IPVersion != version {
+			continue
+		}
+
+		rIPs, err := spiderpoolip.ParseIPRanges(version, r.Spec.IPs)
+		if err != nil {
+			return nil, err
+		}
+		ips = append(ips, rIPs...)
+	}
+
+	return ips, nil
+}

--- a/pkg/subnetmanager/subnet_informer.go
+++ b/pkg/subnetmanager/subnet_informer.go
@@ -413,7 +413,7 @@ func (sc *SubnetController) removeFinalizer(ctx context.Context, subnet *spiderp
 func (sc *SubnetController) notifySubnetIPPool(ctx context.Context, subnet *spiderpoolv1.SpiderSubnet) error {
 	logger := logutils.FromContext(ctx)
 
-	if sc.subnetManager.ipPoolManager.GetAutoPoolRateLimitQueue() == nil {
+	if sc.subnetManager.ipPoolManager.GetAutoPoolRateLimitQueue(*subnet.Spec.IPVersion) == nil {
 		logger.Warn("IPPool manager doesn't have IPPool informer rate limit workqueue!")
 		return nil
 	}
@@ -436,12 +436,12 @@ func (sc *SubnetController) notifySubnetIPPool(ctx context.Context, subnet *spid
 		}
 
 		if ippoolmanager.ShouldScaleIPPool(pool) {
-			if sc.subnetManager.ipPoolManager.GetAutoPoolRateLimitQueue().Len() >= maxQueueLength {
+			if sc.subnetManager.ipPoolManager.GetAutoPoolRateLimitQueue(*subnet.Spec.IPVersion).Len() >= maxQueueLength {
 				logger.Sugar().Errorf("The IPPool workqueue is out of capacity, discard enqueue auto-created IPPool '%s'", pool.Name)
 				return nil
 			}
 
-			sc.subnetManager.ipPoolManager.GetAutoPoolRateLimitQueue().AddRateLimited(pool.Name)
+			sc.subnetManager.ipPoolManager.GetAutoPoolRateLimitQueue(*subnet.Spec.IPVersion).AddRateLimited(pool.Name)
 			logger.Sugar().Debugf("added '%s' to IPPool workqueue", pool.Name)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Icarus9913 <icaruswu66@qq.com>

1. separate controller to v4/v6 to accelerate auto-ippool event to accelerate V4/V6 IPPool generates IPs from each subnet
2. fix ippool status allocatedIPCount update
3. use workqueue for all IPPool status count calculate