### PR TITLE
fix: Occasionally failed to set the correct SpiderSubnet owner ref in the unit test of SpiderIPPool

### DIFF
--- a/cmd/spiderpool-agent/cmd/daemon.go
+++ b/cmd/spiderpool-agent/cmd/daemon.go
@@ -142,6 +142,9 @@ func DaemonMain() {
 		OperationRetries:     agentContext.Cfg.UpdateCRMaxRetries,
 		OperationGapDuration: time.Duration(agentContext.Cfg.WaitSubnetPoolTime) * time.Second,
 	}, agentContext.IPPoolManager, agentContext.EndpointManager, agentContext.NodeManager, agentContext.NSManager, agentContext.PodManager, agentContext.StsManager, agentContext.SubnetManager)
+	if nil != err {
+		logger.Fatal(err.Error())
+	}
 	agentContext.IPAM = ipam
 
 	go func() {

--- a/pkg/ippoolmanager/ippool_mutate.go
+++ b/pkg/ippoolmanager/ippool_mutate.go
@@ -81,6 +81,7 @@ func (iw *IPPoolWebhook) mutateIPPool(ctx context.Context, ipPool *spiderpoolv1.
 func (iw *IPPoolWebhook) setControllerSubnet(ctx context.Context, ipPool *spiderpoolv1.SpiderIPPool) error {
 	logger := logutils.FromContext(ctx)
 
+	// TODO(iiiceoo): There was an occasional bug.
 	owner := metav1.GetControllerOf(ipPool)
 	if v, ok := ipPool.Labels[constant.LabelIPPoolOwnerSpiderSubnet]; ok && owner != nil && v == owner.Name {
 		return nil

--- a/pkg/ippoolmanager/ippool_webhook_test.go
+++ b/pkg/ippoolmanager/ippool_webhook_test.go
@@ -193,11 +193,11 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				ipPoolWebhook.EnableSpiderSubnet = true
 				subnetT.SetUID(uuid.NewUUID())
 				subnetT.Spec.IPVersion = pointer.Int64(constant.IPv4)
-				subnetT.Spec.Subnet = "172.18.40.0/24"
+				subnetT.Spec.Subnet = "172.18.50.0/24"
 				subnetT.Spec.IPs = append(subnetT.Spec.IPs,
 					[]string{
-						"172.18.40.1-172.18.40.2",
-						"172.18.40.10",
+						"172.18.50.1-172.18.50.2",
+						"172.18.50.10",
 					}...,
 				)
 
@@ -206,7 +206,7 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				ipPoolT.Spec.IPVersion = pointer.Int64(constant.IPv4)
-				ipPoolT.Spec.Subnet = "172.18.40.0/24"
+				ipPoolT.Spec.Subnet = "172.18.50.0/24"
 
 				err = ipPoolWebhook.Default(ctx, ipPoolT)
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Signed-off-by: iiiceoo <ziqian.xue@daocloud.io>