### PR TITLE
fix potential panic with SpiderSubnet feature

### DIFF
--- a/pkg/subnetmanager/app_controller.go
+++ b/pkg/subnetmanager/app_controller.go
@@ -607,7 +607,7 @@ func (c *appController) syncHandler(appKey appWorkQueueKey, log *zap.Logger) (er
 
 	var app metav1.Object
 	var subnetConfig *types.PodSubnetAnnoConfig
-	var podAnno, podSelector map[string]string
+	var podAnno map[string]string
 	var appReplicas int
 
 	switch appKey.AppKind {
@@ -622,7 +622,6 @@ func (c *appController) syncHandler(appKey appWorkQueueKey, log *zap.Logger) (er
 		}
 
 		podAnno = deployment.Spec.Template.Annotations
-		podSelector = deployment.Spec.Selector.MatchLabels
 		appReplicas = controllers.GetAppReplicas(deployment.Spec.Replicas)
 		app = deployment.DeepCopy()
 
@@ -637,7 +636,6 @@ func (c *appController) syncHandler(appKey appWorkQueueKey, log *zap.Logger) (er
 		}
 
 		podAnno = replicaSet.Spec.Template.Annotations
-		podSelector = replicaSet.Spec.Selector.MatchLabels
 		appReplicas = controllers.GetAppReplicas(replicaSet.Spec.Replicas)
 		app = replicaSet.DeepCopy()
 
@@ -652,7 +650,6 @@ func (c *appController) syncHandler(appKey appWorkQueueKey, log *zap.Logger) (er
 		}
 
 		podAnno = daemonSet.Spec.Template.Annotations
-		podSelector = daemonSet.Spec.Selector.MatchLabels
 		appReplicas = int(daemonSet.Status.DesiredNumberScheduled)
 		app = daemonSet.DeepCopy()
 
@@ -667,7 +664,6 @@ func (c *appController) syncHandler(appKey appWorkQueueKey, log *zap.Logger) (er
 		}
 
 		podAnno = statefulSet.Spec.Template.Annotations
-		podSelector = statefulSet.Spec.Selector.MatchLabels
 		appReplicas = controllers.GetAppReplicas(statefulSet.Spec.Replicas)
 		app = statefulSet.DeepCopy()
 
@@ -682,7 +678,6 @@ func (c *appController) syncHandler(appKey appWorkQueueKey, log *zap.Logger) (er
 		}
 
 		podAnno = job.Spec.Template.Annotations
-		podSelector = job.Spec.Selector.MatchLabels
 		appReplicas = controllers.CalculateJobPodNum(job.Spec.Parallelism, job.Spec.Completions)
 		app = job.DeepCopy()
 
@@ -697,7 +692,6 @@ func (c *appController) syncHandler(appKey appWorkQueueKey, log *zap.Logger) (er
 		}
 
 		podAnno = cronJob.Spec.JobTemplate.Spec.Template.Annotations
-		podSelector = cronJob.Spec.JobTemplate.Spec.Selector.MatchLabels
 		appReplicas = controllers.CalculateJobPodNum(cronJob.Spec.JobTemplate.Spec.Parallelism, cronJob.Spec.JobTemplate.Spec.Completions)
 		app = cronJob.DeepCopy()
 
@@ -711,7 +705,7 @@ func (c *appController) syncHandler(appKey appWorkQueueKey, log *zap.Logger) (er
 	}
 
 	log.Debug("Going to create IPPool or mark IPPool desired IP number")
-	err = c.createOrMarkIPPool(logutils.IntoContext(context.TODO(), log), *subnetConfig, appKey.AppKind, app, podSelector, appReplicas)
+	err = c.createOrMarkIPPool(logutils.IntoContext(context.TODO(), log), *subnetConfig, appKey.AppKind, app, appReplicas)
 	if nil != err {
 		return fmt.Errorf("failed to create or scale IPPool, error: %w", err)
 	}
@@ -720,8 +714,8 @@ func (c *appController) syncHandler(appKey appWorkQueueKey, log *zap.Logger) (er
 }
 
 // createOrMarkIPPool try to create an IPPool or mark IPPool desired IP number with the give SpiderSubnet configuration
-func (c *appController) createOrMarkIPPool(ctx context.Context, podSubnetConfig types.PodSubnetAnnoConfig, appKind string, app metav1.Object,
-	podSelector map[string]string, appReplicas int) error {
+func (c *appController) createOrMarkIPPool(ctx context.Context, podSubnetConfig types.PodSubnetAnnoConfig,
+	appKind string, app metav1.Object, appReplicas int) error {
 	log := logutils.FromContext(ctx)
 
 	// retrieve application pools
@@ -738,7 +732,7 @@ func (c *appController) createOrMarkIPPool(ctx context.Context, podSubnetConfig 
 			log.Sugar().Debugf("there's no 'IPv%d' IPPoolList retrieved from SpiderSubent '%s'", ipVersion, subnetName)
 			// create an empty IPPool and mark the desired IP number when the subnet name was specified,
 			// and the IPPool informer will implement the scale action
-			err = c.subnetMgr.AllocateEmptyIPPool(ctx, subnetName, appKind, app, podSelector, ipNum, ipVersion, podSubnetConfig.ReclaimIPPool, ifName)
+			err = c.subnetMgr.AllocateEmptyIPPool(ctx, subnetName, appKind, app, ipNum, ipVersion, podSubnetConfig.ReclaimIPPool, ifName)
 		} else if len(poolList.Items) == 1 {
 			pool := poolList.Items[0]
 			log.Sugar().Debugf("found SpiderSubnet '%s' IPPool '%s' and check it whether need to be scaled", subnetName, pool.Name)

--- a/pkg/subnetmanager/subnet_manager.go
+++ b/pkg/subnetmanager/subnet_manager.go
@@ -209,7 +209,7 @@ func (sm *subnetManager) GenerateIPsFromSubnetWhenScaleUpIP(ctx context.Context,
 
 // AllocateEmptyIPPool will create an empty IPPool and mark the status.AutoDesiredIPCount
 // notice: this function only serves for auto-created IPPool
-func (sm *subnetManager) AllocateEmptyIPPool(ctx context.Context, subnetName string, appKind string, app metav1.Object, podSelector map[string]string,
+func (sm *subnetManager) AllocateEmptyIPPool(ctx context.Context, subnetName string, appKind string, app metav1.Object,
 	ipNum int, ipVersion types.IPVersion, reclaimIPPool bool, ifName string) error {
 	if len(subnetName) == 0 {
 		return fmt.Errorf("%w: spider subnet name must be specified", constant.ErrWrongInput)
@@ -254,9 +254,6 @@ func (sm *subnetManager) AllocateEmptyIPPool(ctx context.Context, subnetName str
 			Gateway: subnet.Spec.Gateway,
 			Vlan:    subnet.Spec.Vlan,
 			Routes:  subnet.Spec.Routes,
-			PodAffinity: &metav1.LabelSelector{
-				MatchLabels: podSelector,
-			},
 		},
 	}
 

--- a/pkg/subnetmanager/types/interface.go
+++ b/pkg/subnetmanager/types/interface.go
@@ -22,7 +22,7 @@ type SubnetManager interface {
 	GetSubnetByName(ctx context.Context, subnetName string) (*spiderpoolv1.SpiderSubnet, error)
 	ListSubnets(ctx context.Context, opts ...client.ListOption) (*spiderpoolv1.SpiderSubnetList, error)
 	SetupControllers(client kubernetes.Interface) error
-	AllocateEmptyIPPool(ctx context.Context, subnetMgrName string, appKind string, app metav1.Object, podSelector map[string]string, ipNum int, ipVersion types.IPVersion, reclaimIPPool bool, ifName string) error
+	AllocateEmptyIPPool(ctx context.Context, subnetMgrName string, appKind string, app metav1.Object, ipNum int, ipVersion types.IPVersion, reclaimIPPool bool, ifName string) error
 	CheckScaleIPPool(ctx context.Context, pool *spiderpoolv1.SpiderIPPool, subnetManagerName string, ipNum int) error
 	GenerateIPsFromSubnetWhenScaleUpIP(ctx context.Context, subnetName string, pool *spiderpoolv1.SpiderIPPool, cursor bool) ([]string, error)
 }


### PR DESCRIPTION
For auto-created IPPool, I think there's no need to inherit the application matchLabel(podAffinity).
Because for IPAM or spiderpool-controller components, we just use the label to search the IPPool and no need podAffinity to do a filter. 

Signed-off-by: Icarus9913 <icaruswu66@qq.com>

**What this PR does / why we need it**:
fix bug

**Which issue(s) this PR fixes**:
https://github.com/spidernet-io/spiderpool/issues/1252
