### PR TITLE
fix subnet create ippool asynchronous multile ippools issue

### DIFF
--- a/cmd/spiderpool-controller/cmd/config.go
+++ b/cmd/spiderpool-controller/cmd/config.go
@@ -82,7 +82,7 @@ var envInfo = []envConf{
 	{"VERSION", "", false, &controllerContext.Cfg.AppVersion, nil, nil},
 	{"SPIDERPOOL_ENABLE_SUBNET_DELETE_STALE_IPPOOL", "false", true, nil, &controllerContext.Cfg.EnableSubnetDeleteStaleIPPool, nil},
 	{"SPIDERPOOL_AUTO_IPPOOL_HANDLER_MAX_WORKQUEUE_LENGTH", "10000", true, nil, nil, &controllerContext.Cfg.IPPoolInformerMaxWorkQueueLength},
-	{"SPIDERPOOL_AUTO_IPPOOL_SCALE_RETRY_DELAY_DURATION", "5", true, nil, nil, &controllerContext.Cfg.IPPoolWorkQueueRequeueDelayDuration},
+	{"SPIDERPOOL_AUTO_IPPOOL_SCALE_RETRY_DELAY_DURATION", "5", true, nil, nil, &controllerContext.Cfg.WorkQueueRequeueDelayDuration},
 	{"SPIDERPOOL_IPPOOL_INFORMER_WORKERS", "3", true, nil, nil, &controllerContext.Cfg.IPPoolInformerWorkers},
 	{"SPIDERPOOL_WORKQUEUE_MAX_RETRIES", "500", true, nil, nil, &controllerContext.Cfg.WorkQueueMaxRetries},
 }
@@ -121,11 +121,11 @@ type Config struct {
 	SubnetInformerWorkers            int
 	SubnetInformerMaxWorkqueueLength int
 	WorkQueueMaxRetries              int
-	IPPoolInformerWorkers            int
-
 	// if IPPoolWorkQueueRequeueDelayDuration is negative number, we would not requeue it
-	IPPoolWorkQueueRequeueDelayDuration int
-	IPPoolInformerMaxWorkQueueLength    int
+	WorkQueueRequeueDelayDuration int
+
+	IPPoolInformerWorkers            int
+	IPPoolInformerMaxWorkQueueLength int
 
 	LeaseDuration      int
 	LeaseRenewDeadline int

--- a/cmd/spiderpool-controller/cmd/daemon.go
+++ b/cmd/spiderpool-controller/cmd/daemon.go
@@ -289,7 +289,7 @@ func initControllerServiceManagers(ctx context.Context) {
 		MaxAllocatedIPs:               controllerContext.Cfg.IPPoolMaxAllocatedIPs,
 		LeaderRetryElectGap:           time.Duration(controllerContext.Cfg.LeaseRetryGap) * time.Second,
 		MaxWorkQueueLength:            controllerContext.Cfg.IPPoolInformerMaxWorkQueueLength,
-		WorkQueueRequeueDelayDuration: time.Duration(controllerContext.Cfg.IPPoolWorkQueueRequeueDelayDuration) * time.Second,
+		WorkQueueRequeueDelayDuration: time.Duration(controllerContext.Cfg.WorkQueueRequeueDelayDuration) * time.Second,
 		WorkerNum:                     controllerContext.Cfg.IPPoolInformerWorkers,
 		WorkQueueMaxRetries:           controllerContext.Cfg.WorkQueueMaxRetries,
 	}, controllerContext.CRDManager, controllerContext.RIPManager)
@@ -322,6 +322,7 @@ func initControllerServiceManagers(ctx context.Context) {
 			EnableSubnetDeleteStaleIPPool: controllerContext.Cfg.EnableSubnetDeleteStaleIPPool,
 			LeaderRetryElectGap:           time.Duration(controllerContext.Cfg.LeaseRetryGap) * time.Second,
 			ResyncPeriod:                  time.Duration(controllerContext.Cfg.SubnetResyncPeriod) * time.Second,
+			RequeueDelayDuration:          time.Duration(controllerContext.Cfg.WorkQueueRequeueDelayDuration) * time.Second,
 			Workers:                       controllerContext.Cfg.SubnetInformerWorkers,
 			MaxWorkqueueLength:            controllerContext.Cfg.SubnetInformerMaxWorkqueueLength,
 		}, controllerContext.CRDManager, controllerContext.IPPoolManager, controllerContext.RIPManager)
@@ -414,7 +415,7 @@ func setupInformers() {
 			logger.Fatal(err.Error())
 		}
 
-		err = controllerContext.SubnetManager.SetupControllers(controllerContext.InnerCtx, controllerContext.ClientSet)
+		err = controllerContext.SubnetManager.SetupControllers(controllerContext.ClientSet)
 		if nil != err {
 			logger.Fatal(err.Error())
 		}

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,8 @@ require (
 	sigs.k8s.io/controller-tools v0.8.0
 )
 
+require go.uber.org/multierr v1.8.0
+
 require (
 	cloud.google.com/go/compute v1.7.0 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
@@ -126,7 +128,6 @@ require (
 	github.com/subosito/gotenv v1.3.0 // indirect
 	github.com/toqueteos/webbrowser v1.2.0 // indirect
 	go.mongodb.org/mongo-driver v1.10.1 // indirect
-	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
 	golang.org/x/mod v0.6.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094 // indirect

--- a/pkg/subnetmanager/config.go
+++ b/pkg/subnetmanager/config.go
@@ -18,6 +18,7 @@ type SubnetManagerConfig struct {
 	EnableSubnetDeleteStaleIPPool bool
 	LeaderRetryElectGap           time.Duration
 	ResyncPeriod                  time.Duration
+	RequeueDelayDuration          time.Duration
 
 	Workers            int
 	MaxWorkqueueLength int

--- a/pkg/subnetmanager/controllers/cronjob_informer.go
+++ b/pkg/subnetmanager/controllers/cronjob_informer.go
@@ -11,15 +11,14 @@ import (
 	"github.com/spidernet-io/spiderpool/pkg/logutils"
 )
 
-func (c *Controller) StartCronJobController(informer cache.SharedIndexInformer, stopper chan struct{}) {
-	controllersLogger.Info("Starting CronJob informer")
+func (c *Controller) AddCronJobHandler(informer cache.SharedIndexInformer) {
+	controllersLogger.Info("Setting up CronJob handlers")
 
 	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.onCronJobAdd,
 		UpdateFunc: c.onCronJobUpdate,
 		DeleteFunc: c.onCronJobDelete,
 	})
-	informer.Run(stopper)
 }
 
 func (c *Controller) onCronJobAdd(obj interface{}) {

--- a/pkg/subnetmanager/controllers/daemonset_informer.go
+++ b/pkg/subnetmanager/controllers/daemonset_informer.go
@@ -11,15 +11,14 @@ import (
 	"github.com/spidernet-io/spiderpool/pkg/logutils"
 )
 
-func (c *Controller) StartDaemonSetController(informer cache.SharedIndexInformer, stopper chan struct{}) {
-	controllersLogger.Info("Starting DaemonSet informer")
+func (c *Controller) AddDaemonSetHandler(informer cache.SharedIndexInformer) {
+	controllersLogger.Info("Setting up DaemonSet handlers")
 
 	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.onDaemonSetAdd,
 		UpdateFunc: c.onDaemonSetUpdate,
 		DeleteFunc: c.onDaemonSetDelete,
 	})
-	informer.Run(stopper)
 }
 
 func (c *Controller) onDaemonSetAdd(obj interface{}) {

--- a/pkg/subnetmanager/controllers/deployment_informer.go
+++ b/pkg/subnetmanager/controllers/deployment_informer.go
@@ -11,15 +11,14 @@ import (
 	"github.com/spidernet-io/spiderpool/pkg/logutils"
 )
 
-func (c *Controller) StartDeploymentController(informer cache.SharedIndexInformer, stopper chan struct{}) {
-	controllersLogger.Info("Starting Deployment informer")
+func (c *Controller) AddDeploymentHandler(informer cache.SharedIndexInformer) {
+	controllersLogger.Info("Setting up Deployment handlers")
 
 	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.onDeploymentAdd,
 		UpdateFunc: c.onDeploymentUpdate,
 		DeleteFunc: c.onDeploymentDelete,
 	})
-	informer.Run(stopper)
 }
 
 func (c *Controller) onDeploymentAdd(obj interface{}) {

--- a/pkg/subnetmanager/controllers/job_informer.go
+++ b/pkg/subnetmanager/controllers/job_informer.go
@@ -11,15 +11,14 @@ import (
 	"github.com/spidernet-io/spiderpool/pkg/logutils"
 )
 
-func (c *Controller) StartJobController(informer cache.SharedIndexInformer, stopper chan struct{}) {
-	controllersLogger.Info("Starting Job informer")
+func (c *Controller) AddJobController(informer cache.SharedIndexInformer) {
+	controllersLogger.Info("Setting up Job informer")
 
 	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.onJobAdd,
 		UpdateFunc: c.onJobUpdate,
 		DeleteFunc: c.onJobDelete,
 	})
-	informer.Run(stopper)
 }
 
 func (c *Controller) onJobAdd(obj interface{}) {

--- a/pkg/subnetmanager/controllers/replicaset_informer.go
+++ b/pkg/subnetmanager/controllers/replicaset_informer.go
@@ -11,15 +11,14 @@ import (
 	"github.com/spidernet-io/spiderpool/pkg/logutils"
 )
 
-func (c *Controller) StartReplicaSetController(informer cache.SharedIndexInformer, stopper chan struct{}) {
-	controllersLogger.Info("Starting ReplicaSet informer")
+func (c *Controller) AddReplicaSetHandler(informer cache.SharedIndexInformer) {
+	controllersLogger.Info("Setting up ReplicaSet handlers")
 
 	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.onReplicaSetAdd,
 		UpdateFunc: c.onReplicaSetUpdate,
 		DeleteFunc: c.onReplicaSetDelete,
 	})
-	informer.Run(stopper)
 }
 
 func (c *Controller) onReplicaSetAdd(obj interface{}) {

--- a/pkg/subnetmanager/controllers/statefulset_informer.go
+++ b/pkg/subnetmanager/controllers/statefulset_informer.go
@@ -11,15 +11,14 @@ import (
 	"github.com/spidernet-io/spiderpool/pkg/logutils"
 )
 
-func (c *Controller) StartStatefulSetController(informer cache.SharedIndexInformer, stopper chan struct{}) {
-	controllersLogger.Info("Starting StatefulSet informer")
+func (c *Controller) AddStatefulSetHandler(informer cache.SharedIndexInformer) {
+	controllersLogger.Info("Setting up StatefulSet handlers")
 
 	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.onStatefulSetAdd,
 		UpdateFunc: c.onStatefulSetUpdate,
 		DeleteFunc: c.onStatefulSetDelete,
 	})
-	informer.Run(stopper)
 }
 
 func (c *Controller) onStatefulSetAdd(obj interface{}) {

--- a/pkg/subnetmanager/controllers/utils.go
+++ b/pkg/subnetmanager/controllers/utils.go
@@ -9,8 +9,8 @@ import (
 	"net"
 	"strconv"
 	"strings"
-	"time"
 
+	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 
 	"github.com/spidernet-io/spiderpool/pkg/constant"
@@ -99,9 +99,14 @@ func (in *PodSubnetsAnnoConfig) String() string {
 	return s
 }
 
-func SubnetPoolName(controllerKind, controllerNS, controllerName string, ipVersion types.IPVersion) string {
-	return fmt.Sprintf("auto-%s-%s-%s-v%d-%d",
-		strings.ToLower(controllerKind), strings.ToLower(controllerNS), strings.ToLower(controllerName), ipVersion, time.Now().Unix())
+func SubnetPoolName(controllerKind, controllerNS, controllerName string, ipVersion types.IPVersion, controllerUID apitypes.UID) string {
+	// the format of uuid is "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+	// ref: https://github.com/google/uuid/blob/44b5fee7c49cf3bcdf723f106b36d56ef13ccc88/uuid.go#L185
+	splits := strings.Split(string(controllerUID), "-")
+	lastOne := splits[len(splits)-1]
+
+	return fmt.Sprintf("auto-%s-%s-%s-v%d-%s",
+		strings.ToLower(controllerKind), strings.ToLower(controllerNS), strings.ToLower(controllerName), ipVersion, strings.ToLower(lastOne))
 }
 
 func AppLabelValue(appKind string, appNS, appName string) string {

--- a/pkg/subnetmanager/subnet_controller.go
+++ b/pkg/subnetmanager/subnet_controller.go
@@ -5,19 +5,26 @@ package subnetmanager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"sync"
 	"time"
 
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	apitypes "k8s.io/apimachinery/pkg/types"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	appslisters "k8s.io/client-go/listers/apps/v1"
+	batchlisters "k8s.io/client-go/listers/batch/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/spidernet-io/spiderpool/pkg/constant"
@@ -27,11 +34,22 @@ import (
 	"github.com/spidernet-io/spiderpool/pkg/types"
 )
 
-func (sm *subnetManager) SetupControllers(ctx context.Context, client kubernetes.Interface) error {
-	subnetController, err := controllers.NewSubnetController(sm.ControllerAddOrUpdateHandler(), sm.ControllerDeleteHandler(), logger.Named("Controllers"))
+func (sm *subnetManager) SetupControllers(client kubernetes.Interface) error {
+	sm.workQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Application-Controllers")
+
+	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(client, 0)
+
+	c := newAppController(sm, kubeInformerFactory)
+	subnetController, err := controllers.NewSubnetController(c.ControllerAddOrUpdateHandler(), c.ControllerDeleteHandler(), logger.Named("Controllers"))
 	if nil != err {
 		return fmt.Errorf("failed to set up controllers informers, error: %v", err)
 	}
+	subnetController.AddDeploymentHandler(c.deploymentInformer)
+	subnetController.AddReplicaSetHandler(c.replicaSetInformer)
+	subnetController.AddDaemonSetHandler(c.daemonSetInformer)
+	subnetController.AddStatefulSetHandler(c.statefulSetInformer)
+	subnetController.AddJobController(c.jobInformer)
+	subnetController.AddCronJobHandler(c.cronJobInformer)
 
 	go func() {
 		for {
@@ -40,16 +58,9 @@ func (sm *subnetManager) SetupControllers(ctx context.Context, client kubernetes
 				continue
 			}
 
-			logger.Info("Starting subnet manager controllers informers")
-			kubeInformerFactory := kubeinformers.NewSharedInformerFactory(client, 0)
 			stopper := make(chan struct{})
 
-			go subnetController.StartDeploymentController(kubeInformerFactory.Apps().V1().Deployments().Informer(), stopper)
-			go subnetController.StartReplicaSetController(kubeInformerFactory.Apps().V1().ReplicaSets().Informer(), stopper)
-			go subnetController.StartDaemonSetController(kubeInformerFactory.Apps().V1().DaemonSets().Informer(), stopper)
-			go subnetController.StartStatefulSetController(kubeInformerFactory.Apps().V1().StatefulSets().Informer(), stopper)
-			go subnetController.StartJobController(kubeInformerFactory.Batch().V1().Jobs().Informer(), stopper)
-			go subnetController.StartCronJobController(kubeInformerFactory.Batch().V1().CronJobs().Informer(), stopper)
+			kubeInformerFactory.Start(stopper)
 
 			go func() {
 				for {
@@ -63,7 +74,11 @@ func (sm *subnetManager) SetupControllers(ctx context.Context, client kubernetes
 				}
 			}()
 
-			<-stopper
+			err = c.Run(sm.config.Workers, stopper)
+			if nil != err {
+				logger.Sugar().Errorf("failed to run application controller, error: %v", err)
+			}
+
 			logger.Error("subnet manager controllers broken")
 		}
 	}()
@@ -73,21 +88,20 @@ func (sm *subnetManager) SetupControllers(ctx context.Context, client kubernetes
 
 // ControllerAddOrUpdateHandler serves for kubernetes original controller applications(such as: Deployment,ReplicaSet,Job...),
 // to create a new IPPool or scale the IPPool
-func (sm *subnetManager) ControllerAddOrUpdateHandler() controllers.AppInformersAddOrUpdateFunc {
+func (c *appController) ControllerAddOrUpdateHandler() controllers.AppInformersAddOrUpdateFunc {
 	return func(ctx context.Context, oldObj, newObj interface{}) error {
-		var log *zap.Logger
+		log := logutils.FromContext(ctx)
 
 		var err error
 		var oldSubnetConfig, newSubnetConfig *controllers.PodSubnetAnnoConfig
 		var appKind string
 		var app metav1.Object
-		var podSelector map[string]string
 		var oldAppReplicas, newAppReplicas int
 
 		switch newObject := newObj.(type) {
 		case *appsv1.Deployment:
 			appKind = constant.OwnerDeployment
-			log = logger.With(zap.String(appKind, fmt.Sprintf("%s/%s", newObject.GetNamespace(), newObject.GetName())))
+			log = log.With(zap.String(appKind, fmt.Sprintf("%s/%s", newObject.GetNamespace(), newObject.GetName())))
 
 			// no need reconcile for HostNetwork application
 			if newObject.Spec.Template.Spec.HostNetwork {
@@ -113,8 +127,8 @@ func (sm *subnetManager) ControllerAddOrUpdateHandler() controllers.AppInformers
 				log.Debug("app will use default IPAM mode with no subnet annotation")
 
 				// if one application used to have subnet feature but discard it later, we should also clean up the legacy IPPools
-				if sm.config.EnableSubnetDeleteStaleIPPool {
-					err = sm.tryToCleanUpLegacyIPPools(ctx, appKind, newObject)
+				if c.subnetMgr.config.EnableSubnetDeleteStaleIPPool {
+					err = c.tryToCleanUpLegacyIPPools(ctx, newObject)
 					if nil != err {
 						log.Sugar().Errorf("failed try to clean up legacy IPPools, error: %v", err)
 					}
@@ -124,7 +138,6 @@ func (sm *subnetManager) ControllerAddOrUpdateHandler() controllers.AppInformers
 			}
 
 			app = newObject.DeepCopy()
-			podSelector = newObject.Spec.Selector.MatchLabels
 
 			if oldObj != nil {
 				oldDeployment := oldObj.(*appsv1.Deployment)
@@ -137,7 +150,7 @@ func (sm *subnetManager) ControllerAddOrUpdateHandler() controllers.AppInformers
 
 		case *appsv1.ReplicaSet:
 			appKind = constant.OwnerReplicaSet
-			log = logger.With(zap.String(appKind, fmt.Sprintf("%s/%s", newObject.GetNamespace(), newObject.GetName())))
+			log = log.With(zap.String(appKind, fmt.Sprintf("%s/%s", newObject.GetNamespace(), newObject.GetName())))
 
 			// no need reconcile for HostNetwork application
 			if newObject.Spec.Template.Spec.HostNetwork {
@@ -163,8 +176,8 @@ func (sm *subnetManager) ControllerAddOrUpdateHandler() controllers.AppInformers
 				log.Debug("app will use default IPAM mode with no subnet annotation")
 
 				// if one application used to have subnet feature but discard it later, we should also clean up the legacy IPPools
-				if sm.config.EnableSubnetDeleteStaleIPPool {
-					err = sm.tryToCleanUpLegacyIPPools(ctx, appKind, newObject)
+				if c.subnetMgr.config.EnableSubnetDeleteStaleIPPool {
+					err = c.tryToCleanUpLegacyIPPools(ctx, newObject)
 					if nil != err {
 						log.Sugar().Errorf("failed try to clean up legacy IPPools, error: %v", err)
 					}
@@ -174,7 +187,6 @@ func (sm *subnetManager) ControllerAddOrUpdateHandler() controllers.AppInformers
 			}
 
 			app = newObject.DeepCopy()
-			podSelector = newObject.Spec.Selector.MatchLabels
 
 			if oldObj != nil {
 				oldReplicaSet := oldObj.(*appsv1.ReplicaSet)
@@ -187,7 +199,7 @@ func (sm *subnetManager) ControllerAddOrUpdateHandler() controllers.AppInformers
 
 		case *appsv1.StatefulSet:
 			appKind = constant.OwnerStatefulSet
-			log = logger.With(zap.String(appKind, fmt.Sprintf("%s/%s", newObject.GetNamespace(), newObject.GetName())))
+			log = log.With(zap.String(appKind, fmt.Sprintf("%s/%s", newObject.GetNamespace(), newObject.GetName())))
 
 			// no need reconcile for HostNetwork application
 			if newObject.Spec.Template.Spec.HostNetwork {
@@ -198,7 +210,7 @@ func (sm *subnetManager) ControllerAddOrUpdateHandler() controllers.AppInformers
 			// check the app whether is the top controller or not
 			owner := metav1.GetControllerOf(newObject)
 			if owner != nil {
-				log.Sugar().Debugf("apphas a owner '%s/%s', we would not create or scale IPPool for it", owner.Kind, owner.Name)
+				log.Sugar().Debugf("app has a owner '%s/%s', we would not create or scale IPPool for it", owner.Kind, owner.Name)
 				return nil
 			}
 
@@ -213,8 +225,8 @@ func (sm *subnetManager) ControllerAddOrUpdateHandler() controllers.AppInformers
 				log.Debug("app will use default IPAM mode with no subnet annotation")
 
 				// if one application used to have subnet feature but discard it later, we should also clean up the legacy IPPools
-				if sm.config.EnableSubnetDeleteStaleIPPool {
-					err = sm.tryToCleanUpLegacyIPPools(ctx, appKind, newObject)
+				if c.subnetMgr.config.EnableSubnetDeleteStaleIPPool {
+					err = c.tryToCleanUpLegacyIPPools(ctx, newObject)
 					if nil != err {
 						log.Sugar().Errorf("failed try to clean up legacy IPPools, error: %v", err)
 					}
@@ -224,7 +236,6 @@ func (sm *subnetManager) ControllerAddOrUpdateHandler() controllers.AppInformers
 			}
 
 			app = newObject.DeepCopy()
-			podSelector = newObject.Spec.Selector.MatchLabels
 
 			if oldObj != nil {
 				oldStatefulSet := oldObj.(*appsv1.StatefulSet)
@@ -237,7 +248,7 @@ func (sm *subnetManager) ControllerAddOrUpdateHandler() controllers.AppInformers
 
 		case *batchv1.Job:
 			appKind = constant.OwnerJob
-			log = logger.With(zap.String(appKind, fmt.Sprintf("%s/%s", newObject.GetNamespace(), newObject.GetName())))
+			log = log.With(zap.String(appKind, fmt.Sprintf("%s/%s", newObject.GetNamespace(), newObject.GetName())))
 
 			// no need reconcile for HostNetwork application
 			if newObject.Spec.Template.Spec.HostNetwork {
@@ -263,8 +274,8 @@ func (sm *subnetManager) ControllerAddOrUpdateHandler() controllers.AppInformers
 				log.Debug("app will use default IPAM mode with no subnet annotation")
 
 				// if one application used to have subnet feature but discard it later, we should also clean up the legacy IPPools
-				if sm.config.EnableSubnetDeleteStaleIPPool {
-					err = sm.tryToCleanUpLegacyIPPools(ctx, appKind, newObject)
+				if c.subnetMgr.config.EnableSubnetDeleteStaleIPPool {
+					err = c.tryToCleanUpLegacyIPPools(ctx, newObject)
 					if nil != err {
 						log.Sugar().Errorf("failed try to clean up legacy IPPools, error: %v", err)
 					}
@@ -274,7 +285,6 @@ func (sm *subnetManager) ControllerAddOrUpdateHandler() controllers.AppInformers
 			}
 
 			app = newObject.DeepCopy()
-			podSelector = newObject.Spec.Selector.MatchLabels
 
 			if oldObj != nil {
 				oldJob := oldObj.(*batchv1.Job)
@@ -287,7 +297,7 @@ func (sm *subnetManager) ControllerAddOrUpdateHandler() controllers.AppInformers
 
 		case *batchv1.CronJob:
 			appKind = constant.OwnerCronJob
-			log = logger.With(zap.String(appKind, fmt.Sprintf("%s/%s", newObject.GetNamespace(), newObject.GetName())))
+			log = log.With(zap.String(appKind, fmt.Sprintf("%s/%s", newObject.GetNamespace(), newObject.GetName())))
 
 			// no need reconcile for HostNetwork application
 			if newObject.Spec.JobTemplate.Spec.Template.Spec.HostNetwork {
@@ -313,8 +323,8 @@ func (sm *subnetManager) ControllerAddOrUpdateHandler() controllers.AppInformers
 				log.Debug("app will use default IPAM mode with no subnet annotation")
 
 				// if one application used to have subnet feature but discard it later, we should also clean up the legacy IPPools
-				if sm.config.EnableSubnetDeleteStaleIPPool {
-					err = sm.tryToCleanUpLegacyIPPools(ctx, appKind, newObject)
+				if c.subnetMgr.config.EnableSubnetDeleteStaleIPPool {
+					err = c.tryToCleanUpLegacyIPPools(ctx, newObject)
 					if nil != err {
 						log.Sugar().Errorf("failed try to clean up legacy IPPools, error: %v", err)
 					}
@@ -323,15 +333,7 @@ func (sm *subnetManager) ControllerAddOrUpdateHandler() controllers.AppInformers
 				return nil
 			}
 
-			var lastJob batchv1.Job
-			lastJobName := newObject.Status.Active[len(newObject.Status.Active)].Name
-			err = sm.client.Get(ctx, apitypes.NamespacedName{Namespace: newObject.Namespace, Name: lastJobName}, &lastJob)
-			if nil != err {
-				return fmt.Errorf("failed to get Job '%s/%s', error: %v", newObject.Namespace, lastJobName, err)
-			}
-
 			app = newObject.DeepCopy()
-			podSelector = newObject.Spec.JobTemplate.Spec.Selector.MatchLabels
 
 			if oldObj != nil {
 				oldCronJob := oldObj.(*batchv1.CronJob)
@@ -344,7 +346,7 @@ func (sm *subnetManager) ControllerAddOrUpdateHandler() controllers.AppInformers
 
 		case *appsv1.DaemonSet:
 			appKind = constant.OwnerDaemonSet
-			log = logger.With(zap.String(appKind, fmt.Sprintf("%s/%s", newObject.GetNamespace(), newObject.GetName())))
+			log = log.With(zap.String(appKind, fmt.Sprintf("%s/%s", newObject.GetNamespace(), newObject.GetName())))
 
 			// no need reconcile for HostNetwork application
 			if newObject.Spec.Template.Spec.HostNetwork {
@@ -370,8 +372,8 @@ func (sm *subnetManager) ControllerAddOrUpdateHandler() controllers.AppInformers
 				log.Debug("app will use default IPAM mode with no subnet annotation")
 
 				// if one application used to have subnet feature but discard it later, we should also clean up the legacy IPPools
-				if sm.config.EnableSubnetDeleteStaleIPPool {
-					err = sm.tryToCleanUpLegacyIPPools(ctx, appKind, newObject)
+				if c.subnetMgr.config.EnableSubnetDeleteStaleIPPool {
+					err = c.tryToCleanUpLegacyIPPools(ctx, newObject)
 					if nil != err {
 						log.Sugar().Errorf("failed try to clean up legacy IPPools, error: %v", err)
 					}
@@ -381,7 +383,6 @@ func (sm *subnetManager) ControllerAddOrUpdateHandler() controllers.AppInformers
 			}
 
 			app = newObject.DeepCopy()
-			podSelector = newObject.Spec.Selector.MatchLabels
 
 			if oldObj != nil {
 				oldDaemonSet := oldObj.(*appsv1.DaemonSet)
@@ -396,27 +397,303 @@ func (sm *subnetManager) ControllerAddOrUpdateHandler() controllers.AppInformers
 			return fmt.Errorf("unrecognized application: %+v", newObj)
 		}
 
+		ctx = logutils.IntoContext(ctx, log)
 		// check the difference between the two object and choose to reconcile or not
-		if sm.hasSubnetConfigChanged(logutils.IntoContext(ctx, log), oldSubnetConfig, newSubnetConfig, oldAppReplicas, newAppReplicas, appKind, app) {
-			go func() {
-				log.Debug("Going to create IPPool or mark IPPool desired IP number")
-				err = sm.createOrMarkIPPool(ctx, *newSubnetConfig, appKind, app, podSelector, newAppReplicas)
-				if nil != err {
-					log.Sugar().Errorf("failed to create or scale IPPool, error: %v", err)
-				}
-			}()
+		if c.hasSubnetConfigChanged(ctx, oldSubnetConfig, newSubnetConfig, oldAppReplicas, newAppReplicas, app) {
+			c.enqueueApp(ctx, app, appKind)
 		}
 
 		return nil
 	}
 }
 
+type appController struct {
+	subnetMgr *subnetManager
+
+	deploymentsLister  appslisters.DeploymentLister
+	deploymentInformer cache.SharedIndexInformer
+
+	replicaSetLister   appslisters.ReplicaSetLister
+	replicaSetInformer cache.SharedIndexInformer
+
+	statefulSetLister   appslisters.StatefulSetLister
+	statefulSetInformer cache.SharedIndexInformer
+
+	daemonSetLister   appslisters.DaemonSetLister
+	daemonSetInformer cache.SharedIndexInformer
+
+	jobLister   batchlisters.JobLister
+	jobInformer cache.SharedIndexInformer
+
+	cronJobLister   batchlisters.CronJobLister
+	cronJobInformer cache.SharedIndexInformer
+}
+
+func newAppController(subnetMgr *subnetManager, factory kubeinformers.SharedInformerFactory) *appController {
+	c := &appController{
+		subnetMgr: subnetMgr,
+
+		deploymentsLister:  factory.Apps().V1().Deployments().Lister(),
+		deploymentInformer: factory.Apps().V1().Deployments().Informer(),
+
+		replicaSetLister:   factory.Apps().V1().ReplicaSets().Lister(),
+		replicaSetInformer: factory.Apps().V1().ReplicaSets().Informer(),
+
+		statefulSetLister:   factory.Apps().V1().StatefulSets().Lister(),
+		statefulSetInformer: factory.Apps().V1().StatefulSets().Informer(),
+
+		daemonSetLister:   factory.Apps().V1().DaemonSets().Lister(),
+		daemonSetInformer: factory.Apps().V1().DaemonSets().Informer(),
+
+		jobLister:   factory.Batch().V1().Jobs().Lister(),
+		jobInformer: factory.Batch().V1().Jobs().Informer(),
+
+		cronJobLister:   factory.Batch().V1().CronJobs().Lister(),
+		cronJobInformer: factory.Batch().V1().CronJobs().Informer(),
+	}
+
+	return c
+}
+
+// appWorkQueueKey involves application object meta namespaceKey and application kind
+type appWorkQueueKey struct {
+	MetaNamespaceKey string
+	AppKind          string
+}
+
+// enqueueApp will insert application custom appWorkQueueKey to the workQueue
+func (c *appController) enqueueApp(ctx context.Context, obj interface{}, appKind string) {
+	log := logutils.FromContext(ctx)
+
+	// object meta key: 'namespace/name'
+	metaKey, err := cache.MetaNamespaceKeyFunc(obj)
+	if nil != err {
+		log.Sugar().Errorf("failed to API object '%+v' meta key", obj)
+		return
+	}
+
+	appKey := appWorkQueueKey{
+		MetaNamespaceKey: metaKey,
+		AppKind:          appKind,
+	}
+
+	// validate workqueue capacity
+	maxQueueLength := c.subnetMgr.config.MaxWorkqueueLength
+	if c.subnetMgr.workQueue.Len() >= maxQueueLength {
+		log.Sugar().Errorf("The application controller workqueue is out of capacity, discard enqueue '%v'", appKey)
+		return
+	}
+
+	c.subnetMgr.workQueue.Add(appKey)
+	log.Sugar().Debugf("added '%v' to application controller workequeue", appKey)
+}
+
+func (c *appController) Run(workers int, stopCh <-chan struct{}) error {
+	defer utilruntime.HandleCrash()
+	defer c.subnetMgr.workQueue.ShutDown()
+
+	logger.Debug("Waiting for application informers caches to sync")
+	ok := cache.WaitForCacheSync(stopCh,
+		c.deploymentInformer.HasSynced,
+		c.replicaSetInformer.HasSynced,
+		c.daemonSetInformer.HasSynced,
+		c.statefulSetInformer.HasSynced,
+		c.jobInformer.HasSynced,
+		c.cronJobInformer.HasSynced,
+	)
+	if !ok {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
+
+	for i := 0; i < workers; i++ {
+		go wait.Until(c.runWorker, time.Second, stopCh)
+	}
+
+	logger.Info("application controller workers started")
+
+	<-stopCh
+	logger.Error("Shutting down application controller workers")
+	return nil
+}
+
+func (c *appController) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *appController) processNextWorkItem() bool {
+	obj, shutdown := c.subnetMgr.workQueue.Get()
+	if shutdown {
+		logger.Error("application controller workqueue is already shutdown!")
+		return false
+	}
+
+	var log *zap.Logger
+
+	process := func(obj interface{}) error {
+		defer c.subnetMgr.workQueue.Done(obj)
+		key, ok := obj.(appWorkQueueKey)
+		if !ok {
+			c.subnetMgr.workQueue.Forget(obj)
+			return fmt.Errorf("expected appWorkQueueKey in workQueue but got '%+v'", obj)
+		}
+
+		log = logger.With(
+			zap.String("OPERATION", "process_app_items"),
+			zap.String("Application", fmt.Sprintf("%s/%s", key.AppKind, key.MetaNamespaceKey)),
+		)
+
+		err := c.syncHandler(key, log)
+		if nil != err {
+			// discard wrong input items
+			if errors.Is(err, constant.ErrWrongInput) {
+				c.subnetMgr.workQueue.Forget(obj)
+				return err
+			}
+
+			// requeue the conflict items
+			if apierrors.IsConflict(err) {
+				c.subnetMgr.workQueue.AddRateLimited(obj)
+				log.Sugar().Warnf("encountered conflict '%v', retrying...", err)
+				return nil
+			}
+
+			// if we set nonnegative number for the requeue delay duration, we will requeue it. otherwise we will discard it.
+			if c.subnetMgr.config.RequeueDelayDuration >= 0 {
+				if c.subnetMgr.workQueue.NumRequeues(obj) < c.subnetMgr.config.MaxWorkqueueLength {
+					c.subnetMgr.workQueue.AddAfter(obj, c.subnetMgr.config.RequeueDelayDuration)
+					return fmt.Errorf("encountered error '%v', requeue it after '%v'", err, c.subnetMgr.config.RequeueDelayDuration)
+				}
+
+				log.Warn("out of work queue max retries, drop it")
+			}
+
+			c.subnetMgr.workQueue.Forget(obj)
+			return err
+		}
+
+		c.subnetMgr.workQueue.Forget(obj)
+		return nil
+	}
+
+	if err := process(obj); nil != err {
+		log.Error(err.Error())
+	}
+
+	return true
+}
+
+// syncHandler retrieves appWorkQueueKey from workQueue and try to create the auto-created IPPool or mark the IPPool status.AutoDesiredIPCount
+func (c *appController) syncHandler(appKey appWorkQueueKey, log *zap.Logger) (err error) {
+	namespace, name, err := cache.SplitMetaNamespaceKey(appKey.MetaNamespaceKey)
+	if nil != err {
+		return fmt.Errorf("%w: failed to split meta namespace key '%+v', error: %v", constant.ErrWrongInput, appKey.MetaNamespaceKey, err)
+	}
+
+	var app metav1.Object
+	var subnetConfig *controllers.PodSubnetAnnoConfig
+	var podAnno, podSelector map[string]string
+	var appReplicas int
+
+	switch appKey.AppKind {
+	case constant.OwnerDeployment:
+		deployment, err := c.deploymentsLister.Deployments(namespace).Get(name)
+		if client.IgnoreNotFound(err) != nil {
+			return err
+		}
+
+		podAnno = deployment.Spec.Template.Annotations
+		podSelector = deployment.Spec.Selector.MatchLabels
+		appReplicas = controllers.GetAppReplicas(deployment.Spec.Replicas)
+		app = deployment.DeepCopy()
+
+	case constant.OwnerReplicaSet:
+		replicaSet, err := c.replicaSetLister.ReplicaSets(namespace).Get(name)
+		if client.IgnoreNotFound(err) != nil {
+			return err
+		}
+
+		podAnno = replicaSet.Spec.Template.Annotations
+		podSelector = replicaSet.Spec.Selector.MatchLabels
+		appReplicas = controllers.GetAppReplicas(replicaSet.Spec.Replicas)
+		app = replicaSet.DeepCopy()
+
+	case constant.OwnerDaemonSet:
+		daemonSet, err := c.daemonSetLister.DaemonSets(namespace).Get(name)
+		if client.IgnoreNotFound(err) != nil {
+			return err
+		}
+
+		podAnno = daemonSet.Spec.Template.Annotations
+		podSelector = daemonSet.Spec.Selector.MatchLabels
+		appReplicas = int(daemonSet.Status.DesiredNumberScheduled)
+		app = daemonSet.DeepCopy()
+
+	case constant.OwnerStatefulSet:
+		statefulSet, err := c.statefulSetLister.StatefulSets(namespace).Get(name)
+		if client.IgnoreNotFound(err) != nil {
+			return err
+		}
+
+		podAnno = statefulSet.Spec.Template.Annotations
+		podSelector = statefulSet.Spec.Selector.MatchLabels
+		appReplicas = controllers.GetAppReplicas(statefulSet.Spec.Replicas)
+		app = statefulSet.DeepCopy()
+
+	case constant.OwnerJob:
+		job, err := c.jobLister.Jobs(namespace).Get(name)
+		if client.IgnoreNotFound(err) != nil {
+			return err
+		}
+
+		podAnno = job.Spec.Template.Annotations
+		podSelector = job.Spec.Selector.MatchLabels
+		appReplicas = controllers.CalculateJobPodNum(job.Spec.Parallelism, job.Spec.Completions)
+		app = job.DeepCopy()
+
+	case constant.OwnerCronJob:
+		cronJob, err := c.cronJobLister.CronJobs(namespace).Get(name)
+		if client.IgnoreNotFound(err) != nil {
+			return err
+		}
+
+		podAnno = cronJob.Spec.JobTemplate.Spec.Template.Annotations
+		podSelector = cronJob.Spec.JobTemplate.Spec.Selector.MatchLabels
+		appReplicas = controllers.CalculateJobPodNum(cronJob.Spec.JobTemplate.Spec.Parallelism, cronJob.Spec.JobTemplate.Spec.Completions)
+		app = cronJob.DeepCopy()
+
+	default:
+		return fmt.Errorf("%w: unexpected appWorkQueueKey in workQueue '%+v'", constant.ErrWrongInput, appKey)
+	}
+
+	subnetConfig, err = controllers.GetSubnetAnnoConfig(podAnno)
+	if nil != err {
+		return fmt.Errorf("%w: failed to get pod annotation subnet config, error: %v", constant.ErrWrongInput, err)
+	}
+
+	log.Debug("Going to create IPPool or mark IPPool desired IP number")
+	err = c.createOrMarkIPPool(logutils.IntoContext(context.TODO(), log), *subnetConfig, appKey.AppKind, app, podSelector, appReplicas)
+	if nil != err {
+		return fmt.Errorf("failed to create or scale IPPool, error: %w", err)
+	}
+
+	return nil
+}
+
 // createOrMarkIPPool try to create an IPPool or mark IPPool desired IP number with the give SpiderSubnet configuration
-func (sm *subnetManager) createOrMarkIPPool(ctx context.Context, podSubnetConfig controllers.PodSubnetAnnoConfig, appKind string, app metav1.Object,
+func (c *appController) createOrMarkIPPool(ctx context.Context, podSubnetConfig controllers.PodSubnetAnnoConfig, appKind string, app metav1.Object,
 	podSelector map[string]string, appReplicas int) error {
+	if c.subnetMgr.config.EnableIPv4 && len(podSubnetConfig.SubnetName.IPv4) == 0 {
+		return fmt.Errorf("IPv4 SpiderSubnet not specified when configuration enableIPv4 is on")
+	}
+	if c.subnetMgr.config.EnableIPv6 && len(podSubnetConfig.SubnetName.IPv6) == 0 {
+		return fmt.Errorf("IPv6 SpiderSubnet not specified when configuration enableIPv6 is on")
+	}
+
+	log := logutils.FromContext(ctx)
 
 	// retrieve application pools
-	f := func(ctx context.Context, poolList *spiderpoolv1.SpiderIPPoolList, subnetName string, ipVersion types.IPVersion) error {
+	f := func(ctx context.Context, poolList *spiderpoolv1.SpiderIPPoolList, subnetName string, ipVersion types.IPVersion) (err error) {
 		var ipNum int
 		if podSubnetConfig.FlexibleIPNum != nil {
 			ipNum = appReplicas + *(podSubnetConfig.FlexibleIPNum)
@@ -426,74 +703,68 @@ func (sm *subnetManager) createOrMarkIPPool(ctx context.Context, podSubnetConfig
 
 		// verify whether the pool IPs need to be expanded or not
 		if poolList == nil || len(poolList.Items) == 0 {
+			log.Sugar().Debugf("there's no 'IPv%d' IPPoolList retrieved from SpiderSubent '%s'", ipVersion, subnetName)
 			// create an empty IPPool and mark the desired IP number when the subnet name was specified,
 			// and the IPPool informer will implement the scale action
-			err := sm.AllocateEmptyIPPool(ctx, subnetName, appKind, app, podSelector, ipNum, ipVersion, podSubnetConfig.ReclaimIPPool)
-			if nil != err {
-				return err
-			}
+			err = c.subnetMgr.AllocateEmptyIPPool(ctx, subnetName, appKind, app, podSelector, ipNum, ipVersion, podSubnetConfig.ReclaimIPPool)
 		} else if len(poolList.Items) == 1 {
 			pool := poolList.Items[0]
-			err := sm.CheckScaleIPPool(ctx, &pool, subnetName, ipNum)
-			if nil != err {
-				return err
-			}
+			log.Sugar().Debugf("found SpiderSubnet '%s' IPPool '%s' and check it whether need to be scaled", subnetName, pool.Name)
+			err = c.subnetMgr.CheckScaleIPPool(ctx, &pool, subnetName, ipNum)
 		} else {
-			return fmt.Errorf("it's invalid for '%s/%s/%s' corresponding SpiderSubnet '%s' owns multiple IPPools '%v' for one specify application",
-				appKind, app.GetNamespace(), app.GetName(), subnetName, poolList.Items)
+			err = fmt.Errorf("%w: it's invalid that SpiderSubnet '%s' owns multiple IPPools '%v' for one specify application", constant.ErrWrongInput, subnetName, poolList.Items)
 		}
 
-		return nil
+		return
 	}
 
-	if sm.config.EnableIPv4 && len(podSubnetConfig.SubnetName.IPv4) == 0 {
-		return fmt.Errorf("IPv4 SpiderSubnet not specified when configuration enableIPv4 is on")
-	}
-	if sm.config.EnableIPv6 && len(podSubnetConfig.SubnetName.IPv6) == 0 {
-		return fmt.Errorf("IPv6 SpiderSubnet not specified when configuration enableIPv6 is on")
-	}
+	var errV4, errV6 error
+	var wg sync.WaitGroup
+	if c.subnetMgr.config.EnableIPv4 && len(podSubnetConfig.SubnetName.IPv4) != 0 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
 
-	var errs []error
-	if sm.config.EnableIPv4 {
-		if len(podSubnetConfig.SubnetName.IPv4) != 0 {
-			v4PoolList, err := sm.ipPoolManager.ListIPPools(ctx, client.MatchingLabels{
+			var v4PoolList *spiderpoolv1.SpiderIPPoolList
+			v4PoolList, errV4 = c.subnetMgr.ipPoolManager.ListIPPools(ctx, client.MatchingLabels{
 				constant.LabelIPPoolOwnerApplicationUID: string(app.GetUID()),
 				constant.LabelIPPoolOwnerSpiderSubnet:   podSubnetConfig.SubnetName.IPv4[0],
 				constant.LabelIPPoolOwnerApplication:    controllers.AppLabelValue(appKind, app.GetNamespace(), app.GetName()),
 				constant.LabelIPPoolVersion:             constant.LabelIPPoolVersionV4,
 			})
-			if nil != err {
-				return err
+			if nil != errV4 {
+				return
 			}
 
-			err = f(ctx, v4PoolList, podSubnetConfig.SubnetName.IPv4[0], constant.IPv4)
-			if nil != err {
-				errs = append(errs, err)
-			}
-		}
+			errV4 = f(ctx, v4PoolList, podSubnetConfig.SubnetName.IPv4[0], constant.IPv4)
+		}()
 	}
 
-	if sm.config.EnableIPv6 {
-		if len(podSubnetConfig.SubnetName.IPv6) != 0 {
-			v6PoolList, err := sm.ipPoolManager.ListIPPools(ctx, client.MatchingLabels{
+	if c.subnetMgr.config.EnableIPv6 && len(podSubnetConfig.SubnetName.IPv6) != 0 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			var v6PoolList *spiderpoolv1.SpiderIPPoolList
+			v6PoolList, errV6 = c.subnetMgr.ipPoolManager.ListIPPools(ctx, client.MatchingLabels{
 				constant.LabelIPPoolOwnerApplicationUID: string(app.GetUID()),
 				constant.LabelIPPoolOwnerSpiderSubnet:   podSubnetConfig.SubnetName.IPv6[0],
 				constant.LabelIPPoolOwnerApplication:    controllers.AppLabelValue(appKind, app.GetNamespace(), app.GetName()),
 				constant.LabelIPPoolVersion:             constant.LabelIPPoolVersionV6,
 			})
-			if nil != err {
-				return err
+			if nil != errV6 {
+				return
 			}
 
-			err = f(ctx, v6PoolList, podSubnetConfig.SubnetName.IPv6[0], constant.IPv6)
-			if nil != err {
-				errs = append(errs, err)
-			}
-		}
+			errV6 = f(ctx, v6PoolList, podSubnetConfig.SubnetName.IPv6[0], constant.IPv6)
+		}()
 	}
 
-	if len(errs) != 0 {
-		return utilerrors.NewAggregate(errs)
+	wg.Wait()
+
+	if errV4 != nil || errV6 != nil {
+		// NewAggregate will check each the given error slice elements whether is nil or not
+		return multierr.Append(errV4, errV6)
 	}
 
 	return nil
@@ -501,8 +772,8 @@ func (sm *subnetManager) createOrMarkIPPool(ctx context.Context, podSubnetConfig
 
 // hasSubnetConfigChanged checks whether application subnet configuration changed and the application replicas changed or not.
 // The second parameter newSubnetConfig must not be nil.
-func (sm *subnetManager) hasSubnetConfigChanged(ctx context.Context, oldSubnetConfig, newSubnetConfig *controllers.PodSubnetAnnoConfig,
-	oldAppReplicas, newAppReplicas int, appKind string, app metav1.Object) bool {
+func (c *appController) hasSubnetConfigChanged(ctx context.Context, oldSubnetConfig, newSubnetConfig *controllers.PodSubnetAnnoConfig,
+	oldAppReplicas, newAppReplicas int, app metav1.Object) bool {
 	// go to reconcile directly with new application
 	if oldSubnetConfig == nil {
 		return true
@@ -524,8 +795,8 @@ func (sm *subnetManager) hasSubnetConfigChanged(ctx context.Context, oldSubnetCo
 			log.Sugar().Warnf("change SpiderSubnet IPv4 from '%s' to '%s'", oldSubnetConfig.SubnetName.IPv4[0], newSubnetConfig.SubnetName.IPv4[0])
 
 			// we should clean up the legacy IPPools once changed the SpiderSubnet
-			if sm.config.EnableSubnetDeleteStaleIPPool {
-				if err := sm.tryToCleanUpLegacyIPPools(ctx, appKind, app, client.MatchingLabels{
+			if c.subnetMgr.config.EnableSubnetDeleteStaleIPPool {
+				if err := c.tryToCleanUpLegacyIPPools(ctx, app, client.MatchingLabels{
 					constant.LabelIPPoolOwnerSpiderSubnet: oldSubnetConfig.SubnetName.IPv4[0],
 				}); err != nil {
 					log.Sugar().Errorf("failed to clean up SpiderSubnet '%s' legacy V4 IPPools, error: %v", oldSubnetConfig.SubnetName.IPv4[0], err)
@@ -537,8 +808,8 @@ func (sm *subnetManager) hasSubnetConfigChanged(ctx context.Context, oldSubnetCo
 			log.Sugar().Warnf("change SpiderSubnet IPv6 from '%s' to '%s'", oldSubnetConfig.SubnetName.IPv6[0], newSubnetConfig.SubnetName.IPv6[0])
 
 			// we should clean up the legacy IPPools once changed the SpiderSubnet
-			if sm.config.EnableSubnetDeleteStaleIPPool {
-				if err := sm.tryToCleanUpLegacyIPPools(ctx, appKind, app, client.MatchingLabels{
+			if c.subnetMgr.config.EnableSubnetDeleteStaleIPPool {
+				if err := c.tryToCleanUpLegacyIPPools(ctx, app, client.MatchingLabels{
 					constant.LabelIPPoolOwnerSpiderSubnet: oldSubnetConfig.SubnetName.IPv6[0],
 				}); err != nil {
 					log.Sugar().Errorf("failed to clean up SpiderSubnet '%s' legacy V6 IPPools, error: %v", oldSubnetConfig.SubnetName.IPv6[0], err)
@@ -551,22 +822,21 @@ func (sm *subnetManager) hasSubnetConfigChanged(ctx context.Context, oldSubnetCo
 }
 
 // ControllerDeleteHandler will return a function that clean up the application SpiderSubnet legacies (such as: the before created IPPools)
-func (sm *subnetManager) ControllerDeleteHandler() controllers.APPInformersDelFunc {
+func (c *appController) ControllerDeleteHandler() controllers.APPInformersDelFunc {
 	return func(ctx context.Context, obj interface{}) error {
 		log := logutils.FromContext(ctx)
 
 		var appKind string
 		var app metav1.Object
-		var logPrefix string
 
 		switch object := obj.(type) {
 		case *appsv1.Deployment:
 			appKind = constant.OwnerDeployment
-			logPrefix = fmt.Sprintf("application '%s/%s/%s'", appKind, object.Namespace, object.Name)
+			log = log.With(zap.String(appKind, fmt.Sprintf("%s/%s", object.Namespace, object.Name)))
 
 			owner := metav1.GetControllerOf(object)
 			if owner != nil {
-				log.Sugar().Debugf("%s has a owner '%s/%s', we would not clean up legacies for it", logPrefix, owner.Kind, owner.Name)
+				log.Sugar().Debugf("the application has a owner '%s/%s', we would not clean up legacy for it", owner.Kind, owner.Name)
 				return nil
 			}
 
@@ -574,11 +844,11 @@ func (sm *subnetManager) ControllerDeleteHandler() controllers.APPInformersDelFu
 
 		case *appsv1.ReplicaSet:
 			appKind = constant.OwnerReplicaSet
-			logPrefix = fmt.Sprintf("application '%s/%s/%s'", appKind, object.Namespace, object.Name)
+			log = log.With(zap.String(appKind, fmt.Sprintf("%s/%s", object.Namespace, object.Name)))
 
 			owner := metav1.GetControllerOf(object)
 			if owner != nil {
-				log.Sugar().Debugf("%s has a owner '%s/%s', we would not clean up legacies for it", logPrefix, owner.Kind, owner.Name)
+				log.Sugar().Debugf("the application has a owner '%s/%s', we would not clean up legacy for it", owner.Kind, owner.Name)
 				return nil
 			}
 
@@ -586,11 +856,11 @@ func (sm *subnetManager) ControllerDeleteHandler() controllers.APPInformersDelFu
 
 		case *appsv1.StatefulSet:
 			appKind = constant.OwnerStatefulSet
-			logPrefix = fmt.Sprintf("application '%s/%s/%s'", appKind, object.Namespace, object.Name)
+			log = log.With(zap.String(appKind, fmt.Sprintf("%s/%s", object.Namespace, object.Name)))
 
 			owner := metav1.GetControllerOf(object)
 			if owner != nil {
-				log.Sugar().Debugf("%s has a owner '%s/%s', we would not clean up legacies for it", logPrefix, owner.Kind, owner.Name)
+				log.Sugar().Debugf("the application has a owner '%s/%s', we would not clean up legacy for it", owner.Kind, owner.Name)
 				return nil
 			}
 
@@ -598,11 +868,11 @@ func (sm *subnetManager) ControllerDeleteHandler() controllers.APPInformersDelFu
 
 		case *batchv1.Job:
 			appKind = constant.OwnerJob
-			logPrefix = fmt.Sprintf("application '%s/%s/%s'", appKind, object.Namespace, object.Name)
+			log = log.With(zap.String(appKind, fmt.Sprintf("%s/%s", object.Namespace, object.Name)))
 
 			owner := metav1.GetControllerOf(object)
 			if owner != nil {
-				log.Sugar().Debugf("%s has a owner '%s/%s', we would not clean up legacies for it", logPrefix, owner.Kind, owner.Name)
+				log.Sugar().Debugf("the application has a owner '%s/%s', we would not clean up legacy for it", owner.Kind, owner.Name)
 				return nil
 			}
 
@@ -610,12 +880,11 @@ func (sm *subnetManager) ControllerDeleteHandler() controllers.APPInformersDelFu
 
 		case *batchv1.CronJob:
 			appKind = constant.OwnerCronJob
-			logPrefix = fmt.Sprintf("application '%s/%s/%s'", appKind, object.Namespace, object.Name)
+			log = log.With(zap.String(appKind, fmt.Sprintf("%s/%s", object.Namespace, object.Name)))
 
 			owner := metav1.GetControllerOf(object)
 			if owner != nil {
-				log.Sugar().Debugf("%s has a owner '%s/%s', we would not clean up legacies for it", logPrefix, owner.Kind, owner.Name)
-
+				log.Sugar().Debugf("the application has a owner '%s/%s', we would not clean up legacy for it", owner.Kind, owner.Name)
 				return nil
 			}
 
@@ -623,12 +892,11 @@ func (sm *subnetManager) ControllerDeleteHandler() controllers.APPInformersDelFu
 
 		case *appsv1.DaemonSet:
 			appKind = constant.OwnerDaemonSet
-			logPrefix = fmt.Sprintf("application '%s/%s/%s'", appKind, object.Namespace, object.Name)
+			log = log.With(zap.String(appKind, fmt.Sprintf("%s/%s", object.Namespace, object.Name)))
 
 			owner := metav1.GetControllerOf(object)
 			if owner != nil {
-				log.Sugar().Debugf("%s has a owner '%s/%s', we would not clean up legacies for it", logPrefix, owner.Kind, owner.Name)
-
+				log.Sugar().Debugf("the application has a owner '%s/%s', we would not clean up legacy for it", owner.Kind, owner.Name)
 				return nil
 			}
 
@@ -639,8 +907,9 @@ func (sm *subnetManager) ControllerDeleteHandler() controllers.APPInformersDelFu
 		}
 
 		// clean up all legacy IPPools that matched with the application UID
+		ctx = logutils.IntoContext(ctx, log)
 		go func() {
-			err := sm.tryToCleanUpLegacyIPPools(ctx, appKind, app)
+			err := c.tryToCleanUpLegacyIPPools(ctx, app)
 			if nil != err {
 				log.Sugar().Errorf("failed to clean up legacy IPPool, error: %v", err)
 			}
@@ -650,8 +919,8 @@ func (sm *subnetManager) ControllerDeleteHandler() controllers.APPInformersDelFu
 	}
 }
 
-func (sm *subnetManager) tryToCleanUpLegacyIPPools(ctx context.Context, appKind string, app metav1.Object, labels ...client.MatchingLabels) error {
-	log := logutils.FromContext(ctx).With(zap.String(appKind, fmt.Sprintf("%s/%s", app.GetNamespace(), app.GetName())))
+func (c *appController) tryToCleanUpLegacyIPPools(ctx context.Context, app metav1.Object, labels ...client.MatchingLabels) error {
+	log := logutils.FromContext(ctx)
 
 	matchLabel := client.MatchingLabels{
 		constant.LabelIPPoolOwnerApplicationUID: string(app.GetUID()),
@@ -664,9 +933,9 @@ func (sm *subnetManager) tryToCleanUpLegacyIPPools(ctx context.Context, appKind 
 		}
 	}
 
-	poolList, err := sm.ipPoolManager.ListIPPools(ctx, matchLabel)
+	poolList, err := c.subnetMgr.ipPoolManager.ListIPPools(ctx, matchLabel)
 	if nil != err {
-		return fmt.Errorf("failed to retrieve '%s/%s/%s' IPPools, error: %v", appKind, app.GetNamespace(), app.GetName(), err)
+		return err
 	}
 
 	if poolList != nil && len(poolList.Items) != 0 {
@@ -674,7 +943,7 @@ func (sm *subnetManager) tryToCleanUpLegacyIPPools(ctx context.Context, appKind 
 
 		deletePool := func(pool *spiderpoolv1.SpiderIPPool) {
 			defer wg.Done()
-			err := sm.ipPoolManager.DeleteIPPool(ctx, pool)
+			err := c.subnetMgr.ipPoolManager.DeleteIPPool(ctx, pool)
 			if nil != err {
 				log.Sugar().Errorf("failed to delete IPPool '%s', error: %v", pool.Name, err)
 				return

--- a/pkg/subnetmanager/types/interface.go
+++ b/pkg/subnetmanager/types/interface.go
@@ -21,7 +21,7 @@ type SubnetManager interface {
 	SetupInformer(ctx context.Context, client crdclientset.Interface, controllerLeader election.SpiderLeaseElector) error
 	GetSubnetByName(ctx context.Context, subnetName string) (*spiderpoolv1.SpiderSubnet, error)
 	ListSubnets(ctx context.Context, opts ...client.ListOption) (*spiderpoolv1.SpiderSubnetList, error)
-	SetupControllers(ctx context.Context, client kubernetes.Interface) error
+	SetupControllers(client kubernetes.Interface) error
 	AllocateEmptyIPPool(ctx context.Context, subnetMgrName string, appKind string, app metav1.Object, podSelector map[string]string, ipNum int, ipVersion types.IPVersion, reclaimIPPool bool) error
 	CheckScaleIPPool(ctx context.Context, pool *spiderpoolv1.SpiderIPPool, subnetManagerName string, ipNum int) error
 	GenerateIPsFromSubnetWhenScaleUpIP(ctx context.Context, subnetName string, pool *spiderpoolv1.SpiderIPPool, cursor bool) ([]string, error)


### PR DESCRIPTION
1. Fix subnet create ippool asynchronous multile ippools issue, change auto-created ippool name with uuid.
2. Add workqueue for application controller, in which case we can create different IPPools asynchronously.(The same IPPool will be processed synchronously)
3. In the dual stack, we created 40 app and it cost almost 50s to create empty IPPools

Signed-off-by: Icarus9913 <icaruswu66@qq.com>


**What this PR does / why we need it**:
fix bug

**Which issue(s) this PR fixes**:
https://github.com/spidernet-io/spiderpool/issues/1088
