### PR TITLE
auto-created IPPool podAffinity adjustment

### DIFF
--- a/pkg/subnetmanager/subnet_manager.go
+++ b/pkg/subnetmanager/subnet_manager.go
@@ -210,7 +210,7 @@ func (sm *subnetManager) GenerateIPsFromSubnetWhenScaleUpIP(ctx context.Context,
 // AllocateEmptyIPPool will create an empty IPPool and mark the status.AutoDesiredIPCount
 // notice: this function only serves for auto-created IPPool
 func (sm *subnetManager) AllocateEmptyIPPool(ctx context.Context, subnetName string, appKind string, app metav1.Object,
-	ipNum int, ipVersion types.IPVersion, reclaimIPPool bool, ifName string) error {
+	podSelector *metav1.LabelSelector, ipNum int, ipVersion types.IPVersion, reclaimIPPool bool, ifName string) error {
 	if len(subnetName) == 0 {
 		return fmt.Errorf("%w: spider subnet name must be specified", constant.ErrWrongInput)
 	}
@@ -250,10 +250,11 @@ func (sm *subnetManager) AllocateEmptyIPPool(ctx context.Context, subnetName str
 			Labels: poolLabels,
 		},
 		Spec: spiderpoolv1.IPPoolSpec{
-			Subnet:  subnet.Spec.Subnet,
-			Gateway: subnet.Spec.Gateway,
-			Vlan:    subnet.Spec.Vlan,
-			Routes:  subnet.Spec.Routes,
+			Subnet:      subnet.Spec.Subnet,
+			Gateway:     subnet.Spec.Gateway,
+			Vlan:        subnet.Spec.Vlan,
+			Routes:      subnet.Spec.Routes,
+			PodAffinity: podSelector,
 		},
 	}
 

--- a/pkg/subnetmanager/types/interface.go
+++ b/pkg/subnetmanager/types/interface.go
@@ -22,7 +22,7 @@ type SubnetManager interface {
 	GetSubnetByName(ctx context.Context, subnetName string) (*spiderpoolv1.SpiderSubnet, error)
 	ListSubnets(ctx context.Context, opts ...client.ListOption) (*spiderpoolv1.SpiderSubnetList, error)
 	SetupControllers(client kubernetes.Interface) error
-	AllocateEmptyIPPool(ctx context.Context, subnetMgrName string, appKind string, app metav1.Object, ipNum int, ipVersion types.IPVersion, reclaimIPPool bool, ifName string) error
+	AllocateEmptyIPPool(ctx context.Context, subnetMgrName string, appKind string, app metav1.Object, podSelector *metav1.LabelSelector, ipNum int, ipVersion types.IPVersion, reclaimIPPool bool, ifName string) error
 	CheckScaleIPPool(ctx context.Context, pool *spiderpoolv1.SpiderIPPool, subnetManagerName string, ipNum int) error
 	GenerateIPsFromSubnetWhenScaleUpIP(ctx context.Context, subnetName string, pool *spiderpoolv1.SpiderIPPool, cursor bool) ([]string, error)
 }


### PR DESCRIPTION
After PR [#1242](https://github.com/spidernet-io/spiderpool/pull/1242), we still decide to add application match label for auto-created IPPool.
 
Here's a usage case:
Once we set the `ipam.spidernet.io/ippool-reclaim` with `true`, we can still use this IPPool after the application was deleted.
And we can use the `podAffinity` to bind another application with the corresponding match labels.

Signed-off-by: Icarus9913 <icaruswu66@qq.com>


**What this PR does / why we need it**:
fix bug

**Which issue(s) this PR fixes**:
https://github.com/spidernet-io/spiderpool/pull/1260#issue-1522348860
