### PR TITLE
add auto-created ippool gc

### DIFF
--- a/pkg/ippoolmanager/types/interface.go
+++ b/pkg/ippoolmanager/types/interface.go
@@ -36,7 +36,7 @@ type IPPoolManager interface {
 	AllocateIP(ctx context.Context, poolName, containerID, nic string, pod *corev1.Pod) (*models.IPConfig, *spiderpoolv1.SpiderIPPool, error)
 	ReleaseIP(ctx context.Context, poolName string, ipAndCIDs []types.IPAndCID) error
 	CheckVlanSame(ctx context.Context, poolNameList []string) (map[types.Vlan][]string, bool, error)
-	RemoveFinalizer(ctx context.Context, poolName string) error
+	RemoveFinalizer(ctx context.Context, pool *spiderpoolv1.SpiderIPPool) error
 	UpdateAllocatedIPs(ctx context.Context, containerID string, pod *corev1.Pod, oldIPConfig models.IPConfig) error
 	CreateIPPool(ctx context.Context, pool *spiderpoolv1.SpiderIPPool) error
 	ScaleIPPoolWithIPs(ctx context.Context, pool *spiderpoolv1.SpiderIPPool, ipRanges []string, action ScaleAction, desiredIPNum int) error

--- a/pkg/subnetmanager/controllers/utils.go
+++ b/pkg/subnetmanager/controllers/utils.go
@@ -109,8 +109,23 @@ func SubnetPoolName(controllerKind, controllerNS, controllerName string, ipVersi
 		strings.ToLower(controllerKind), strings.ToLower(controllerNS), strings.ToLower(controllerName), ipVersion, strings.ToLower(lastOne))
 }
 
+// AppLabelValue will joint the application type, namespace and name.
+// the format is "{appKind}-{appNS}-{appName}"
 func AppLabelValue(appKind string, appNS, appName string) string {
-	return fmt.Sprintf("%s-%s-%s", strings.ToLower(appKind), strings.ToLower(appNS), strings.ToLower(appName))
+	return fmt.Sprintf("%s-%s-%s", appKind, appNS, appName)
+}
+
+// ParseAppLabelValue will unpack the application label value, its corresponding function is AppLabelValue
+func ParseAppLabelValue(str string) (appKind, appNS, appName string, isFound bool) {
+	typeKind, after, found := strings.Cut(str, "-")
+	if found {
+		isFound = found
+		appKind = typeKind
+
+		appNS, appName, _ = strings.Cut(after, "-")
+	}
+
+	return
 }
 
 func GetAppReplicas(replicas *int32) int {


### PR DESCRIPTION
For auto-create IPPool workqueue enqueue cases:
1. The IPPool's IPs number is not equal with the auto-desired IP number, we'll try to scale it.
2. The IPPool's allocated IPs are empty, we will check whether the IPPool should be deleted or not.


Signed-off-by: Icarus9913 <icaruswu66@qq.com>


**What this PR does / why we need it**:
fix bug

**Which issue(s) this PR fixes**:
https://github.com/spidernet-io/spiderpool/issues/1129
