### PR TITLE
Add ClusterDefaultSubnet and SpiderSubnet multiple interfaces support

### DIFF
--- a/.github/.spelling
+++ b/.github/.spelling
@@ -271,3 +271,10 @@ kruise
 OpenKruise
 CloneSet
 _
+FlexibleIPNumber
+ClusterDefaultSubnet
+DefaultFlexibleIPNumber
+default_ipv4_ippool
+default_ipv6_ippool
+clusterDefaultIPv4Subnet
+clusterDefaultIPv6Subnet

--- a/charts/spiderpool/README.md
+++ b/charts/spiderpool/README.md
@@ -127,20 +127,21 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 
 ### clusterDefaultPool parameters
 
-| Name                                   | Description                                                                     | Value               |
-| -------------------------------------- | ------------------------------------------------------------------------------- | ------------------- |
-| `clusterDefaultPool.installIPv4IPPool` | install ipv4 spiderpool instance. It is required to set feature.enableIPv4=true | `false`             |
-| `clusterDefaultPool.installIPv6IPPool` | install ipv6 spiderpool instance. It is required to set feature.enableIPv6=true | `false`             |
-| `clusterDefaultPool.ipv4IPPoolName`    | the name of ipv4 spiderpool instance                                            | `default-v4-ippool` |
-| `clusterDefaultPool.ipv6IPPoolName`    | the name of ipv6 spiderpool instance                                            | `default-v6-ippool` |
-| `clusterDefaultPool.ipv4SubnetName`    | the name of ipv4 spidersubnet instance                                          | `default-v4-subnet` |
-| `clusterDefaultPool.ipv6SubnetName`    | the name of ipv6 spidersubnet instance                                          | `default-v6-subnet` |
-| `clusterDefaultPool.ipv4Subnet`        | the subnet of ipv4 spiderpool instance                                          | `""`                |
-| `clusterDefaultPool.ipv6Subnet`        | the subnet of ipv6 spiderpool instance                                          | `""`                |
-| `clusterDefaultPool.ipv4IPRanges`      | the available IP of ipv4 spiderpool instance                                    | `[]`                |
-| `clusterDefaultPool.ipv6IPRanges`      | the available IP of ipv6 spiderpool instance                                    | `[]`                |
-| `clusterDefaultPool.ipv4Gateway`       | the gateway of ipv4 subnet                                                      | `""`                |
-| `clusterDefaultPool.ipv6Gateway`       | the gateway of ipv6 subnet                                                      | `""`                |
+| Name                                        | Description                                                                     | Value               |
+|---------------------------------------------|---------------------------------------------------------------------------------| ------------------- |
+| `clusterDefaultPool.installIPv4IPPool`      | install ipv4 spiderpool instance. It is required to set feature.enableIPv4=true | `false`             |
+| `clusterDefaultPool.installIPv6IPPool`      | install ipv6 spiderpool instance. It is required to set feature.enableIPv6=true | `false`             |
+| `clusterDefaultPool.ipv4IPPoolName`         | the name of ipv4 spiderpool instance                                            | `default-v4-ippool` |
+| `clusterDefaultPool.ipv6IPPoolName`         | the name of ipv6 spiderpool instance                                            | `default-v6-ippool` |
+| `clusterDefaultPool.ipv4SubnetName`         | the name of ipv4 spidersubnet instance                                          | `default-v4-subnet` |
+| `clusterDefaultPool.ipv6SubnetName`         | the name of ipv6 spidersubnet instance                                          | `default-v6-subnet` |
+| `clusterDefaultPool.ipv4Subnet`             | the subnet of ipv4 spiderpool instance                                          | `""`                |
+| `clusterDefaultPool.ipv6Subnet`             | the subnet of ipv6 spiderpool instance                                          | `""`                |
+| `clusterDefaultPool.ipv4IPRanges`           | the available IP of ipv4 spiderpool instance                                    | `[]`                |
+| `clusterDefaultPool.ipv6IPRanges`           | the available IP of ipv6 spiderpool instance                                    | `[]`                |
+| `clusterDefaultPool.ipv4Gateway`            | the gateway of ipv4 subnet                                                      | `""`                |
+| `clusterDefaultPool.ipv6Gateway`            | the gateway of ipv6 subnet                                                      | `""`                |
+| `clusterDefaultPool.subnetFlexibleIPNumber` | the default flexible IP number of SpiderSubnet feature auto-created IPPools     | `1`                 |
 
 
 ### spiderpoolAgent parameters

--- a/charts/spiderpool/README.md
+++ b/charts/spiderpool/README.md
@@ -127,21 +127,21 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 
 ### clusterDefaultPool parameters
 
-| Name                                        | Description                                                                     | Value               |
-|---------------------------------------------|---------------------------------------------------------------------------------| ------------------- |
-| `clusterDefaultPool.installIPv4IPPool`      | install ipv4 spiderpool instance. It is required to set feature.enableIPv4=true | `false`             |
-| `clusterDefaultPool.installIPv6IPPool`      | install ipv6 spiderpool instance. It is required to set feature.enableIPv6=true | `false`             |
-| `clusterDefaultPool.ipv4IPPoolName`         | the name of ipv4 spiderpool instance                                            | `default-v4-ippool` |
-| `clusterDefaultPool.ipv6IPPoolName`         | the name of ipv6 spiderpool instance                                            | `default-v6-ippool` |
-| `clusterDefaultPool.ipv4SubnetName`         | the name of ipv4 spidersubnet instance                                          | `default-v4-subnet` |
-| `clusterDefaultPool.ipv6SubnetName`         | the name of ipv6 spidersubnet instance                                          | `default-v6-subnet` |
-| `clusterDefaultPool.ipv4Subnet`             | the subnet of ipv4 spiderpool instance                                          | `""`                |
-| `clusterDefaultPool.ipv6Subnet`             | the subnet of ipv6 spiderpool instance                                          | `""`                |
-| `clusterDefaultPool.ipv4IPRanges`           | the available IP of ipv4 spiderpool instance                                    | `[]`                |
-| `clusterDefaultPool.ipv6IPRanges`           | the available IP of ipv6 spiderpool instance                                    | `[]`                |
-| `clusterDefaultPool.ipv4Gateway`            | the gateway of ipv4 subnet                                                      | `""`                |
-| `clusterDefaultPool.ipv6Gateway`            | the gateway of ipv6 subnet                                                      | `""`                |
-| `clusterDefaultPool.subnetFlexibleIPNumber` | the default flexible IP number of SpiderSubnet feature auto-created IPPools     | `1`                 |
+| Name                                               | Description                                                                     | Value               |
+| -------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------- |
+| `clusterDefaultPool.installIPv4IPPool`             | install ipv4 spiderpool instance. It is required to set feature.enableIPv4=true | `false`             |
+| `clusterDefaultPool.installIPv6IPPool`             | install ipv6 spiderpool instance. It is required to set feature.enableIPv6=true | `false`             |
+| `clusterDefaultPool.ipv4IPPoolName`                | the name of ipv4 spiderpool instance                                            | `default-v4-ippool` |
+| `clusterDefaultPool.ipv6IPPoolName`                | the name of ipv6 spiderpool instance                                            | `default-v6-ippool` |
+| `clusterDefaultPool.ipv4SubnetName`                | the name of ipv4 spidersubnet instance                                          | `default-v4-subnet` |
+| `clusterDefaultPool.ipv6SubnetName`                | the name of ipv6 spidersubnet instance                                          | `default-v6-subnet` |
+| `clusterDefaultPool.ipv4Subnet`                    | the subnet of ipv4 spiderpool instance                                          | `""`                |
+| `clusterDefaultPool.ipv6Subnet`                    | the subnet of ipv6 spiderpool instance                                          | `""`                |
+| `clusterDefaultPool.ipv4IPRanges`                  | the available IP of ipv4 spiderpool instance                                    | `[]`                |
+| `clusterDefaultPool.ipv6IPRanges`                  | the available IP of ipv6 spiderpool instance                                    | `[]`                |
+| `clusterDefaultPool.ipv4Gateway`                   | the gateway of ipv4 subnet                                                      | `""`                |
+| `clusterDefaultPool.ipv6Gateway`                   | the gateway of ipv6 subnet                                                      | `""`                |
+| `clusterDefaultPool.subnetDefaultFlexibleIPNumber` | the default flexible IP number of SpiderSubnet feature auto-created IPPools     | `1`                 |
 
 
 ### spiderpoolAgent parameters

--- a/charts/spiderpool/templates/configmap.yaml
+++ b/charts/spiderpool/templates/configmap.yaml
@@ -30,3 +30,18 @@ data:
     {{- else}}
     clusterDefaultIPv6IPPool: []
     {{- end }}
+    {{- if ( and .Values.feature.enableSpiderSubnet .Values.feature.enableIPv4 ) }}
+    clusterDefaultIPv4Subnet: [{{ .Values.clusterDefaultPool.ipv4SubnetName }}]
+    {{- else}}
+    clusterDefaultIPv4Subnet: []
+    {{- end}}
+    {{- if ( and .Values.feature.enableSpiderSubnet .Values.feature.enableIPv6 )}}
+    clusterDefaultIPv6Subnet: [{{ .Values.clusterDefaultPool.ipv6SubnetName }}]
+    {{- else}}
+    clusterDefaultIPv6Subnet: []
+    {{- end }}
+    {{- if .Values.feature.enableSpiderSubnet }}
+    clusterDefaultSubnetFlexibleIPNumber: {{ .Values.clusterDefaultPool.subnetFlexibleIPNumber }}
+    {{- else}}
+    clusterDefaultSubnetFlexibleIPNumber: 0
+    {{- end }}

--- a/charts/spiderpool/templates/configmap.yaml
+++ b/charts/spiderpool/templates/configmap.yaml
@@ -41,7 +41,7 @@ data:
     clusterDefaultIPv6Subnet: []
     {{- end }}
     {{- if .Values.feature.enableSpiderSubnet }}
-    clusterDefaultSubnetFlexibleIPNumber: {{ .Values.clusterDefaultPool.subnetFlexibleIPNumber }}
+    clusterSubnetDefaultFlexibleIPNumber: {{ .Values.clusterDefaultPool.subnetDefaultFlexibleIPNumber }}
     {{- else}}
-    clusterDefaultSubnetFlexibleIPNumber: 0
+    clusterSubnetDefaultFlexibleIPNumber: 0
     {{- end }}

--- a/charts/spiderpool/values.yaml
+++ b/charts/spiderpool/values.yaml
@@ -103,6 +103,9 @@ clusterDefaultPool:
   ## @param clusterDefaultPool.ipv6Gateway the gateway of ipv6 subnet
   ipv6Gateway: ""
 
+  ## @param clusterDefaultPool.subnetFlexibleIPNumber the default flexible IP number of SpiderSubnet feature auto-created IPPools
+  subnetFlexibleIPNumber: 1
+
 ## @section spiderpoolAgent parameters
 ##
 spiderpoolAgent:

--- a/charts/spiderpool/values.yaml
+++ b/charts/spiderpool/values.yaml
@@ -103,8 +103,8 @@ clusterDefaultPool:
   ## @param clusterDefaultPool.ipv6Gateway the gateway of ipv6 subnet
   ipv6Gateway: ""
 
-  ## @param clusterDefaultPool.subnetFlexibleIPNumber the default flexible IP number of SpiderSubnet feature auto-created IPPools
-  subnetFlexibleIPNumber: 1
+  ## @param clusterDefaultPool.subnetDefaultFlexibleIPNumber the default flexible IP number of SpiderSubnet feature auto-created IPPools
+  subnetDefaultFlexibleIPNumber: 1
 
 ## @section spiderpoolAgent parameters
 ##

--- a/cmd/spiderpool-agent/cmd/config.go
+++ b/cmd/spiderpool-agent/cmd/config.go
@@ -94,14 +94,17 @@ type Config struct {
 	LimiterMaxWaitTime  int
 
 	// configmap
-	IpamUnixSocketPath       string   `yaml:"ipamUnixSocketPath"`
-	EnableIPv4               bool     `yaml:"enableIPv4"`
-	EnableIPv6               bool     `yaml:"enableIPv6"`
-	ClusterDefaultIPv4IPPool []string `yaml:"clusterDefaultIPv4IPPool"`
-	ClusterDefaultIPv6IPPool []string `yaml:"clusterDefaultIPv6IPPool"`
-	NetworkMode              string   `yaml:"networkMode"`
-	EnableStatefulSet        bool     `yaml:"enableStatefulSet"`
-	EnableSpiderSubnet       bool     `yaml:"enableSpiderSubnet"`
+	IpamUnixSocketPath                string   `yaml:"ipamUnixSocketPath"`
+	EnableIPv4                        bool     `yaml:"enableIPv4"`
+	EnableIPv6                        bool     `yaml:"enableIPv6"`
+	ClusterDefaultIPv4IPPool          []string `yaml:"clusterDefaultIPv4IPPool"`
+	ClusterDefaultIPv6IPPool          []string `yaml:"clusterDefaultIPv6IPPool"`
+	ClusterDefaultIPv4Subnet          []string `yaml:"clusterDefaultIPv4Subnet"`
+	ClusterDefaultIPv6Subnet          []string `yaml:"clusterDefaultIPv6Subnet"`
+	NetworkMode                       string   `yaml:"networkMode"`
+	EnableStatefulSet                 bool     `yaml:"enableStatefulSet"`
+	EnableSpiderSubnet                bool     `yaml:"enableSpiderSubnet"`
+	ClusterDefaultSubnetFlexibleIPNum int      `yaml:"clusterDefaultSubnetFlexibleIPNumber"`
 
 	GoMaxProcs int
 }

--- a/cmd/spiderpool-agent/cmd/config.go
+++ b/cmd/spiderpool-agent/cmd/config.go
@@ -104,7 +104,7 @@ type Config struct {
 	NetworkMode                       string   `yaml:"networkMode"`
 	EnableStatefulSet                 bool     `yaml:"enableStatefulSet"`
 	EnableSpiderSubnet                bool     `yaml:"enableSpiderSubnet"`
-	ClusterDefaultSubnetFlexibleIPNum int      `yaml:"clusterDefaultSubnetFlexibleIPNumber"`
+	ClusterSubnetDefaultFlexibleIPNum int      `yaml:"clusterSubnetDefaultFlexibleIPNumber"`
 
 	GoMaxProcs int
 }

--- a/cmd/spiderpool-agent/cmd/daemon.go
+++ b/cmd/spiderpool-agent/cmd/daemon.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spidernet-io/spiderpool/pkg/nodemanager"
 	"github.com/spidernet-io/spiderpool/pkg/podmanager"
 	"github.com/spidernet-io/spiderpool/pkg/reservedipmanager"
+	"github.com/spidernet-io/spiderpool/pkg/singletons"
 	"github.com/spidernet-io/spiderpool/pkg/statefulsetmanager"
 	"github.com/spidernet-io/spiderpool/pkg/subnetmanager"
 	"github.com/spidernet-io/spiderpool/pkg/workloadendpointmanager"
@@ -70,11 +71,20 @@ func DaemonMain() {
 	if nil != err {
 		logger.Fatal("Load configmap failed, " + err.Error())
 	}
+
+	// init singleton ClusterDefaultPool
+	logger.Sugar().Infof("Init Cluster default pool configurations")
+	singletons.InitClusterDefaultPool(agentContext.Cfg.ClusterDefaultIPv4IPPool, agentContext.Cfg.ClusterDefaultIPv6IPPool,
+		agentContext.Cfg.ClusterDefaultIPv4Subnet, agentContext.Cfg.ClusterDefaultIPv6Subnet,
+		agentContext.Cfg.ClusterDefaultSubnetFlexibleIPNum)
+
 	logger.With(zap.String("IpamUnixSocketPath", agentContext.Cfg.IpamUnixSocketPath),
 		zap.Bool("EnabledIPv4", agentContext.Cfg.EnableIPv4),
 		zap.Bool("EnabledIPv6", agentContext.Cfg.EnableIPv6),
 		zap.Strings("ClusterDefaultIPv4IPPool", agentContext.Cfg.ClusterDefaultIPv4IPPool),
 		zap.Strings("ClusterDefaultIPv6IPPool", agentContext.Cfg.ClusterDefaultIPv6IPPool),
+		zap.Strings("ClusterDefaultIPv4Subnet", agentContext.Cfg.ClusterDefaultIPv4Subnet),
+		zap.Strings("ClusterDefaultIPv6Subnet", agentContext.Cfg.ClusterDefaultIPv6Subnet),
 		zap.String("NetworkMode", agentContext.Cfg.NetworkMode)).
 		Info("Load configmap successfully")
 

--- a/cmd/spiderpool-agent/cmd/daemon.go
+++ b/cmd/spiderpool-agent/cmd/daemon.go
@@ -76,7 +76,7 @@ func DaemonMain() {
 	logger.Sugar().Infof("Init Cluster default pool configurations")
 	singletons.InitClusterDefaultPool(agentContext.Cfg.ClusterDefaultIPv4IPPool, agentContext.Cfg.ClusterDefaultIPv6IPPool,
 		agentContext.Cfg.ClusterDefaultIPv4Subnet, agentContext.Cfg.ClusterDefaultIPv6Subnet,
-		agentContext.Cfg.ClusterDefaultSubnetFlexibleIPNum)
+		agentContext.Cfg.ClusterSubnetDefaultFlexibleIPNum)
 
 	logger.With(zap.String("IpamUnixSocketPath", agentContext.Cfg.IpamUnixSocketPath),
 		zap.Bool("EnabledIPv4", agentContext.Cfg.EnableIPv4),

--- a/cmd/spiderpool-controller/cmd/config.go
+++ b/cmd/spiderpool-controller/cmd/config.go
@@ -135,10 +135,15 @@ type Config struct {
 	LeaseRetryGap      int
 
 	// configmap
-	EnableIPv4         bool `yaml:"enableIPv4"`
-	EnableIPv6         bool `yaml:"enableIPv6"`
-	EnableStatefulSet  bool `yaml:"enableStatefulSet"`
-	EnableSpiderSubnet bool `yaml:"enableSpiderSubnet"`
+	EnableIPv4                        bool     `yaml:"enableIPv4"`
+	EnableIPv6                        bool     `yaml:"enableIPv6"`
+	EnableStatefulSet                 bool     `yaml:"enableStatefulSet"`
+	EnableSpiderSubnet                bool     `yaml:"enableSpiderSubnet"`
+	ClusterDefaultIPv4IPPool          []string `yaml:"clusterDefaultIPv4IPPool"`
+	ClusterDefaultIPv6IPPool          []string `yaml:"clusterDefaultIPv6IPPool"`
+	ClusterDefaultIPv4Subnet          []string `yaml:"clusterDefaultIPv4Subnet"`
+	ClusterDefaultIPv6Subnet          []string `yaml:"clusterDefaultIPv6Subnet"`
+	ClusterDefaultSubnetFlexibleIPNum int      `yaml:"clusterDefaultSubnetFlexibleIPNumber"`
 
 	GoMaxProcs int
 }

--- a/cmd/spiderpool-controller/cmd/config.go
+++ b/cmd/spiderpool-controller/cmd/config.go
@@ -143,7 +143,7 @@ type Config struct {
 	ClusterDefaultIPv6IPPool          []string `yaml:"clusterDefaultIPv6IPPool"`
 	ClusterDefaultIPv4Subnet          []string `yaml:"clusterDefaultIPv4Subnet"`
 	ClusterDefaultIPv6Subnet          []string `yaml:"clusterDefaultIPv6Subnet"`
-	ClusterDefaultSubnetFlexibleIPNum int      `yaml:"clusterDefaultSubnetFlexibleIPNumber"`
+	ClusterSubnetDefaultFlexibleIPNum int      `yaml:"clusterSubnetDefaultFlexibleIPNumber"`
 
 	GoMaxProcs int
 }

--- a/cmd/spiderpool-controller/cmd/daemon.go
+++ b/cmd/spiderpool-controller/cmd/daemon.go
@@ -31,6 +31,7 @@ import (
 	"github.com/spidernet-io/spiderpool/pkg/nodemanager"
 	"github.com/spidernet-io/spiderpool/pkg/podmanager"
 	"github.com/spidernet-io/spiderpool/pkg/reservedipmanager"
+	"github.com/spidernet-io/spiderpool/pkg/singletons"
 	"github.com/spidernet-io/spiderpool/pkg/statefulsetmanager"
 	"github.com/spidernet-io/spiderpool/pkg/subnetmanager"
 	"github.com/spidernet-io/spiderpool/pkg/workloadendpointmanager"
@@ -73,6 +74,12 @@ func DaemonMain() {
 	if nil != err {
 		logger.Sugar().Fatalf("failed to load configmap, error: %v", err)
 	}
+
+	// init singleton ClusterDefaultPool
+	logger.Sugar().Infof("Init Cluster default pool configurations")
+	singletons.InitClusterDefaultPool(controllerContext.Cfg.ClusterDefaultIPv4IPPool, controllerContext.Cfg.ClusterDefaultIPv6IPPool,
+		controllerContext.Cfg.ClusterDefaultIPv4Subnet, controllerContext.Cfg.ClusterDefaultIPv6Subnet,
+		controllerContext.Cfg.ClusterDefaultSubnetFlexibleIPNum)
 
 	controllerContext.InnerCtx, controllerContext.InnerCancel = context.WithCancel(context.Background())
 

--- a/cmd/spiderpool-controller/cmd/daemon.go
+++ b/cmd/spiderpool-controller/cmd/daemon.go
@@ -79,7 +79,7 @@ func DaemonMain() {
 	logger.Sugar().Infof("Init Cluster default pool configurations")
 	singletons.InitClusterDefaultPool(controllerContext.Cfg.ClusterDefaultIPv4IPPool, controllerContext.Cfg.ClusterDefaultIPv6IPPool,
 		controllerContext.Cfg.ClusterDefaultIPv4Subnet, controllerContext.Cfg.ClusterDefaultIPv6Subnet,
-		controllerContext.Cfg.ClusterDefaultSubnetFlexibleIPNum)
+		controllerContext.Cfg.ClusterSubnetDefaultFlexibleIPNum)
 
 	controllerContext.InnerCtx, controllerContext.InnerCancel = context.WithCancel(context.Background())
 

--- a/cmd/spiderpool-init/cmd/root.go
+++ b/cmd/spiderpool-init/cmd/root.go
@@ -154,9 +154,15 @@ func Execute() {
 			ObjectMeta: metav1.ObjectMeta{Name: Config.PoolV4Name},
 			Spec: spiderpoolv1.IPPoolSpec{
 				Subnet: Config.PoolV4Subnet,
-				IPs:    Config.PoolV4IPRanges,
 			},
 		}
+
+		// if we create SpiderSubnet CR object, we'll create an empty default IPPool.
+		// Otherwise, we'll create a truly useful default IPPool
+		if len(Config.SubnetV4Name) == 0 {
+			pool.Spec.IPs = Config.PoolV4IPRanges
+		}
+
 		if len(Config.PoolV4Gateway) > 0 {
 			pool.Spec.Gateway = &Config.PoolV4Gateway
 		}
@@ -198,9 +204,15 @@ func Execute() {
 			ObjectMeta: metav1.ObjectMeta{Name: Config.PoolV6Name},
 			Spec: spiderpoolv1.IPPoolSpec{
 				Subnet: Config.PoolV6Subnet,
-				IPs:    Config.PoolV6IPRanges,
 			},
 		}
+
+		// if we create SpiderSubnet CR object, we'll create an empty default IPPool.
+		// Otherwise, we'll create a truly useful default IPPool
+		if len(Config.SubnetV6Name) == 0 {
+			pool.Spec.IPs = Config.PoolV6IPRanges
+		}
+
 		if len(Config.PoolV6Gateway) > 0 {
 			pool.Spec.Gateway = &Config.PoolV6Gateway
 		}

--- a/docs/concepts/allocation.md
+++ b/docs/concepts/allocation.md
@@ -6,9 +6,16 @@ When a pod is creating, it will follow steps below to get an IP.
 
     For which ippool is used by a pod, the following rules are listed from high to low priority.
 
+    * SpiderSubnet annotation. "ipam.spidernet.io/subnets" and "ipam.spidernet.io/subnet" will choose to use auto-created ippool if the SpiderSubnet feature is enabled. See [SpiderSubnet](../usage/spider-subnet.md) for detail.
+
     * Honor pod annotation. "ipam.spidernet.io/ippool" and "ipam.spidernet.io/ippools" could be used to specify an ippool. See [Pod Annotation](../usage/annotation.md) for detail.
 
     * Namespace annotation. "ipam.spidernet.io/defaultv4ippool" and "ipam.spidernet.io/defaultv6ippool" could be used to specify an ippool. See [namespace annotation](../usage/annotation.md) for detail.
+
+    * CNI configuration file. It can be set to "default_ipv4_ippool" and "default_ipv6_ippool" in the CNI configuration file. See [configuration](../usage/config.md) for detail.
+
+    * Cluster default subnet.(you can do not specify any annotations and it will try to use cluster default subnet auto-created ippool if the SpiderSubnet feature it enabled)
+     It can be set to "clusterDefaultIPv4Subnet" and "clusterDefaultIPv6Subnet" in the "spiderpool-conf" ConfigMap. See [configuration](../usage/config.md) for detail.
 
     * Cluster default ippool.
       It can be set to "clusterDefaultIPv4IPPool" and "clusterDefaultIPv6IPPool" in the "spiderpool-conf" ConfigMap. See [configuration](../usage/config.md) for detail.

--- a/docs/concepts/annotation.md
+++ b/docs/concepts/annotation.md
@@ -2,6 +2,32 @@
 
 Spiderpool provides annotations for configuring custom ippools and routes.
 
+## Application annotations
+
+Once you set up SpiderSubnet feature, you can specify SpiderSubnet annotations for the application templates.
+For more details, please refer to [SpiderSubnet](../usage/spider-subnet.md)
+
+Notice: The current version only supports to use one SpiderSubnet V4/V6 CR for one interface, you shouldn't specify 2 or more SpiderSubnet V4 CRs,
+and it will choose the first one to use.
+
+### ipam.spidernet.io/subnets
+
+Here's an example for multiple interfaces to use SpiderSubnet.
+
+```yaml
+ipam.spidernet.io/subnets: |-
+  [{"interface": "eth0", "ipv4": ["subnet-demo-v4-1"], "ipv6": ["subnet-demo-v6-1"]},
+   {"interface": "net2", "ipv4": ["subnet-demo-v4-2"], "ipv6": ["subnet-demo-v6-2"]}]
+```
+
+### ipam.spidernet.io/subnet
+
+This is used for SpiderSubnet with single interface.
+
+```yaml
+ipam.spidernet.io/subnet: '{"ipv4": ["subnet-demo-v4"], "ipv6": ["subnet-demo-v6"]}'
+```
+
 ## Pod annotations
 
 For a pod, you can specify Spiderpool annotations for a special request.

--- a/docs/concepts/config.md
+++ b/docs/concepts/config.md
@@ -51,12 +51,18 @@ metadata:
   name: spiderpool-conf
   namespace: kube-system
 data:
-  ipamUnixSocketPath: /var/run/spidernet/spiderpool.sock
-  networkMode: legacy
-  enableIPv4: true
-  enableIPv6: true
-  clusterDefaultIPv4IPPool: [default-v4-ippool]
-  clusterDefaultIPv6IPPool: [default-v6-ippool]
+  conf.yml: |
+    ipamUnixSocketPath: /var/run/spidernet/spiderpool.sock
+    networkMode: legacy
+    enableIPv4: true
+    enableIPv6: true
+    enableStatefulSet: true
+    enableSpiderSubnet: true
+    clusterDefaultIPv4IPPool: [default-v4-ippool]
+    clusterDefaultIPv6IPPool: [default-v6-ippool]
+    clusterDefaultIPv4Subnet: [default-v4-subnet]
+    clusterDefaultIPv6Subnet: [default-v6-subnet]
+    clusterSubnetDefaultFlexibleIPNumber: 1
 ```
 
 - `ipamUnixSocketPath` (string): Spiderpool agent listens to this UNIX socket file and handles IPAM requests from IPAM plugin.
@@ -68,8 +74,17 @@ data:
 - `enableIPv6` (bool):
   - `true`: Enable IPv6 IP allocation capability of Spiderpool.
   - `false`: Disable IPv6 IP allocation capability of Spiderpool.
+- `enableStatefulSet` (bool):
+  - `true`: Enable StatefulSet capability of Spiderpool.
+  - `false`: Disable StatefulSet capability of Spiderpool.
+- `enableSpiderSubnet` (bool):
+  - `true`: Enable SpiderSubnet capability of Spiderpool.
+  - `false`: Disable SpiderSubnet capability of Spiderpool.
 - `clusterDefaultIPv4IPPool` (array): Global default IPv4 ippools. It takes effect across the cluster.
 - `clusterDefaultIPv6IPPool` (array): Global default IPv6 ippools. It takes effect across the cluster.
+- `clusterDefaultIPv4Subnet` (array): Global default IPv4 subnets. It takes effect across the cluster.
+- `clusterDefaultIPv6Subnet` (array): Global default IPv6 subnets. It takes effect across the cluster.
+- `clusterSubnetDefaultFlexibleIPNumber` (int): Global SpiderSubnet default flexible IP number. It takes effect across the cluster.
 
 ## Spiderpool-agent env
 

--- a/docs/develop/upgrade.md
+++ b/docs/develop/upgrade.md
@@ -8,15 +8,15 @@ Please consult the segments from your current release until now before upgrading
 
 ### Description
 
-There's a design flaw for SpiderSubnet feature in auto-created IPPool label.
+1. There's a design flaw for SpiderSubnet feature in auto-created IPPool label.
 The previous label `ipam.spidernet.io/owner-application` corresponding value uses '-' as separative sign.
 For example, we have deployment `ns398-174835790/deploy398-82311862` and the corresponding label value is `Deployment-ns398-174835790-deploy398-82311862`.
-It's very hard to unpack it to trace back what the application namespace and name is.
-
+It's very hard to unpack it to trace back what the application namespace and name is.  
 Now, we use '_' rather than '-' as slash for SpiderSubnet feature label `ipam.spidernet.io/owner-application`, and the upper case
-will be like `Deployment_ns398-174835790_deploy398-82311862`
-
+will be like `Deployment_ns398-174835790_deploy398-82311862`.  
 Reference PR: [#1162](https://github.com/spidernet-io/spiderpool/pull/1162)
+2. In order to support multiple interfaces with SpiderSubnet feature, we also add one more label for auto-created IPPool.
+The key is `ipam.spidernet.io/interface`, and the value is the corresponding interface name.
 
 ### Operation steps
 
@@ -28,4 +28,10 @@ Reference PR: [#1162](https://github.com/spidernet-io/spiderpool/pull/1162)
     kubectl patch sp ${auto-pool} --type merge --patch '{"metadata": {"labels": {"ipam.spidernet.io/owner-application": ${AppLabelValue}}}}'
    ```
 
-3. Update your Spiderpool components version and restart them all.
+3. Add one more label
+
+   ```shell
+    kubectl patch sp ${auto-pool} --type merge --patch '{"metadata": {"labels": {"ipam.spidernet.io/interface": "eth0"}}}}'
+   ```
+
+4. Update your Spiderpool components version and restart them all.

--- a/docs/example/spider-subnet/cluster-default-subnet-deployment.yaml
+++ b/docs/example/spider-subnet/cluster-default-subnet-deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-default-subnet-deploy
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cluster-default-subnet-deploy
+  template:
+    metadata:
+      labels:
+        app: cluster-default-subnet-deploy
+    spec:
+      containers:
+        - name: demo-deploy-subnet
+          image: busybox
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/docs/example/spider-subnet/multiple-interfaces.yaml
+++ b/docs/example/spider-subnet/multiple-interfaces.yaml
@@ -1,0 +1,67 @@
+apiVersion: spiderpool.spidernet.io/v1
+kind: SpiderSubnet
+metadata:
+  name: subnet-demo-v4-1
+spec:
+  ipVersion: 4
+  subnet: 172.15.0.0/16
+  ips:
+    - 172.15.41.1-172.15.41.200
+---
+apiVersion: spiderpool.spidernet.io/v1
+kind: SpiderSubnet
+metadata:
+  name: subnet-demo-v6-1
+spec:
+  ipVersion: 6
+  subnet: 2002::ac0f:0/64
+  ips:
+    - 2002::ac0f:2901-2002::ac0f:29c8
+---
+apiVersion: spiderpool.spidernet.io/v1
+kind: SpiderSubnet
+metadata:
+  name: subnet-demo-v4-2
+spec:
+  ipVersion: 4
+  subnet: 172.14.0.0/16
+  ips:
+    - 172.14.41.1-172.14.41.200
+---
+apiVersion: spiderpool.spidernet.io/v1
+kind: SpiderSubnet
+metadata:
+  name: subnet-demo-v6-2
+spec:
+  ipVersion: 6
+  subnet: fe80:f853:ccd:e790::/64
+  ips:
+    - fe80:f853:ccd:e790:d::1-fe80:f853:ccd:e790:d::c8
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: subnet-mutilple-interface-deploy
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: subnet-mutilple-interface-deploy
+  template:
+    metadata:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: kube-system/macvlan-cni2
+        ipam.spidernet.io/subnets: |-
+          [{"interface": "eth0", "ipv4": ["subnet-demo-v4-1"], "ipv6": ["subnet-demo-v6-1"]},
+           {"interface": "net2", "ipv4": ["subnet-demo-v4-2"], "ipv6": ["subnet-demo-v6-2"]}]
+        ipam.spidernet.io/ippool-ip-number: "+2"
+        ipam.spidernet.io/ippool-reclaim: "true"
+      labels:
+        app: subnet-mutilple-interface-deploy
+    spec:
+      containers:
+        - name: demo-deploy-subnet
+          image: busybox
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]

--- a/pkg/constant/k8s.go
+++ b/pkg/constant/k8s.go
@@ -73,6 +73,7 @@ const (
 	LabelIPPoolOwnerApplicationUID = AnnotationPre + "/owner-application-uid"
 	LabelIPPoolVersion             = AnnotationPre + "/ippool-version"
 	LabelIPPoolReclaimIPPool       = AnnoSpiderSubnetReclaimIPPool
+	LabelIPPoolInterface           = AnnotationPre + "/interface"
 	LabelIPPoolVersionV4           = "IPv4"
 	LabelIPPoolVersionV6           = "IPv6"
 )
@@ -109,3 +110,5 @@ const (
 	EventReasonDeleteIPPool = "DeleteIPPool"
 	EventReasonResyncSubnet = "ResyncSubnet"
 )
+
+const ClusterDefaultInterfaceName = "eth0"

--- a/pkg/singletons/singleton.go
+++ b/pkg/singletons/singleton.go
@@ -1,0 +1,18 @@
+// Copyright 2022 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+
+package singletons
+
+import "github.com/spidernet-io/spiderpool/pkg/types"
+
+// ClusterDefaultPool is a singleton recording cluster default IPPool and Subnet configurations
+var ClusterDefaultPool = new(types.ClusterDefaultPoolConfig)
+
+// InitClusterDefaultPool will init ClusterDefaultPool with the given params
+func InitClusterDefaultPool(clusterDefaultV4IPPool, clusterDefaultV6IPPool, clusterDefaultV4Subnet, clusterDefaultV6Subnet []string, flexibleIPNumber int) {
+	ClusterDefaultPool.ClusterDefaultIPv4IPPool = clusterDefaultV4IPPool
+	ClusterDefaultPool.ClusterDefaultIPv6IPPool = clusterDefaultV6IPPool
+	ClusterDefaultPool.ClusterDefaultIPv4Subnet = clusterDefaultV4Subnet
+	ClusterDefaultPool.ClusterDefaultIPv6Subnet = clusterDefaultV6Subnet
+	ClusterDefaultPool.ClusterDefaultSubnetFlexibleIPNumber = flexibleIPNumber
+}

--- a/pkg/singletons/singleton.go
+++ b/pkg/singletons/singleton.go
@@ -14,5 +14,5 @@ func InitClusterDefaultPool(clusterDefaultV4IPPool, clusterDefaultV6IPPool, clus
 	ClusterDefaultPool.ClusterDefaultIPv6IPPool = clusterDefaultV6IPPool
 	ClusterDefaultPool.ClusterDefaultIPv4Subnet = clusterDefaultV4Subnet
 	ClusterDefaultPool.ClusterDefaultIPv6Subnet = clusterDefaultV6Subnet
-	ClusterDefaultPool.ClusterDefaultSubnetFlexibleIPNumber = flexibleIPNumber
+	ClusterDefaultPool.ClusterSubnetDefaultFlexibleIPNumber = flexibleIPNumber
 }

--- a/pkg/subnetmanager/app_controller.go
+++ b/pkg/subnetmanager/app_controller.go
@@ -114,14 +114,14 @@ func (c *appController) ControllerAddOrUpdateHandler() controllers.AppInformersA
 			}
 
 			newAppReplicas = controllers.GetAppReplicas(newObject.Spec.Replicas)
-			newSubnetConfig, err = controllers.GetSubnetAnnoConfig(newObject.Spec.Template.Annotations)
+			newSubnetConfig, err = controllers.GetSubnetAnnoConfig(newObject.Spec.Template.Annotations, log)
 			if nil != err {
 				return fmt.Errorf("failed to get app subnet configuration, error: %v", err)
 			}
 
 			// default IPAM mode
-			if newSubnetConfig == nil {
-				log.Debug("app will use default IPAM mode with no subnet annotation")
+			if newSubnetConfig == nil || (len(newSubnetConfig.SubnetName.IPv4) == 0 && len(newSubnetConfig.SubnetName.IPv6) == 0) {
+				log.Debug("app will use default IPAM mode, because there's no subnet annotation or no ClusterDefaultSubnets")
 
 				// if one application used to have subnet feature but discard it later, we should also clean up the legacy IPPools
 				if c.subnetMgr.config.EnableSubnetDeleteStaleIPPool {
@@ -139,7 +139,7 @@ func (c *appController) ControllerAddOrUpdateHandler() controllers.AppInformersA
 			if oldObj != nil {
 				oldDeployment := oldObj.(*appsv1.Deployment)
 				oldAppReplicas = controllers.GetAppReplicas(oldDeployment.Spec.Replicas)
-				oldSubnetConfig, err = controllers.GetSubnetAnnoConfig(oldDeployment.Spec.Template.Annotations)
+				oldSubnetConfig, err = controllers.GetSubnetAnnoConfig(oldDeployment.Spec.Template.Annotations, log)
 				if nil != err {
 					return fmt.Errorf("failed to get old app subnet configuration, error: %v", err)
 				}
@@ -163,14 +163,14 @@ func (c *appController) ControllerAddOrUpdateHandler() controllers.AppInformersA
 			}
 
 			newAppReplicas = controllers.GetAppReplicas(newObject.Spec.Replicas)
-			newSubnetConfig, err = controllers.GetSubnetAnnoConfig(newObject.Spec.Template.Annotations)
+			newSubnetConfig, err = controllers.GetSubnetAnnoConfig(newObject.Spec.Template.Annotations, log)
 			if nil != err {
 				return fmt.Errorf("failed to get app subnet configuration, error: %v", err)
 			}
 
 			// default IPAM mode
-			if newSubnetConfig == nil {
-				log.Debug("app will use default IPAM mode with no subnet annotation")
+			if newSubnetConfig == nil || (len(newSubnetConfig.SubnetName.IPv4) == 0 && len(newSubnetConfig.SubnetName.IPv6) == 0) {
+				log.Debug("app will use default IPAM mode, because there's no subnet annotation or no ClusterDefaultSubnets")
 
 				// if one application used to have subnet feature but discard it later, we should also clean up the legacy IPPools
 				if c.subnetMgr.config.EnableSubnetDeleteStaleIPPool {
@@ -188,7 +188,7 @@ func (c *appController) ControllerAddOrUpdateHandler() controllers.AppInformersA
 			if oldObj != nil {
 				oldReplicaSet := oldObj.(*appsv1.ReplicaSet)
 				oldAppReplicas = controllers.GetAppReplicas(oldReplicaSet.Spec.Replicas)
-				oldSubnetConfig, err = controllers.GetSubnetAnnoConfig(oldReplicaSet.Spec.Template.Annotations)
+				oldSubnetConfig, err = controllers.GetSubnetAnnoConfig(oldReplicaSet.Spec.Template.Annotations, log)
 				if nil != err {
 					return fmt.Errorf("failed to get old app subnet configuration, error: %v", err)
 				}
@@ -212,14 +212,14 @@ func (c *appController) ControllerAddOrUpdateHandler() controllers.AppInformersA
 			}
 
 			newAppReplicas = controllers.GetAppReplicas(newObject.Spec.Replicas)
-			newSubnetConfig, err = controllers.GetSubnetAnnoConfig(newObject.Spec.Template.Annotations)
+			newSubnetConfig, err = controllers.GetSubnetAnnoConfig(newObject.Spec.Template.Annotations, log)
 			if nil != err {
 				return fmt.Errorf("failed to get app subnet configuration, error: %v", err)
 			}
 
 			// default IPAM mode
-			if newSubnetConfig == nil {
-				log.Debug("app will use default IPAM mode with no subnet annotation")
+			if newSubnetConfig == nil || (len(newSubnetConfig.SubnetName.IPv4) == 0 && len(newSubnetConfig.SubnetName.IPv6) == 0) {
+				log.Debug("app will use default IPAM mode, because there's no subnet annotation or no ClusterDefaultSubnets")
 
 				// if one application used to have subnet feature but discard it later, we should also clean up the legacy IPPools
 				if c.subnetMgr.config.EnableSubnetDeleteStaleIPPool {
@@ -237,7 +237,7 @@ func (c *appController) ControllerAddOrUpdateHandler() controllers.AppInformersA
 			if oldObj != nil {
 				oldStatefulSet := oldObj.(*appsv1.StatefulSet)
 				oldAppReplicas = controllers.GetAppReplicas(oldStatefulSet.Spec.Replicas)
-				oldSubnetConfig, err = controllers.GetSubnetAnnoConfig(oldStatefulSet.Spec.Template.Annotations)
+				oldSubnetConfig, err = controllers.GetSubnetAnnoConfig(oldStatefulSet.Spec.Template.Annotations, log)
 				if nil != err {
 					return fmt.Errorf("failed to get old app subnet configuration, error: %v", err)
 				}
@@ -261,14 +261,14 @@ func (c *appController) ControllerAddOrUpdateHandler() controllers.AppInformersA
 			}
 
 			newAppReplicas = controllers.CalculateJobPodNum(newObject.Spec.Parallelism, newObject.Spec.Completions)
-			newSubnetConfig, err = controllers.GetSubnetAnnoConfig(newObject.Spec.Template.Annotations)
+			newSubnetConfig, err = controllers.GetSubnetAnnoConfig(newObject.Spec.Template.Annotations, log)
 			if nil != err {
 				return fmt.Errorf("failed to get app subnet configuration, error: %v", err)
 			}
 
 			// default IPAM mode
-			if newSubnetConfig == nil {
-				log.Debug("app will use default IPAM mode with no subnet annotation")
+			if newSubnetConfig == nil || (len(newSubnetConfig.SubnetName.IPv4) == 0 && len(newSubnetConfig.SubnetName.IPv6) == 0) {
+				log.Debug("app will use default IPAM mode, because there's no subnet annotation or no ClusterDefaultSubnets")
 
 				// if one application used to have subnet feature but discard it later, we should also clean up the legacy IPPools
 				if c.subnetMgr.config.EnableSubnetDeleteStaleIPPool {
@@ -286,7 +286,7 @@ func (c *appController) ControllerAddOrUpdateHandler() controllers.AppInformersA
 			if oldObj != nil {
 				oldJob := oldObj.(*batchv1.Job)
 				oldAppReplicas = controllers.CalculateJobPodNum(oldJob.Spec.Parallelism, oldJob.Spec.Completions)
-				oldSubnetConfig, err = controllers.GetSubnetAnnoConfig(oldJob.Spec.Template.Annotations)
+				oldSubnetConfig, err = controllers.GetSubnetAnnoConfig(oldJob.Spec.Template.Annotations, log)
 				if nil != err {
 					return fmt.Errorf("failed to get old app subnet configuration, error: %v", err)
 				}
@@ -310,14 +310,14 @@ func (c *appController) ControllerAddOrUpdateHandler() controllers.AppInformersA
 			}
 
 			newAppReplicas = controllers.CalculateJobPodNum(newObject.Spec.JobTemplate.Spec.Parallelism, newObject.Spec.JobTemplate.Spec.Completions)
-			newSubnetConfig, err = controllers.GetSubnetAnnoConfig(newObject.Spec.JobTemplate.Spec.Template.Annotations)
+			newSubnetConfig, err = controllers.GetSubnetAnnoConfig(newObject.Spec.JobTemplate.Spec.Template.Annotations, log)
 			if nil != err {
 				return fmt.Errorf("failed to get app subnet configuration, error: %v", err)
 			}
 
 			// default IPAM mode
-			if newSubnetConfig == nil {
-				log.Debug("app will use default IPAM mode with no subnet annotation")
+			if newSubnetConfig == nil || (len(newSubnetConfig.SubnetName.IPv4) == 0 && len(newSubnetConfig.SubnetName.IPv6) == 0) {
+				log.Debug("app will use default IPAM mode, because there's no subnet annotation or no ClusterDefaultSubnets")
 
 				// if one application used to have subnet feature but discard it later, we should also clean up the legacy IPPools
 				if c.subnetMgr.config.EnableSubnetDeleteStaleIPPool {
@@ -335,7 +335,7 @@ func (c *appController) ControllerAddOrUpdateHandler() controllers.AppInformersA
 			if oldObj != nil {
 				oldCronJob := oldObj.(*batchv1.CronJob)
 				oldAppReplicas = controllers.CalculateJobPodNum(oldCronJob.Spec.JobTemplate.Spec.Parallelism, oldCronJob.Spec.JobTemplate.Spec.Completions)
-				oldSubnetConfig, err = controllers.GetSubnetAnnoConfig(oldCronJob.Spec.JobTemplate.Spec.Template.Annotations)
+				oldSubnetConfig, err = controllers.GetSubnetAnnoConfig(oldCronJob.Spec.JobTemplate.Spec.Template.Annotations, log)
 				if nil != err {
 					return fmt.Errorf("failed to get old app subnet configuration, error: %v", err)
 				}
@@ -359,14 +359,14 @@ func (c *appController) ControllerAddOrUpdateHandler() controllers.AppInformersA
 			}
 
 			newAppReplicas = int(newObject.Status.DesiredNumberScheduled)
-			newSubnetConfig, err = controllers.GetSubnetAnnoConfig(newObject.Spec.Template.Annotations)
+			newSubnetConfig, err = controllers.GetSubnetAnnoConfig(newObject.Spec.Template.Annotations, log)
 			if nil != err {
 				return fmt.Errorf("failed to get app subnet configuration, error: %v", err)
 			}
 
 			// default IPAM mode
-			if newSubnetConfig == nil {
-				log.Debug("app will use default IPAM mode with no subnet annotation")
+			if newSubnetConfig == nil || (len(newSubnetConfig.SubnetName.IPv4) == 0 && len(newSubnetConfig.SubnetName.IPv6) == 0) {
+				log.Debug("app will use default IPAM mode, because there's no subnet annotation or no ClusterDefaultSubnets")
 
 				// if one application used to have subnet feature but discard it later, we should also clean up the legacy IPPools
 				if c.subnetMgr.config.EnableSubnetDeleteStaleIPPool {
@@ -384,7 +384,7 @@ func (c *appController) ControllerAddOrUpdateHandler() controllers.AppInformersA
 			if oldObj != nil {
 				oldDaemonSet := oldObj.(*appsv1.DaemonSet)
 				oldAppReplicas = int(oldDaemonSet.Status.DesiredNumberScheduled)
-				oldSubnetConfig, err = controllers.GetSubnetAnnoConfig(oldDaemonSet.Spec.Template.Annotations)
+				oldSubnetConfig, err = controllers.GetSubnetAnnoConfig(oldDaemonSet.Spec.Template.Annotations, log)
 				if nil != err {
 					return fmt.Errorf("failed to get old app subnet configuration, error: %v", err)
 				}
@@ -705,7 +705,7 @@ func (c *appController) syncHandler(appKey appWorkQueueKey, log *zap.Logger) (er
 		return fmt.Errorf("%w: unexpected appWorkQueueKey in workQueue '%+v'", constant.ErrWrongInput, appKey)
 	}
 
-	subnetConfig, err = controllers.GetSubnetAnnoConfig(podAnno)
+	subnetConfig, err = controllers.GetSubnetAnnoConfig(podAnno, log)
 	if nil != err {
 		return fmt.Errorf("%w: failed to get pod annotation subnet config, error: %v", constant.ErrWrongInput, err)
 	}

--- a/pkg/subnetmanager/controllers/utils.go
+++ b/pkg/subnetmanager/controllers/utils.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -21,94 +22,18 @@ import (
 	"github.com/spidernet-io/spiderpool/pkg/types"
 )
 
-var ErrorAnnoInput = fmt.Errorf("wrong annotation input")
-
 var errInvalidInput = func(str string) error {
 	return fmt.Errorf("invalid input '%s'", str)
 }
 
-// PodSubnetAnnoConfig is used for the annotation `ipam.spidernet.io/subnet`,
-type PodSubnetAnnoConfig struct {
-	SubnetName    AnnoSubnetItems
-	FlexibleIPNum *int
-	AssignIPNum   int
-	ReclaimIPPool bool
-}
-
-func (in *PodSubnetAnnoConfig) String() string {
-	if in == nil {
-		return "nil"
-	}
-
-	s := strings.Join([]string{`&PodSubnetAnnoConfig{`,
-		`SubnetName:` + strings.Replace(strings.Replace(in.SubnetName.String(), "AnnoSubnetItems", "", 1), `&`, ``, 1) + `,`,
-		`FlexibleIPNum:` + spiderpoolv1.ValueToStringGenerated(in.FlexibleIPNum) + `,`,
-		`AssignIPNumber:` + fmt.Sprintf("%v", in.AssignIPNum) + `,`,
-		`ReclaimIPPool:` + fmt.Sprintf("%v", in.ReclaimIPPool),
-		`}`,
-	}, "")
-	return s
-}
-
-// AnnoSubnetItems describes the SpiderSubnet CR names and NIC
-type AnnoSubnetItems struct {
-	Interface string   `json:"interface,omitempty"`
-	IPv4      []string `json:"ipv4,omitempty"`
-	IPv6      []string `json:"ipv6,omitempty"`
-}
-
-func (in *AnnoSubnetItems) String() string {
-	if in == nil {
-		return "nil"
-	}
-
-	s := strings.Join([]string{`&AnnoSubnetItems{`,
-		`Interface:` + fmt.Sprintf("%v", in.Interface) + `,`,
-		`IPv4:` + fmt.Sprintf("%v", in.IPv4) + `,`,
-		`IPv6:` + fmt.Sprintf("%v", in.IPv6),
-		`}`,
-	}, "")
-	return s
-}
-
-// PodSubnetsAnnoConfig is used for the annotation `ipam.spidernet.io/subnets`,
-// NOT support in the present version.
-type PodSubnetsAnnoConfig struct {
-	SubnetName    []AnnoSubnetItems
-	FlexibleIPNum *int
-	AssignIPNum   int
-	ReclaimIPPool bool
-}
-
-func (in *PodSubnetsAnnoConfig) String() string {
-	if in == nil {
-		return "nil"
-	}
-
-	repeatedStringForSubnetName := "[]SubnetName{"
-	for _, f := range in.SubnetName {
-		repeatedStringForSubnetName += strings.Replace(strings.Replace(f.String(), "AnnoSubnetItems", "", 1), `&`, ``, 1) + ","
-	}
-	repeatedStringForSubnetName += "}"
-
-	s := strings.Join([]string{`&PodSubnetsAnnoConfig`,
-		`SubnetName:` + repeatedStringForSubnetName + `,`,
-		`FlexibleIPNum:` + spiderpoolv1.ValueToStringGenerated(in.FlexibleIPNum) + `,`,
-		`AssignIPNumber:` + fmt.Sprintf("%v", in.AssignIPNum) + `,`,
-		`ReclaimIPPool:` + fmt.Sprintf("%v", in.ReclaimIPPool),
-		`}`,
-	}, "")
-	return s
-}
-
-func SubnetPoolName(controllerKind, controllerNS, controllerName string, ipVersion types.IPVersion, controllerUID apitypes.UID) string {
-	// the format of uuid is "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+func SubnetPoolName(controllerKind, controllerNS, controllerName string, ipVersion types.IPVersion, ifName string, controllerUID apitypes.UID) string {
+	// the format of uuid is "xxxxxxxx-xxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 	// ref: https://github.com/google/uuid/blob/44b5fee7c49cf3bcdf723f106b36d56ef13ccc88/uuid.go#L185
 	splits := strings.Split(string(controllerUID), "-")
 	lastOne := splits[len(splits)-1]
 
-	return fmt.Sprintf("auto-%s-%s-%s-v%d-%s",
-		strings.ToLower(controllerKind), strings.ToLower(controllerNS), strings.ToLower(controllerName), ipVersion, strings.ToLower(lastOne))
+	return fmt.Sprintf("auto-%s-%s-%s-v%d-%s-%s",
+		strings.ToLower(controllerKind), strings.ToLower(controllerNS), strings.ToLower(controllerName), ipVersion, ifName, strings.ToLower(lastOne))
 }
 
 // AppLabelValue will joint the application type, namespace and name as a label value, then we need unpack it for tracing
@@ -163,27 +88,20 @@ func GenSubnetFreeIPs(subnet *spiderpoolv1.SpiderSubnet) ([]net.IP, error) {
 // GetSubnetAnnoConfig generates SpiderSubnet configuration from pod annotation,
 // if the pod doesn't have the related subnet annotation but has IPPools/IPPool relative annotation it will return nil.
 // If the pod doesn't have any subnet/ippool annotations, it will use the cluster default subnet configuration.
-func GetSubnetAnnoConfig(podAnnotations map[string]string, log *zap.Logger) (*PodSubnetAnnoConfig, error) {
-	var subnetAnnoConfig PodSubnetAnnoConfig
+func GetSubnetAnnoConfig(podAnnotations map[string]string, log *zap.Logger) (*types.PodSubnetAnnoConfig, error) {
+	var subnetAnnoConfig types.PodSubnetAnnoConfig
 
 	// annotation: ipam.spidernet.io/subnets
 	subnets, ok := podAnnotations[constant.AnnoSpiderSubnets]
 	if ok {
 		log.Sugar().Debugf("found SpiderSubnet feature annotation '%s' value '%s'", constant.AnnoSpiderSubnets, subnets)
-		var subnetsItems []AnnoSubnetItems
-		err := json.Unmarshal([]byte(subnets), &subnetsItems)
+		err := json.Unmarshal([]byte(subnets), &subnetAnnoConfig.MultipleSubnets)
 		if nil != err {
 			return nil, fmt.Errorf("failed to parse anntation '%s' value '%s', error: %v", constant.AnnoSpiderSubnets, subnets, err)
 		}
-		if len(subnetsItems) == 0 {
-			return nil, fmt.Errorf("%w: annotation '%s' value requires at least one item", ErrorAnnoInput, constant.AnnoSpiderSubnets)
-		}
-
-		// the present version, we just only support to use one network Interface with SpiderSubnet feature
-		firstSubnetItem := subnetsItems[0]
-		subnetAnnoConfig.SubnetName = firstSubnetItem
 	} else {
 		// annotation: ipam.spidernet.io/subnet
+		subnetAnnoConfig.SingleSubnet = new(types.AnnoSubnetItem)
 		subnet, ok := podAnnotations[constant.AnnoSpiderSubnet]
 		if !ok {
 			// default IPAM mode
@@ -197,23 +115,16 @@ func GetSubnetAnnoConfig(podAnnotations map[string]string, log *zap.Logger) (*Po
 			// default cluster subnet
 			log.Sugar().Infof("no IPPool or Subnet annotations found, use cluster default subnet IPv4: '%v', IPv6: '%v'",
 				singletons.ClusterDefaultPool.ClusterDefaultIPv4Subnet, singletons.ClusterDefaultPool.ClusterDefaultIPv6Subnet)
-			subnetAnnoConfig.SubnetName.IPv4 = singletons.ClusterDefaultPool.ClusterDefaultIPv4Subnet
-			subnetAnnoConfig.SubnetName.IPv6 = singletons.ClusterDefaultPool.ClusterDefaultIPv6Subnet
+
+			subnetAnnoConfig.SingleSubnet.IPv4 = singletons.ClusterDefaultPool.ClusterDefaultIPv4Subnet
+			subnetAnnoConfig.SingleSubnet.IPv6 = singletons.ClusterDefaultPool.ClusterDefaultIPv6Subnet
 		} else {
 			log.Sugar().Debugf("found SpiderSubnet feature annotation '%s' value '%s'", constant.AnnoSpiderSubnet, subnets)
-			err := json.Unmarshal([]byte(subnet), &subnetAnnoConfig.SubnetName)
+			err := json.Unmarshal([]byte(subnet), &subnetAnnoConfig.SingleSubnet)
 			if nil != err {
 				return nil, fmt.Errorf("failed to parse anntation '%s' value '%s', error: %v", constant.AnnoSpiderSubnet, subnet, err)
 			}
 		}
-	}
-
-	// the present version, we just only support one SpiderSubnet object to choose
-	if len(subnetAnnoConfig.SubnetName.IPv4) > 1 {
-		subnetAnnoConfig.SubnetName.IPv4 = []string{subnetAnnoConfig.SubnetName.IPv4[0]}
-	}
-	if len(subnetAnnoConfig.SubnetName.IPv6) > 1 {
-		subnetAnnoConfig.SubnetName.IPv6 = []string{subnetAnnoConfig.SubnetName.IPv6[0]}
 	}
 
 	var isFlexible bool
@@ -226,12 +137,12 @@ func GetSubnetAnnoConfig(podAnnotations map[string]string, log *zap.Logger) (*Po
 		log.Sugar().Debugf("use IPPool IP number '%s'", poolIPNum)
 		isFlexible, ipNum, err = getPoolIPNumber(poolIPNum)
 		if nil != err {
-			return nil, fmt.Errorf("%w: %v", ErrorAnnoInput, err)
+			return nil, err
 		}
 
 		// check out negative number
 		if ipNum < 0 {
-			return nil, fmt.Errorf("%w: subnet '%s' value must equal or greater than 0", ErrorAnnoInput, constant.AnnoSpiderSubnetPoolIPNumber)
+			return nil, fmt.Errorf("subnet '%s' value must equal or greater than 0", constant.AnnoSpiderSubnetPoolIPNumber)
 		}
 
 		if isFlexible {
@@ -242,8 +153,8 @@ func GetSubnetAnnoConfig(podAnnotations map[string]string, log *zap.Logger) (*Po
 	} else {
 		// no annotation "ipam.spidernet.io/ippool-ip-number", we'll use the configmap clusterDefaultSubnetFlexibleIPNumber
 		log.Sugar().Debugf("no specified IPPool IP number, default to use cluster default subnet flexible IP number: %d",
-			singletons.ClusterDefaultPool.ClusterDefaultSubnetFlexibleIPNumber)
-		subnetAnnoConfig.FlexibleIPNum = pointer.Int(singletons.ClusterDefaultPool.ClusterDefaultSubnetFlexibleIPNumber)
+			singletons.ClusterDefaultPool.ClusterSubnetDefaultFlexibleIPNumber)
+		subnetAnnoConfig.FlexibleIPNum = pointer.Int(singletons.ClusterDefaultPool.ClusterSubnetDefaultFlexibleIPNumber)
 	}
 
 	// annotation: "ipam.spidernet.io/reclaim-ippool", reclaim IPPool or not (default true)
@@ -252,7 +163,7 @@ func GetSubnetAnnoConfig(podAnnotations map[string]string, log *zap.Logger) (*Po
 		log.Sugar().Debugf("determine to reclaim IPPool '%s'", reclaimPool)
 		parseBool, err := strconv.ParseBool(reclaimPool)
 		if nil != err {
-			return nil, fmt.Errorf("%w: failed to parse spider subnet '%s', error: %v", ErrorAnnoInput, constant.AnnoSpiderSubnetReclaimIPPool, err)
+			return nil, fmt.Errorf("failed to parse spider subnet '%s', error: %v", constant.AnnoSpiderSubnetReclaimIPPool, err)
 		}
 		subnetAnnoConfig.ReclaimIPPool = parseBool
 	} else {
@@ -260,7 +171,72 @@ func GetSubnetAnnoConfig(podAnnotations map[string]string, log *zap.Logger) (*Po
 		subnetAnnoConfig.ReclaimIPPool = true
 	}
 
+	err = mutateAndValidateSubnetAnno(&subnetAnnoConfig)
+	if nil != err {
+		return nil, err
+	}
+
 	return &subnetAnnoConfig, nil
+}
+
+// mutateAndValidateSubnetAnno will filter multiple subnets you specified and only leaves you the first one to use.
+// And it also checks Interface name or subnets you specified whether are duplicate.
+func mutateAndValidateSubnetAnno(subnetConfig *types.PodSubnetAnnoConfig) error {
+	// the present version, we just only support one SpiderSubnet object to choose
+	if len(subnetConfig.MultipleSubnets) != 0 {
+		var v4SubnetsArray, v6SubnetsArray []string
+		var ifNameArray []string
+
+		for index := range subnetConfig.MultipleSubnets {
+			if len(subnetConfig.MultipleSubnets[index].IPv4) != 0 {
+				subnetConfig.MultipleSubnets[index].IPv4 = []string{subnetConfig.MultipleSubnets[index].IPv4[0]}
+				if subnetConfig.MultipleSubnets[index].IPv4[0] == "" {
+					return fmt.Errorf("it's invalid to set an empty IPv4 subnet with mutilple interfaces")
+				}
+				v4SubnetsArray = append(v4SubnetsArray, subnetConfig.MultipleSubnets[index].IPv4[0])
+			}
+			if len(subnetConfig.MultipleSubnets[index].IPv6) != 0 {
+				subnetConfig.MultipleSubnets[index].IPv6 = []string{subnetConfig.MultipleSubnets[index].IPv6[0]}
+				if subnetConfig.MultipleSubnets[index].IPv6[0] == "" {
+					return fmt.Errorf("it's invalid to set an empty IPv6 subnet with mutilple interfaces")
+				}
+				v6SubnetsArray = append(v6SubnetsArray, subnetConfig.MultipleSubnets[index].IPv6[0])
+			}
+
+			ifNameArray = append(ifNameArray, subnetConfig.MultipleSubnets[index].Interface)
+		}
+
+		// validate duplicate subnet
+		if containsDuplicate(v4SubnetsArray) || containsDuplicate(v6SubnetsArray) {
+			return fmt.Errorf("it's invalid to use the same subnet for multiple interfaces: %v", subnetConfig)
+		}
+
+		// validate duplicate interface
+		if containsDuplicate(ifNameArray) {
+			return fmt.Errorf("it's invalid to use the same Interface name for multiple interfaces: %v", subnetConfig)
+		}
+	} else if subnetConfig.SingleSubnet != nil {
+		if len(subnetConfig.SingleSubnet.IPv4) != 0 {
+			subnetConfig.SingleSubnet.IPv4 = []string{subnetConfig.SingleSubnet.IPv4[0]}
+			if subnetConfig.SingleSubnet.IPv4[0] == "" {
+				return fmt.Errorf("it's invalid to set an empty IPv4 subnet with single interface")
+			}
+		}
+		if len(subnetConfig.SingleSubnet.IPv6) != 0 {
+			subnetConfig.SingleSubnet.IPv6 = []string{subnetConfig.SingleSubnet.IPv6[0]}
+			if subnetConfig.SingleSubnet.IPv6[0] == "" {
+				return fmt.Errorf("it's invalid to set an empty IPv6 subnet with single interface")
+			}
+		}
+		// specify 'eth0' as the default single interface if it's none.
+		if subnetConfig.SingleSubnet.Interface == "" {
+			subnetConfig.SingleSubnet.Interface = constant.ClusterDefaultInterfaceName
+		}
+	} else {
+		return fmt.Errorf("no subnets specified: %v", subnetConfig)
+	}
+
+	return nil
 }
 
 // getPoolIPNumber judges the given parameter is fixed or flexible
@@ -320,4 +296,35 @@ func CalculateJobPodNum(jobSpecParallelism, jobSpecCompletions *int32) int {
 	}
 
 	return 1
+}
+
+// IsDefaultIPPoolMode judges whether we use subnet feature or not with the given parameter types.PodSubnetAnnoConfig
+func IsDefaultIPPoolMode(subnetConfig *types.PodSubnetAnnoConfig) bool {
+	if subnetConfig == nil {
+		return true
+	}
+
+	if len(subnetConfig.MultipleSubnets) != 0 {
+		return false
+	}
+
+	// if we do not set the cluster default SpiderSubnet, the dual stack subnets configuration will be empty
+	if subnetConfig.SingleSubnet != nil {
+		if len(subnetConfig.SingleSubnet.IPv4) == 0 && len(subnetConfig.SingleSubnet.IPv6) == 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+// containsDuplicate checks whether the given string array has the duplicate element
+func containsDuplicate(arr []string) bool {
+	sort.Strings(arr)
+	for i := 1; i < len(arr); i++ {
+		if arr[i] == arr[i-1] {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/subnetmanager/subnet_manager.go
+++ b/pkg/subnetmanager/subnet_manager.go
@@ -210,7 +210,7 @@ func (sm *subnetManager) GenerateIPsFromSubnetWhenScaleUpIP(ctx context.Context,
 // AllocateEmptyIPPool will create an empty IPPool and mark the status.AutoDesiredIPCount
 // notice: this function only serves for auto-created IPPool
 func (sm *subnetManager) AllocateEmptyIPPool(ctx context.Context, subnetName string, appKind string, app metav1.Object, podSelector map[string]string,
-	ipNum int, ipVersion types.IPVersion, reclaimIPPool bool) error {
+	ipNum int, ipVersion types.IPVersion, reclaimIPPool bool, ifName string) error {
 	if len(subnetName) == 0 {
 		return fmt.Errorf("%w: spider subnet name must be specified", constant.ErrWrongInput)
 	}
@@ -231,6 +231,7 @@ func (sm *subnetManager) AllocateEmptyIPPool(ctx context.Context, subnetName str
 		constant.LabelIPPoolOwnerSpiderSubnet:   subnet.Name,
 		constant.LabelIPPoolOwnerApplication:    controllers.AppLabelValue(appKind, app.GetNamespace(), app.GetName()),
 		constant.LabelIPPoolOwnerApplicationUID: string(app.GetUID()),
+		constant.LabelIPPoolInterface:           ifName,
 	}
 
 	if ipVersion == constant.IPv4 {
@@ -245,7 +246,7 @@ func (sm *subnetManager) AllocateEmptyIPPool(ctx context.Context, subnetName str
 
 	sp := &spiderpoolv1.SpiderIPPool{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   controllers.SubnetPoolName(appKind, app.GetNamespace(), app.GetName(), ipVersion, app.GetUID()),
+			Name:   controllers.SubnetPoolName(appKind, app.GetNamespace(), app.GetName(), ipVersion, ifName, app.GetUID()),
 			Labels: poolLabels,
 		},
 		Spec: spiderpoolv1.IPPoolSpec{

--- a/pkg/subnetmanager/types/interface.go
+++ b/pkg/subnetmanager/types/interface.go
@@ -22,7 +22,7 @@ type SubnetManager interface {
 	GetSubnetByName(ctx context.Context, subnetName string) (*spiderpoolv1.SpiderSubnet, error)
 	ListSubnets(ctx context.Context, opts ...client.ListOption) (*spiderpoolv1.SpiderSubnetList, error)
 	SetupControllers(client kubernetes.Interface) error
-	AllocateEmptyIPPool(ctx context.Context, subnetMgrName string, appKind string, app metav1.Object, podSelector map[string]string, ipNum int, ipVersion types.IPVersion, reclaimIPPool bool) error
+	AllocateEmptyIPPool(ctx context.Context, subnetMgrName string, appKind string, app metav1.Object, podSelector map[string]string, ipNum int, ipVersion types.IPVersion, reclaimIPPool bool, ifName string) error
 	CheckScaleIPPool(ctx context.Context, pool *spiderpoolv1.SpiderIPPool, subnetManagerName string, ipNum int) error
 	GenerateIPsFromSubnetWhenScaleUpIP(ctx context.Context, subnetName string, pool *spiderpoolv1.SpiderIPPool, cursor bool) ([]string, error)
 }

--- a/pkg/types/k8s.go
+++ b/pkg/types/k8s.go
@@ -38,3 +38,11 @@ type AnnoPodAssignedEthxValue struct {
 type AnnoNSDefautlV4PoolValue []string
 
 type AnnoNSDefautlV6PoolValue []string
+
+type ClusterDefaultPoolConfig struct {
+	ClusterDefaultIPv4IPPool             []string
+	ClusterDefaultIPv6IPPool             []string
+	ClusterDefaultIPv4Subnet             []string
+	ClusterDefaultIPv6Subnet             []string
+	ClusterDefaultSubnetFlexibleIPNumber int
+}

--- a/pkg/types/k8s.go
+++ b/pkg/types/k8s.go
@@ -44,5 +44,20 @@ type ClusterDefaultPoolConfig struct {
 	ClusterDefaultIPv6IPPool             []string
 	ClusterDefaultIPv4Subnet             []string
 	ClusterDefaultIPv6Subnet             []string
-	ClusterDefaultSubnetFlexibleIPNumber int
+	ClusterSubnetDefaultFlexibleIPNumber int
+}
+
+type PodSubnetAnnoConfig struct {
+	MultipleSubnets []AnnoSubnetItem
+	SingleSubnet    *AnnoSubnetItem
+	FlexibleIPNum   *int
+	AssignIPNum     int
+	ReclaimIPPool   bool
+}
+
+// AnnoSubnetItem describes the SpiderSubnet CR names and NIC
+type AnnoSubnetItem struct {
+	Interface string   `json:"interface,omitempty"`
+	IPv4      []string `json:"ipv4,omitempty"`
+	IPv6      []string `json:"ipv6,omitempty"`
 }

--- a/pkg/types/types_string.go
+++ b/pkg/types/types_string.go
@@ -1,0 +1,49 @@
+// Copyright 2022 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+func valueToStringGenerated(v interface{}) string {
+	rv := reflect.ValueOf(v)
+	if rv.IsNil() {
+		return "nil"
+	}
+	pv := reflect.Indirect(rv).Interface()
+	return fmt.Sprintf("*%v", pv)
+}
+
+func (in *PodSubnetAnnoConfig) String() string {
+	if in == nil {
+		return "nil"
+	}
+
+	s := strings.Join([]string{`&PodSubnetAnnoConfig{`,
+		`MultipleSubnets` + fmt.Sprintf("%v", in.MultipleSubnets),
+		`SingleSubnet:` + strings.Replace(strings.Replace(in.SingleSubnet.String(), "AnnoSubnetItem", "", 1), `&`, ``, 1) + `,`,
+		`FlexibleIPNum:` + valueToStringGenerated(in.FlexibleIPNum) + `,`,
+		`AssignIPNumber:` + fmt.Sprintf("%v", in.AssignIPNum) + `,`,
+		`ReclaimIPPool:` + fmt.Sprintf("%v", in.ReclaimIPPool),
+		`}`,
+	}, "")
+	return s
+}
+
+func (in *AnnoSubnetItem) String() string {
+	if in == nil {
+		return "nil"
+	}
+
+	s := strings.Join([]string{`&AnnoSubnetItem{`,
+		`Interface:` + fmt.Sprintf("%v", in.Interface) + `,`,
+		`IPv4:` + fmt.Sprintf("%v", in.IPv4) + `,`,
+		`IPv6:` + fmt.Sprintf("%v", in.IPv6),
+		`}`,
+	}, "")
+	return s
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -59,7 +59,7 @@ endif
 		MULTUS_CNI_NAMESPACE=$(MULTUS_CNI_NAMESPACE) \
 		MULTUS_ADDITIONAL_CNI_NAME=$(MULTUS_ADDITIONAL_CNI_NAME) \
 		MULTUS_DEFAULT_CNI_NAME=$(MULTUS_DEFAULT_CNI_NAME) \
-		scripts/installTestPod.sh $(E2E_KUBECONFIG)
+		scripts/installTestPod.sh $(E2E_KUBECONFIG) $(E2E_SPIDERPOOL_ENABLE_SUBNET)
 	@echo ""
 	@echo "-----------------------------------------------------------------------------------------------------"
 	@echo "       ip family: $(E2E_IP_FAMILY)"

--- a/test/e2e/reservedip/reservedip_test.go
+++ b/test/e2e/reservedip/reservedip_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/spidernet-io/e2eframework/tools"
 	"github.com/spidernet-io/spiderpool/pkg/constant"
-	subnetmanager "github.com/spidernet-io/spiderpool/pkg/subnetmanager/controllers"
+	"github.com/spidernet-io/spiderpool/pkg/types"
 	"github.com/spidernet-io/spiderpool/test/e2e/common"
 )
 
@@ -132,7 +132,7 @@ var _ = Describe("test reservedIP", Label("reservedIP"), func() {
 
 			// I00011: The subnet automatically creates an ippool and allocates IP, and should consider reservedIP
 			if frame.Info.SpiderSubnetEnabled {
-				subnetAnno := subnetmanager.AnnoSubnetItems{}
+				subnetAnno := types.AnnoSubnetItem{}
 				if frame.Info.IpV4Enabled {
 					subnetAnno.IPv4 = []string{v4SubnetName}
 				}

--- a/test/e2e/subnet/subnet_test.go
+++ b/test/e2e/subnet/subnet_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/spidernet-io/spiderpool/pkg/ip"
 	spiderpool "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v1"
 	"github.com/spidernet-io/spiderpool/pkg/lock"
-	subnetmanager "github.com/spidernet-io/spiderpool/pkg/subnetmanager/controllers"
 	"github.com/spidernet-io/spiderpool/pkg/types"
 	"github.com/spidernet-io/spiderpool/test/e2e/common"
 	appsv1 "k8s.io/api/apps/v1"
@@ -102,7 +101,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 
 		It("Validate competition for simultaneous creation, expansion, and deletion", Serial, Label("I00006", "I00008"), func() {
 			// Create deployments in bulk in a subnet
-			subnetAnno := subnetmanager.AnnoSubnetItems{}
+			subnetAnno := types.AnnoSubnetItem{}
 			if frame.Info.IpV4Enabled {
 				subnetAnno.IPv4 = []string{v4SubnetName}
 			}
@@ -284,7 +283,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 				deployPatchReplicasNum  int32  = 2
 			)
 
-			subnetAnno := subnetmanager.AnnoSubnetItems{}
+			subnetAnno := types.AnnoSubnetItem{}
 			if frame.Info.IpV4Enabled {
 				subnetAnno.IPv4 = []string{v4SubnetName}
 			}
@@ -508,7 +507,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 			ipv4Gw := strings.Split(v4SubnetObject.Spec.Subnet, "0/")[0] + "1"
 			v6Dst := "::/0"
 			ipv6Gw := strings.Split(v6SubnetObject.Spec.Subnet, "/")[0] + "1"
-			subnetAnno := subnetmanager.AnnoSubnetItems{}
+			subnetAnno := types.AnnoSubnetItem{}
 			if frame.Info.IpV4Enabled {
 				*v4Ipversion = int64(4)
 				if i, err := strconv.Atoi(common.GenerateRandomNumber(4095)); err != nil {
@@ -758,7 +757,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 		})
 
 		It("Automatically create multiple ippools that can not use the same network segment and use IPs other than excludeIPs. ", Label("I00004", "S00004"), func() {
-			subnetAnno := subnetmanager.AnnoSubnetItems{}
+			subnetAnno := types.AnnoSubnetItem{}
 			// ExcludeIPs cannot be used by ippools that are created automatically
 			if frame.Info.IpV4Enabled {
 				v4SubnetObject.Spec.ExcludeIPs = v4SubnetObject.Spec.IPs

--- a/test/scripts/installTestPod.sh
+++ b/test/scripts/installTestPod.sh
@@ -4,11 +4,13 @@
 # Copyright Authors of Spider
 
 E2E_KUBECONFIG="$1"
+E2E_SPIDERPOOL_ENABLE_SUBNET="$2"
 
 [ -z "$E2E_KUBECONFIG" ] && echo "error, miss E2E_KUBECONFIG " && exit 1
 [ ! -f "$E2E_KUBECONFIG" ] && echo "error, could not find file $E2E_KUBECONFIG " && exit 1
 echo "$CURRENT_FILENAME : E2E_KUBECONFIG $E2E_KUBECONFIG "
 
+[ -z "$E2E_SPIDERPOOL_ENABLE_SUBNET" ] && echo "not found E2E_SPIDERPOOL_ENABLE_SUBNET, default to set it false " &&  E2E_SPIDERPOOL_ENABLE_SUBNET=false
 
 NAME=test-pod
 cat <<EOF | kubectl apply --kubeconfig ${E2E_KUBECONFIG} -f -
@@ -27,7 +29,9 @@ spec:
   template:
     metadata:
       annotations:
-        k8s.v1.cni.cncf.io/networks: ${MULTUS_CNI_NAMESPACE}/${MULTUS_ADDITIONAL_CNI_NAME}
+        $(if [[ "${E2E_SPIDERPOOL_ENABLE_SUBNET}" == "false" ]];then
+        echo "k8s.v1.cni.cncf.io/networks: ${MULTUS_CNI_NAMESPACE}/${MULTUS_ADDITIONAL_CNI_NAME}"
+        fi)
       name: $NAME
       labels:
         app: $NAME


### PR DESCRIPTION
⚠️⚠️⚠️ This change is make it incompatible with the previous release version
(We add another label for auto-created IPPool, which ipam and spiderpool-controller will rely on it.)
⚠️⚠️⚠️ For upgrade pre-steps, please check [upgrade.md](https://github.com/spidernet-io/spiderpool/blob/b73c976609b0f7bf7ca4581db2973cb6ab4aa6ce/docs/develop/upgrade.md)


1. Add cluster default subnet support. Once we use SpiderSubnet feature, we can set no other annotations for the application and it will use SpiderSubnet with ClusterDefaultSubnet which is specified in the configmap. (only support single Interface)
2. Add SpiderSubnet multiple Interface support.
3. Update SpiderSubnet usage document.

Signed-off-by: Icarus9913 <icaruswu66@qq.com>


**What this PR does / why we need it**:
new feature

