### PR TITLE
change the label of auto-created ippool for GC needs

### DIFF
--- a/.github/.spelling
+++ b/.github/.spelling
@@ -270,3 +270,4 @@ i.e
 kruise
 OpenKruise
 CloneSet
+_

--- a/docs/develop/upgrade.md
+++ b/docs/develop/upgrade.md
@@ -1,0 +1,31 @@
+# Upgrading Spiderpool Versions 
+
+This document describes breaking changes, as well as how to fix them, that have occurred at given releases.
+Please consult the segments from your current release until now before upgrading your spiderpool.
+
+
+## Upgrade to 0.3.6 from (<=0.3.5)
+
+### Description
+
+There's a design flaw for SpiderSubnet feature in auto-created IPPool label.
+The previous label `ipam.spidernet.io/owner-application` corresponding value uses '-' as separative sign.
+For example, we have deployment `ns398-174835790/deploy398-82311862` and the corresponding label value is `Deployment-ns398-174835790-deploy398-82311862`.
+It's very hard to unpack it to trace back what the application namespace and name is.
+
+Now, we use '_' rather than '-' as slash for SpiderSubnet feature label `ipam.spidernet.io/owner-application`, and the upper case
+will be like `Deployment_ns398-174835790_deploy398-82311862`
+
+Reference PR: [#1162](https://github.com/spidernet-io/spiderpool/pull/1162)
+
+### Operation steps
+
+1. Find all auto-created IPPools, their name format is `auto-${appKind}-${appNS}-${appName}-v${ipVersion}-${uid}` such as `auto-deployment-default-demo-deploy-subnet-v4-69d041b98b41`.
+
+2. Replace their label, just like this:
+
+   ```shell
+    kubectl patch sp ${auto-pool} --type merge --patch '{"metadata": {"labels": {"ipam.spidernet.io/owner-application": ${AppLabelValue}}}}'
+   ```
+
+3. Update your Spiderpool components version and restart them all.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -67,3 +67,4 @@ nav:
       - develop/swagger_openapi.md
       - develop/test.md
       - develop/changelog.md
+      - develop/upgrade.md

--- a/docs/usage/spider-subnet.md
+++ b/docs/usage/spider-subnet.md
@@ -75,7 +75,7 @@ metadata:
   labels:
     ipam.spidernet.io/ippool-reclaim: "true"
     ipam.spidernet.io/ippool-version: IPv4
-    ipam.spidernet.io/owner-application: deployment-default-demo-deploy-subnet
+    ipam.spidernet.io/owner-application: Deployment_default_demo-deploy-subnet
     ipam.spidernet.io/owner-application-uid: 94ceb817-8250-460e-b1af-69d041b98b41
     ipam.spidernet.io/owner-spider-subnet: subnet-demo-v4
   name: auto-deployment-default-demo-deploy-subnet-v4-1667358680
@@ -144,7 +144,7 @@ metadata:
   labels:
     ipam.spidernet.io/ippool-reclaim: "true"
     ipam.spidernet.io/ippool-version: IPv4
-    ipam.spidernet.io/owner-application: deployment-default-demo-deploy-subnet
+    ipam.spidernet.io/owner-application: Deployment_default_demo-deploy-subnet
     ipam.spidernet.io/owner-application-uid: 94ceb817-8250-460e-b1af-69d041b98b41
     ipam.spidernet.io/owner-spider-subnet: subnet-demo-v4
   name: auto-deployment-default-demo-deploy-subnet-v4-1667358680

--- a/pkg/subnetmanager/controllers/utils.go
+++ b/pkg/subnetmanager/controllers/utils.go
@@ -109,20 +109,23 @@ func SubnetPoolName(controllerKind, controllerNS, controllerName string, ipVersi
 		strings.ToLower(controllerKind), strings.ToLower(controllerNS), strings.ToLower(controllerName), ipVersion, strings.ToLower(lastOne))
 }
 
-// AppLabelValue will joint the application type, namespace and name.
-// the format is "{appKind}-{appNS}-{appName}"
+// AppLabelValue will joint the application type, namespace and name as a label value, then we need unpack it for tracing
+// [ns and object name constraint Ref]: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
+// [label value ref]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+// Because the label value enable you to use '_', then we can use it as the slash.
+// So, for tracing it back, we set format is "{appKind}_{appNS}_{appName}"
 func AppLabelValue(appKind string, appNS, appName string) string {
-	return fmt.Sprintf("%s-%s-%s", appKind, appNS, appName)
+	return fmt.Sprintf("%s_%s_%s", appKind, appNS, appName)
 }
 
 // ParseAppLabelValue will unpack the application label value, its corresponding function is AppLabelValue
 func ParseAppLabelValue(str string) (appKind, appNS, appName string, isFound bool) {
-	typeKind, after, found := strings.Cut(str, "-")
+	typeKind, after, found := strings.Cut(str, "_")
 	if found {
 		isFound = found
 		appKind = typeKind
 
-		appNS, appName, _ = strings.Cut(after, "-")
+		appNS, appName, _ = strings.Cut(after, "_")
 	}
 
 	return


### PR DESCRIPTION
⚠️⚠️⚠️ This change is  make it incompatible with the previous release version
(The ipam and spiderpool-controller will use this label to find the application corresponding auto-created IPPool, once we change it. It's incompatible with the previous version spiderpool)

⚠️⚠️⚠️ For upgrade pre-steps, please check [upgrade.md](https://github.com/spidernet-io/spiderpool/blob/b73c976609b0f7bf7ca4581db2973cb6ab4aa6ce/docs/develop/upgrade.md)

The correlative PR: https://github.com/spidernet-io/spiderpool/pull/1135 implements auto-created IPPool garbage collect, it will use the IPPool label `ipam.spidernet.io/owner-application` to trace back the corresponding application.
But the current function implementation just use '-' to assemble the application identification.
```go 
// AppLabelValue will joint the application type, namespace and name.
// the format is "{appKind}-{appNS}-{appName}"
func AppLabelValue(appKind string, appNS, appName string) string {
	return fmt.Sprintf("%s-%s-%s", appKind, appNS, appName)
}
```
For this, it's very hard to unpack every variable. 
For instance, you could set the namespace as `ns398-174835790` and the deployment name `deploy398-82311862`. And it will return a string like `Deployment-ns398-174835790-deploy398-82311862`

I suggest to use "_"  rather than "-" as slash for spider subnet feature 'ipam.spidernet.io/owner-application' label value.
And the upper case will be `Deployment_ns398-174835790_deploy398-82311862`


Signed-off-by: Icarus9913 <icaruswu66@qq.com>


**What this PR does / why we need it**:
fix bug

**Which issue(s) this PR fixes**:
https://github.com/spidernet-io/spiderpool/issues/1161#1135
