### PR TITLE
E2E: The subnet automatically creates an ippool and allocates IP, and should consider reservedIP

### DIFF
--- a/test/doc/annotation.md
+++ b/test/doc/annotation.md
@@ -11,5 +11,5 @@
 | A00007  | Spiderpool will successively try to allocate IPs in the order of the elements in the IPPool array until the first allocation succeeds or all fail | p1       | true  | done   |       |
 | A00008  | Successfully run an annotated multi-container pod                    | p2       |       | done   |       |
 | A00009  | Modify the annotated IPPool for a specified Deployment pod<br />Modify the annotated IPPool for a specified StatefulSet pod                 | p2       |       |  done   |       |
-| A00010  | Modify the annotated IPPool for a pod running on multiple NICs       | p3       |       |        |       |
+| A00010  | Modify the annotated IPPool for a pod running on multiple NICs       | p3       |       | done   |       |
 | A00011  | Use the ippool route with `cleanGateway=false` in the pod annotation as a default route | p3     |     |  done  |         |

--- a/test/doc/cidr.md
+++ b/test/doc/cidr.md
@@ -12,5 +12,5 @@
 | I00008  | Scale up and down the number of deployment several times to see if the state of the ippools is eventually stable                    |   p1     |       |  done  |       |
 | I00009  | Create 100 Subnets with the same `Subnet.spec` and see if only one succeeds in the end                                              |   p1     |       |  done  |       |
 | I00010  | Create 100 IPPools with the same `IPPool.spec` and see if only one succeeds in the end                                              |   p1     |       |  done  |       |
-| I00011  | In ippool it should consider reservedIPs when subnets are assigned                                                                  |   p1     |       |        |       |
+| I00011  | The subnet automatically creates an ippool and allocates IP, and should consider reservedIP                                         |   p1     |       |  done  |       |
 

--- a/test/e2e/annotation/annotation_suite_test.go
+++ b/test/e2e/annotation/annotation_suite_test.go
@@ -3,8 +3,9 @@
 package annotation_test
 
 import (
-	spiderpool "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v1"
 	"testing"
+
+	spiderpool "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/test/e2e/reservedip/reservedip_test.go
+++ b/test/e2e/reservedip/reservedip_test.go
@@ -4,18 +4,21 @@ package reservedip_test
 
 import (
 	"context"
+	"encoding/json"
 
 	v1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spidernet-io/e2eframework/tools"
 	"github.com/spidernet-io/spiderpool/pkg/constant"
+	subnetmanager "github.com/spidernet-io/spiderpool/pkg/subnetmanager/controllers"
 	"github.com/spidernet-io/spiderpool/test/e2e/common"
 )
 
 var _ = Describe("test reservedIP", Label("reservedIP"), func() {
-	var nsName, DeployName, v4PoolName, v6PoolName, v4ReservedIpName, v6ReservedIpName string
+	var nsName, manualDeployName, autoDeployName, v4PoolName, v6PoolName, v4ReservedIpName, v6ReservedIpName string
 	var v4PoolNameList, v6PoolNameList []string
 	var iPv4PoolObj, iPv6PoolObj *v1.SpiderIPPool
 	var v4ReservedIpObj, v6ReservedIpObj *v1.SpiderReservedIP
@@ -27,33 +30,35 @@ var _ = Describe("test reservedIP", Label("reservedIP"), func() {
 		if frame.Info.SpiderSubnetEnabled {
 			// Subnet Adaptation
 			if frame.Info.IpV4Enabled {
-				v4SubnetName, v4SubnetObject = common.GenerateExampleV4SubnetObject(1)
+				v4SubnetName, v4SubnetObject = common.GenerateExampleV4SubnetObject(5)
 				Expect(v4SubnetObject).NotTo(BeNil())
 				Expect(common.CreateSubnet(frame, v4SubnetObject)).NotTo(HaveOccurred())
 			}
 			if frame.Info.IpV6Enabled {
-				v6SubnetName, v6SubnetObject = common.GenerateExampleV6SubnetObject(1)
+				v6SubnetName, v6SubnetObject = common.GenerateExampleV6SubnetObject(5)
 				Expect(v6SubnetObject).NotTo(BeNil())
 				Expect(common.CreateSubnet(frame, v6SubnetObject)).NotTo(HaveOccurred())
 			}
 		}
 
-		//Init namespace name and create
+		// Init namespace name and create
 		nsName = "ns" + tools.RandomName()
 		GinkgoWriter.Printf("Try to create namespace %v \n", nsName)
 		err := frame.CreateNamespaceUntilDefaultServiceAccountReady(nsName, common.ServiceAccountReadyTimeout)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create namespace %v", nsName)
 
 		// Init test Deployment/Pod name
-		DeployName = "sr-pod" + tools.RandomName()
-
+		manualDeployName = "sr-manual-pod" + tools.RandomName()
+		autoDeployName = "sr-auto-pod" + tools.RandomName()
+		ctx, cancel := context.WithTimeout(context.Background(), common.PodStartTimeout)
+		defer cancel()
 		if frame.Info.IpV4Enabled {
 			v4PoolName, iPv4PoolObj = common.GenerateExampleIpv4poolObject(1)
 			if frame.Info.SpiderSubnetEnabled {
 				iPv4PoolObj.Spec.Subnet = v4SubnetObject.Spec.Subnet
 				iPv4PoolObj.Spec.IPs = v4SubnetObject.Spec.IPs
 			}
-			err := common.CreateIppool(frame, iPv4PoolObj)
+			err := common.CreateIppoolInSpiderSubnet(ctx, frame, v4SubnetName, iPv4PoolObj, 1)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create v4 Pool %v \n", v4PoolName)
 			GinkgoWriter.Printf("Successfully created v4 Pool: %v \n", v4PoolName)
 			v4PoolNameList = append(v4PoolNameList, v4PoolName)
@@ -65,7 +70,7 @@ var _ = Describe("test reservedIP", Label("reservedIP"), func() {
 				iPv6PoolObj.Spec.Subnet = v6SubnetObject.Spec.Subnet
 				iPv6PoolObj.Spec.IPs = v6SubnetObject.Spec.IPs
 			}
-			err := common.CreateIppool(frame, iPv6PoolObj)
+			err := common.CreateIppoolInSpiderSubnet(ctx, frame, v6SubnetName, iPv6PoolObj, 1)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create v6 Pool %v \n", v6PoolName)
 			GinkgoWriter.Printf("Successfully created v6 Pool: %v \n", v6PoolName)
 			v6PoolNameList = append(v6PoolNameList, v6PoolName)
@@ -93,18 +98,19 @@ var _ = Describe("test reservedIP", Label("reservedIP"), func() {
 	})
 
 	It("S00001: an IP who is set in ReservedIP CRD, should not be assigned to a pod; S00003: Failed to set same IP in excludeIPs when an IP is assigned to a pod",
-		Label("S00001", "smoke", "S00003"), func() {
+		Label("S00001", "smoke", "S00003", "I00011"), func() {
 			const deployOriginialNum = int(1)
+			const fixedIPNumber string = "+1"
 
 			if frame.Info.IpV4Enabled {
-				v4ReservedIpName, v4ReservedIpObj = common.GenerateExampleV4ReservedIpObject(iPv4PoolObj.Spec.IPs)
+				v4ReservedIpName, v4ReservedIpObj = common.GenerateExampleV4ReservedIpObject(v4SubnetObject.Spec.IPs)
 				err = common.CreateReservedIP(frame, v4ReservedIpObj)
 				Expect(err).NotTo(HaveOccurred())
 				GinkgoWriter.Printf("Successfully created v4 reservedIP: %v \n", v4ReservedIpName)
 			}
 
 			if frame.Info.IpV6Enabled {
-				v6ReservedIpName, v6ReservedIpObj = common.GenerateExampleV6ReservedIpObject(iPv6PoolObj.Spec.IPs)
+				v6ReservedIpName, v6ReservedIpObj = common.GenerateExampleV6ReservedIpObject(v6SubnetObject.Spec.IPs)
 				err = common.CreateReservedIP(frame, v6ReservedIpObj)
 				Expect(err).NotTo(HaveOccurred())
 				GinkgoWriter.Printf("Successfully created v6 reservedIP : %v \n", v6ReservedIpName)
@@ -113,16 +119,56 @@ var _ = Describe("test reservedIP", Label("reservedIP"), func() {
 			podIppoolAnnoStr := common.GeneratePodIPPoolAnnotations(frame, common.NIC1, v4PoolNameList, v6PoolNameList)
 
 			// Generate Deployment yaml and annotation
-			deployObject := common.GenerateExampleDeploymentYaml(DeployName, nsName, int32(deployOriginialNum))
-			deployObject.Spec.Template.Annotations = map[string]string{constant.AnnoPodIPPool: podIppoolAnnoStr}
-			GinkgoWriter.Printf("Try to create Deployment: %v/%v with annotation %v = %v \n", nsName, DeployName, constant.AnnoPodIPPool, podIppoolAnnoStr)
+			manualDeployObject := common.GenerateExampleDeploymentYaml(manualDeployName, nsName, int32(deployOriginialNum))
+			manualDeployObject.Spec.Template.Annotations = map[string]string{constant.AnnoPodIPPool: podIppoolAnnoStr}
+			GinkgoWriter.Printf("Try to create Deployment: %v/%v with annotation %v = %v \n", nsName, manualDeployName, constant.AnnoPodIPPool, podIppoolAnnoStr)
 
 			// Try to create a Deployment and wait for replicas to meet expectations（because the Pod is not running）
 			ctx1, cancel1 := context.WithTimeout(context.Background(), common.PodStartTimeout)
 			defer cancel1()
-			podlist, err := common.CreateDeployUntilExpectedReplicas(frame, deployObject, ctx1)
+			podlist, err := common.CreateDeployUntilExpectedReplicas(frame, manualDeployObject, ctx1)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(int32(len(podlist.Items))).Should(Equal(*deployObject.Spec.Replicas))
+			Expect(int32(len(podlist.Items))).Should(Equal(*manualDeployObject.Spec.Replicas))
+
+			// I00011: The subnet automatically creates an ippool and allocates IP, and should consider reservedIP
+			if frame.Info.SpiderSubnetEnabled {
+				subnetAnno := subnetmanager.AnnoSubnetItems{}
+				if frame.Info.IpV4Enabled {
+					subnetAnno.IPv4 = []string{v4SubnetName}
+				}
+				if frame.Info.IpV6Enabled {
+					subnetAnno.IPv6 = []string{v6SubnetName}
+				}
+				subnetAnnoMarshal, err := json.Marshal(subnetAnno)
+				Expect(err).NotTo(HaveOccurred())
+				annotationMap := map[string]string{
+					constant.AnnoSpiderSubnetPoolIPNumber: fixedIPNumber,
+					constant.AnnoSpiderSubnet:             string(subnetAnnoMarshal),
+				}
+				autoDeployObject := common.GenerateExampleDeploymentYaml(autoDeployName, nsName, int32(deployOriginialNum))
+				autoDeployObject.Spec.Template.Annotations = annotationMap
+				ctx, cancel := context.WithTimeout(context.Background(), common.PodStartTimeout)
+				defer cancel()
+				GinkgoWriter.Printf("subnet feature enable and create deploy %v/%v. \n", nsName, autoDeployName)
+				autoPod, err := common.CreateDeployUntilExpectedReplicas(frame, autoDeployObject, ctx)
+				Expect(err).NotTo(HaveOccurred())
+
+				ctx1, cancel1 := context.WithTimeout(context.Background(), common.PodStartTimeout)
+				defer cancel1()
+				if frame.Info.IpV4Enabled {
+					Expect(common.WaitIppoolNumberInSubnet(ctx1, frame, v4SubnetName, 2)).NotTo(HaveOccurred())
+					v4PoolNameList, err = common.GetPoolNameListInSubnet(frame, v4SubnetName)
+					Expect(err).NotTo(HaveOccurred())
+				}
+				if frame.Info.IpV6Enabled {
+					Expect(common.WaitIppoolNumberInSubnet(ctx1, frame, v6SubnetName, 2)).NotTo(HaveOccurred())
+					v6PoolNameList, err = common.GetPoolNameListInSubnet(frame, v6SubnetName)
+					Expect(err).NotTo(HaveOccurred())
+				}
+
+				// subnet feature enable
+				podlist.Items = append(podlist.Items, autoPod.Items...)
+			}
 
 			// Get the Pod creation failure Event
 			ctx, cancel := context.WithTimeout(context.Background(), common.EventOccurTimeout)
@@ -144,13 +190,35 @@ var _ = Describe("test reservedIP", Label("reservedIP"), func() {
 				GinkgoWriter.Printf("Delete v6 reservedIP: %v successfully \n", v6ReservedIpName)
 			}
 
-			// After removing the reservedIP, wait for the Pod to restart until running
-			err = frame.RestartDeploymentPodUntilReady(DeployName, nsName, common.PodReStartTimeout)
+			GinkgoWriter.Println("After removing the reservedIP, wait for the Pod to restart until running.")
+			err = frame.RestartDeploymentPodUntilReady(manualDeployName, nsName, common.PodReStartTimeout)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Succeeded to assign IPv4、IPv6 ip for Deployment/Pod and Deployment/Pod IP recorded in IPPool
-			common.CheckPodIpReadyByLabel(frame, deployObject.Spec.Selector.MatchLabels, v4PoolNameList, v6PoolNameList)
-			GinkgoWriter.Printf("Pod %v/%v IP recorded in IPPool %v %v \n", nsName, DeployName, v4PoolNameList, v6PoolNameList)
+			common.CheckPodIpReadyByLabel(frame, manualDeployObject.Spec.Selector.MatchLabels, v4PoolNameList, v6PoolNameList)
+			GinkgoWriter.Printf("Pod %v/%v IP recorded in IPPool %v %v \n", nsName, manualDeployName, v4PoolNameList, v6PoolNameList)
+
+			if frame.Info.SpiderSubnetEnabled {
+				GinkgoWriter.Println("The subnet feature is enabled, check the ippool status after removing the reserved IP.")
+				err = frame.RestartDeploymentPodUntilReady(autoDeployName, nsName, common.PodReStartTimeout)
+				Expect(err).NotTo(HaveOccurred())
+
+				ctx3, cancel3 := context.WithTimeout(context.Background(), common.PodStartTimeout)
+				defer cancel3()
+				if frame.Info.IpV4Enabled {
+					Expect(common.WaitValidateSubnetAndPoolIpConsistency(ctx3, frame, v4SubnetName)).NotTo(HaveOccurred())
+				}
+				if frame.Info.IpV6Enabled {
+					Expect(common.WaitValidateSubnetAndPoolIpConsistency(ctx3, frame, v6SubnetName)).NotTo(HaveOccurred())
+				}
+
+				// Check that the pod's ip is recorded in the ippool
+				restartPodList, err := frame.GetPodList(client.InNamespace(nsName))
+				Expect(err).NotTo(HaveOccurred())
+				ok, _, _, err := common.CheckPodIpRecordInIppool(frame, v4PoolNameList, v6PoolNameList, restartPodList)
+				Expect(ok).NotTo(BeFalse())
+				Expect(err).NotTo(HaveOccurred())
+			}
 
 			// S00003: Failed to set same IP in excludeIPs when an IP is assigned to a Pod
 			if frame.Info.IpV4Enabled {
@@ -169,7 +237,11 @@ var _ = Describe("test reservedIP", Label("reservedIP"), func() {
 			}
 
 			// Delete the deployment
-			GinkgoWriter.Printf("Delete Deployment: %v/%v \n", nsName, DeployName)
-			Expect(frame.DeleteDeployment(DeployName, nsName)).To(Succeed())
+			GinkgoWriter.Printf("Delete manual deployment: %v/%v \n", nsName, manualDeployName)
+			Expect(frame.DeleteDeployment(manualDeployName, nsName)).To(Succeed())
+			if frame.Info.SpiderSubnetEnabled {
+				GinkgoWriter.Printf("Delete auto deployment: %v/%v \n", nsName, autoDeployName)
+				Expect(frame.DeleteDeployment(autoDeployName, nsName)).To(Succeed())
+			}
 		})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
This pr will add e2e case I00011 and A00010
I00011: The subnet automatically creates an ippool and allocates IP, and should consider reservedIP 
A00010: "Successfully run pods with multi-NIC ippools annotations

**Which issue(s) this PR fixes**:
none

**Special notes for your reviewer**:
none

**make sure your commit is signed off**
Signed-off-by: ty-dc <tao.yang@daocloud.io>