### PR TITLE
fix statefulset ip allocation retrieve

### DIFF
--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -145,7 +145,8 @@ func (i *ipam) retrieveStsIPAllocation(ctx context.Context, containerID, nic str
 
 	// There's no possible that a StatefulSet Pod Endpoint's field 'Status.Current' is nil.
 	if endpoint.Status.Current == nil {
-		return nil, fmt.Errorf("current IP allocation is lost, endpoint %s/%s data broken: %+v", endpoint.Namespace, endpoint.Name, endpoint)
+		logger.Sugar().Warnf("SpiderEndpoint '%s/%s' doesn't have current IP allocation, try to re-allocate", endpoint.Namespace, endpoint.Name)
+		return nil, nil
 	}
 
 	logger.Info("Retrieve the IP allocation of StatefulSet")


### PR DESCRIPTION
Once we use statefulset dual stack and allocated IPv4 successfully but failed to allocated IPv6.
In this case, the SpiderEndpoint object is exist but the status current IP allocation was rolled back and no data. 
We should continue process it 

Signed-off-by: Icarus9913 <icaruswu66@qq.com>

---

**What this PR does / why we need it**:
fix bug 

**Which issue(s) this PR fixes**:
https://github.com/spidernet-io/spiderpool/issues/1034
