### PR TITLE
improve subnet controller performance

### DIFF
--- a/cmd/spiderpool-controller/cmd/config.go
+++ b/cmd/spiderpool-controller/cmd/config.go
@@ -56,7 +56,7 @@ var envInfo = []envConf{
 	{"SPIDERPOOL_WORKLOADENDPOINT_MAX_HISTORY_RECORDS", "100", false, nil, nil, &controllerContext.Cfg.WorkloadEndpointMaxHistoryRecords},
 	{"SPIDERPOOL_IPPOOL_MAX_ALLOCATED_IPS", "5000", false, nil, nil, &controllerContext.Cfg.IPPoolMaxAllocatedIPs},
 	{"SPIDERPOOL_SUBNET_RESYNC_PERIOD", "300", false, nil, nil, &controllerContext.Cfg.SubnetResyncPeriod},
-	{"SPIDERPOOL_SUBNET_INFORMER_WORKERS", "3", false, nil, nil, &controllerContext.Cfg.SubnetInformerWorkers},
+	{"SPIDERPOOL_SUBNET_INFORMER_WORKERS", "5", false, nil, nil, &controllerContext.Cfg.SubnetInformerWorkers},
 	{"SPIDERPOOL_SUBNET_INFORMER_MAX_WORKQUEUE_LENGTH", "10000", false, nil, nil, &controllerContext.Cfg.SubnetInformerMaxWorkqueueLength},
 	{"SPIDERPOOL_UPDATE_CR_MAX_RETRIES", "3", false, nil, nil, &controllerContext.Cfg.UpdateCRMaxRetries},
 	{"SPIDERPOOL_UPDATE_CR_RETRY_UNIT_TIME", "300", false, nil, nil, &controllerContext.Cfg.UpdateCRRetryUnitTime},
@@ -82,8 +82,8 @@ var envInfo = []envConf{
 	{"VERSION", "", false, &controllerContext.Cfg.AppVersion, nil, nil},
 	{"SPIDERPOOL_ENABLE_SUBNET_DELETE_STALE_IPPOOL", "false", true, nil, &controllerContext.Cfg.EnableSubnetDeleteStaleIPPool, nil},
 	{"SPIDERPOOL_AUTO_IPPOOL_HANDLER_MAX_WORKQUEUE_LENGTH", "10000", true, nil, nil, &controllerContext.Cfg.IPPoolInformerMaxWorkQueueLength},
-	{"SPIDERPOOL_AUTO_IPPOOL_SCALE_RETRY_DELAY_DURATION", "5", true, nil, nil, &controllerContext.Cfg.WorkQueueRequeueDelayDuration},
-	{"SPIDERPOOL_IPPOOL_INFORMER_WORKERS", "3", true, nil, nil, &controllerContext.Cfg.IPPoolInformerWorkers},
+	{"SPIDERPOOL_AUTO_IPPOOL_SCALE_RETRY_DELAY_DURATION", "1", true, nil, nil, &controllerContext.Cfg.WorkQueueRequeueDelayDuration},
+	{"SPIDERPOOL_IPPOOL_INFORMER_WORKERS", "5", true, nil, nil, &controllerContext.Cfg.IPPoolInformerWorkers},
 	{"SPIDERPOOL_WORKQUEUE_MAX_RETRIES", "500", true, nil, nil, &controllerContext.Cfg.WorkQueueMaxRetries},
 }
 

--- a/pkg/ippoolmanager/ippool_informer.go
+++ b/pkg/ippoolmanager/ippool_informer.go
@@ -268,18 +268,18 @@ func (c *poolInformerController) Run(workers int, stopCh <-chan struct{}) error 
 
 	for i := 0; i < workers; i++ {
 		informerLogger.Sugar().Debugf("Starting All IPPool processing worker '%d'", i)
-		go wait.Until(c.runAllIPPoolWorker, time.Second, stopCh)
+		go wait.Until(c.runAllIPPoolWorker, 500*time.Millisecond, stopCh)
 	}
 
 	if c.poolMgr.config.EnableSpiderSubnet && enableV4 {
 		informerLogger.Debug("Staring IPv4 Auto-created IPPool processing worker")
 		defer c.poolMgr.v4AutoCreatedRateLimitQueue.ShutDown()
-		go wait.Until(c.runV4AutoCreatePoolWorker, time.Second, stopCh)
+		go wait.Until(c.runV4AutoCreatePoolWorker, 500*time.Millisecond, stopCh)
 	}
 	if c.poolMgr.config.EnableSpiderSubnet && enableV6 {
 		informerLogger.Debug("Staring IPv6 Auto-created IPPool processing worker")
 		defer c.poolMgr.v6AutoCreatedRateLimitQueue.ShutDown()
-		go wait.Until(c.runV6AutoCreatePoolWorker, time.Second, stopCh)
+		go wait.Until(c.runV6AutoCreatePoolWorker, 500*time.Millisecond, stopCh)
 	}
 
 	informerLogger.Info("IPPool controller workers started")
@@ -358,14 +358,14 @@ func (c *poolInformerController) processNextWorkItem(workQueue workqueue.RateLim
 
 			if apierrors.IsConflict(err) {
 				workQueue.AddRateLimited(poolName)
-				log.Sugar().Warnf("encountered update conflict '%v', retrying...", err)
+				log.Sugar().Warnf("encountered ippool informer update conflict '%v', retrying...", err)
 				return nil
 			}
 
 			// if we set nonnegative number for the requeue delay duration, we will requeue it. otherwise we will discard it.
 			if c.poolMgr.config.WorkQueueRequeueDelayDuration >= 0 {
 				if workQueue.NumRequeues(obj) < c.poolMgr.config.WorkQueueMaxRetries {
-					log.Sugar().Errorf("encountered error '%v', requeue it after '%v'", err, c.poolMgr.config.WorkQueueRequeueDelayDuration)
+					log.Sugar().Errorf("encountered ippool informer error '%v', requeue it after '%v'", err, c.poolMgr.config.WorkQueueRequeueDelayDuration)
 					workQueue.AddAfter(poolName, c.poolMgr.config.WorkQueueRequeueDelayDuration)
 					return nil
 				}

--- a/pkg/ippoolmanager/ippool_manager.go
+++ b/pkg/ippoolmanager/ippool_manager.go
@@ -369,7 +369,6 @@ func (im *ipPoolManager) DeleteIPPool(ctx context.Context, pool *spiderpoolv1.Sp
 // Notice: we shouldn't get retries in this method and the upper level calling function will requeue the workqueue once we return an error,
 func (im *ipPoolManager) ScaleIPPoolWithIPs(ctx context.Context, pool *spiderpoolv1.SpiderIPPool, ipRanges []string, action ippoolmanagertypes.ScaleAction, desiredIPNum int) error {
 	log := logutils.FromContext(ctx)
-	rand.Seed(time.Now().UnixNano())
 
 	var err error
 
@@ -425,11 +424,6 @@ func (im *ipPoolManager) ScaleIPPoolWithIPs(ctx context.Context, pool *spiderpoo
 }
 
 func (im *ipPoolManager) UpdateDesiredIPNumber(ctx context.Context, pool *spiderpoolv1.SpiderIPPool, ipNum int) error {
-	pool, err := im.GetIPPoolByName(ctx, pool.Name)
-	if nil != err {
-		return err
-	}
-
 	if pool.Status.AutoDesiredIPCount == nil {
 		pool.Status.AutoDesiredIPCount = new(int64)
 	} else {
@@ -439,7 +433,7 @@ func (im *ipPoolManager) UpdateDesiredIPNumber(ctx context.Context, pool *spider
 	}
 
 	*pool.Status.AutoDesiredIPCount = int64(ipNum)
-	err = im.client.Status().Update(ctx, pool)
+	err := im.client.Status().Update(ctx, pool)
 	if nil != err {
 		return err
 	}

--- a/pkg/subnetmanager/subnet_informer.go
+++ b/pkg/subnetmanager/subnet_informer.go
@@ -206,7 +206,7 @@ func (sc *SubnetController) Run(workers int, stopCh <-chan struct{}) error {
 
 	informerLogger.Info("Starting workers")
 	for i := 0; i < workers; i++ {
-		go wait.Until(sc.runWorker, time.Second, stopCh)
+		go wait.Until(sc.runWorker, 500*time.Millisecond, stopCh)
 	}
 
 	informerLogger.Info("Started workers")


### PR DESCRIPTION
1.add more workers for IPPool and App controller
2.decrease the requeue delay duration
3.fix application controller error handler

After test, we will cost 36s to create empty auto-created IPPools and flush the autoDesiredIPNumber for 40 deployments in dual stack. And it will cost 77s for subnet to allocate IPs for these auto-created IPPools.

Signed-off-by: Icarus9913 icaruswu66@qq.com


**What this PR does / why we need it**:
1.fix bug
2.improve subnet controller performance

**Which issue(s) this PR fixes**:
https://github.com/spidernet-io/spiderpool/issues/1102
https://github.com/spidernet-io/spiderpool/issues/1100
