### PR TITLE
fix spider subnet leader lost and never work if it get a leader later

### DIFF
--- a/pkg/ippoolmanager/ippool_informer.go
+++ b/pkg/ippoolmanager/ippool_informer.go
@@ -37,11 +37,9 @@ func (im *ipPoolManager) SetupInformer(client crdclientset.Interface, controller
 	if controllerLeader == nil {
 		return fmt.Errorf("failed to start SpiderIPPool informer, controller leader must be specified")
 	}
-
-	informerLogger = logutils.Logger.Named("SpiderIPPool-Informer")
-
 	im.leader = controllerLeader
 
+	informerLogger = logutils.Logger.Named("SpiderIPPool-Informer")
 	informerLogger.Info("try to register SpiderIPPool informer")
 	go func() {
 		for {
@@ -50,13 +48,13 @@ func (im *ipPoolManager) SetupInformer(client crdclientset.Interface, controller
 				continue
 			}
 
-			// stopper lifecycle is same with spiderIPPoolInformer
+			// stopper lifecycle is same with spiderIPPool Informer
 			stopper := make(chan struct{})
 
 			go func() {
 				for {
 					if !im.leader.IsElected() {
-						informerLogger.Warn("leader lost! stop SpiderIPPool informer!")
+						informerLogger.Error("leader lost! stop SpiderIPPool informer!")
 						close(stopper)
 						return
 					}

--- a/pkg/subnetmanager/controllers/cronjob_informer.go
+++ b/pkg/subnetmanager/controllers/cronjob_informer.go
@@ -29,14 +29,14 @@ func (c *Controller) onCronJobAdd(obj interface{}) {
 }
 
 func (c *Controller) onCronJobUpdate(oldObj interface{}, newObj interface{}) {
-	err := c.reconcileFunc(context.TODO(), oldObj, newObj)
+	err := c.reconcileFunc(logutils.IntoContext(context.TODO(), controllersLogger), oldObj, newObj)
 	if nil != err {
 		controllersLogger.Sugar().Errorf("onCronJobUpdate: %v", err)
 	}
 }
 
 func (c *Controller) onCronJobDelete(obj interface{}) {
-	err := c.cleanupFunc(context.TODO(), obj)
+	err := c.cleanupFunc(logutils.IntoContext(context.TODO(), controllersLogger), obj)
 	if nil != err {
 		controllersLogger.Sugar().Errorf("onCronJobDelete: %v", err)
 	}

--- a/pkg/subnetmanager/controllers/daemonset_informer.go
+++ b/pkg/subnetmanager/controllers/daemonset_informer.go
@@ -29,14 +29,14 @@ func (c *Controller) onDaemonSetAdd(obj interface{}) {
 }
 
 func (c *Controller) onDaemonSetUpdate(oldObj interface{}, newObj interface{}) {
-	err := c.reconcileFunc(context.TODO(), oldObj, newObj)
+	err := c.reconcileFunc(logutils.IntoContext(context.TODO(), controllersLogger), oldObj, newObj)
 	if nil != err {
 		controllersLogger.Sugar().Errorf("onDaemonSetUpdate: %v", err)
 	}
 }
 
 func (c *Controller) onDaemonSetDelete(obj interface{}) {
-	err := c.cleanupFunc(context.TODO(), obj)
+	err := c.cleanupFunc(logutils.IntoContext(context.TODO(), controllersLogger), obj)
 	if nil != err {
 		controllersLogger.Sugar().Errorf("onDaemonSetDelete: %v", err)
 	}

--- a/pkg/subnetmanager/controllers/deployment_informer.go
+++ b/pkg/subnetmanager/controllers/deployment_informer.go
@@ -29,14 +29,14 @@ func (c *Controller) onDeploymentAdd(obj interface{}) {
 }
 
 func (c *Controller) onDeploymentUpdate(oldObj interface{}, newObj interface{}) {
-	err := c.reconcileFunc(context.TODO(), oldObj, newObj)
+	err := c.reconcileFunc(logutils.IntoContext(context.TODO(), controllersLogger), oldObj, newObj)
 	if nil != err {
 		controllersLogger.Sugar().Errorf("onDeploymentUpdate: %v", err)
 	}
 }
 
 func (c *Controller) onDeploymentDelete(obj interface{}) {
-	err := c.cleanupFunc(context.TODO(), obj)
+	err := c.cleanupFunc(logutils.IntoContext(context.TODO(), controllersLogger), obj)
 	if nil != err {
 		controllersLogger.Sugar().Errorf("onDeploymentDelete: %v", err)
 	}

--- a/pkg/subnetmanager/controllers/job_informer.go
+++ b/pkg/subnetmanager/controllers/job_informer.go
@@ -29,14 +29,14 @@ func (c *Controller) onJobAdd(obj interface{}) {
 }
 
 func (c *Controller) onJobUpdate(oldObj interface{}, newObj interface{}) {
-	err := c.reconcileFunc(context.TODO(), oldObj, newObj)
+	err := c.reconcileFunc(logutils.IntoContext(context.TODO(), controllersLogger), oldObj, newObj)
 	if nil != err {
 		controllersLogger.Sugar().Errorf("onJobUpdate: %v", err)
 	}
 }
 
 func (c *Controller) onJobDelete(obj interface{}) {
-	err := c.cleanupFunc(context.TODO(), obj)
+	err := c.cleanupFunc(logutils.IntoContext(context.TODO(), controllersLogger), obj)
 	if nil != err {
 		controllersLogger.Sugar().Errorf("onJobDelete: %v", err)
 	}

--- a/pkg/subnetmanager/controllers/replicaset_informer.go
+++ b/pkg/subnetmanager/controllers/replicaset_informer.go
@@ -29,14 +29,14 @@ func (c *Controller) onReplicaSetAdd(obj interface{}) {
 }
 
 func (c *Controller) onReplicaSetUpdate(oldObj interface{}, newObj interface{}) {
-	err := c.reconcileFunc(context.TODO(), oldObj, newObj)
+	err := c.reconcileFunc(logutils.IntoContext(context.TODO(), controllersLogger), oldObj, newObj)
 	if nil != err {
 		controllersLogger.Sugar().Errorf("onReplicaSetUpdate: %v", err)
 	}
 }
 
 func (c *Controller) onReplicaSetDelete(obj interface{}) {
-	err := c.cleanupFunc(context.TODO(), obj)
+	err := c.cleanupFunc(logutils.IntoContext(context.TODO(), controllersLogger), obj)
 	if nil != err {
 		controllersLogger.Sugar().Errorf("onReplicaSetDelete: %v", err)
 	}

--- a/pkg/subnetmanager/controllers/statefulset_informer.go
+++ b/pkg/subnetmanager/controllers/statefulset_informer.go
@@ -29,14 +29,14 @@ func (c *Controller) onStatefulSetAdd(obj interface{}) {
 }
 
 func (c *Controller) onStatefulSetUpdate(oldObj interface{}, newObj interface{}) {
-	err := c.reconcileFunc(context.TODO(), oldObj, newObj)
+	err := c.reconcileFunc(logutils.IntoContext(context.TODO(), controllersLogger), oldObj, newObj)
 	if nil != err {
 		controllersLogger.Sugar().Errorf("onStatefulSetUpdate: %v", err)
 	}
 }
 
 func (c *Controller) onStatefulSetDelete(obj interface{}) {
-	err := c.cleanupFunc(context.TODO(), obj)
+	err := c.cleanupFunc(logutils.IntoContext(context.TODO(), controllersLogger), obj)
 	if nil != err {
 		controllersLogger.Sugar().Errorf("onStatefulSetDelete: %v", err)
 	}

--- a/pkg/subnetmanager/subnet_informer.go
+++ b/pkg/subnetmanager/subnet_informer.go
@@ -51,16 +51,8 @@ func (sm *subnetManager) SetupInformer(ctx context.Context, client clientset.Int
 		return fmt.Errorf("failed to start Subnet informer, controller leader must be specified")
 	}
 
-	informerLogger = logutils.Logger.Named("Subnet-Informer")
 	sm.leader = controllerLeader
-
-	informerLogger.Info("Initialize Subnet informer")
-	informerFactory := externalversions.NewSharedInformerFactory(client, sm.config.ResyncPeriod)
-	subnetController := newSubnetController(
-		sm,
-		informerFactory.Spiderpool().V1().SpiderSubnets(),
-		informerFactory.Spiderpool().V1().SpiderIPPools(),
-	)
+	informerLogger = logutils.Logger.Named("Subnet-Informer")
 
 	go func() {
 		for {
@@ -68,6 +60,14 @@ func (sm *subnetManager) SetupInformer(ctx context.Context, client clientset.Int
 				time.Sleep(sm.config.LeaderRetryElectGap)
 				continue
 			}
+
+			informerLogger.Info("Initialize Subnet informer")
+			informerFactory := externalversions.NewSharedInformerFactory(client, sm.config.ResyncPeriod)
+			subnetController := newSubnetController(
+				sm,
+				informerFactory.Spiderpool().V1().SpiderSubnets(),
+				informerFactory.Spiderpool().V1().SpiderIPPools(),
+			)
 
 			subnetController.innerCtx, subnetController.innerCancel = context.WithCancel(ctx)
 			go func() {


### PR DESCRIPTION
Because we don't new workqueue once we re-elect and get a leader, so the workqueue will also in shut down phase after the spiderpool-controller lost the leader.
So, just new a workqueue in every leader phase.

Signed-off-by: Icarus9913 <icaruswu66@qq.com>

**What this PR does / why we need it**:
fix bug

**Which issue(s) this PR fixes**:
https://github.com/spidernet-io/spiderpool/issues/1154
