### PR TITLE
SpiderSubnet feature app operator refactor

### DIFF
--- a/cmd/spiderpool-controller/cmd/config.go
+++ b/cmd/spiderpool-controller/cmd/config.go
@@ -81,7 +81,6 @@ var envInfo = []envConf{
 	{"GIT_COMMIT_VERSION", "", false, &controllerContext.Cfg.CommitVersion, nil, nil},
 	{"GIT_COMMIT_TIME", "", false, &controllerContext.Cfg.CommitTime, nil, nil},
 	{"VERSION", "", false, &controllerContext.Cfg.AppVersion, nil, nil},
-	{"SPIDERPOOL_ENABLE_SUBNET_DELETE_STALE_IPPOOL", "false", true, nil, &controllerContext.Cfg.EnableSubnetDeleteStaleIPPool, nil},
 	{"SPIDERPOOL_AUTO_IPPOOL_HANDLER_MAX_WORKQUEUE_LENGTH", "10000", true, nil, nil, &controllerContext.Cfg.IPPoolInformerMaxWorkQueueLength},
 	{"SPIDERPOOL_WORKQUEUE_RETRY_DELAY_DURATION", "5", true, nil, nil, &controllerContext.Cfg.WorkQueueRequeueDelayDuration},
 	{"SPIDERPOOL_IPPOOL_INFORMER_WORKERS", "3", true, nil, nil, &controllerContext.Cfg.IPPoolInformerWorkers},
@@ -102,9 +101,8 @@ type Config struct {
 	TlsServerKeyPath  string
 
 	// env
-	LogLevel                      string
-	EnabledMetric                 bool
-	EnableSubnetDeleteStaleIPPool bool
+	LogLevel      string
+	EnabledMetric bool
 
 	HttpPort       string
 	MetricHttpPort string

--- a/pkg/metric/metrics_instance.go
+++ b/pkg/metric/metrics_instance.go
@@ -47,6 +47,10 @@ const (
 	ip_gc_failure_counts = "ip_gc_failure_counts"
 
 	subnet_ippool_counts = "subnet_ippool_counts"
+
+	// spiderpool controller SpiderSubnet feature
+	auto_ippool_create_or_mark_conflict_counts = "auto_ippool_create_or_mark_conflict_counts"
+	ippool_informer_conflict_counts            = "ippool_informer_conflict_counts"
 )
 
 var (
@@ -82,6 +86,10 @@ var (
 	IPGCFailureCounts instrument.Int64Counter
 
 	SubnetPoolCounts = new(asyncInt64Gauge)
+
+	// spiderpool controller SpiderSubnet feature
+	AutoPoolCreateOrMarkConflictCounts instrument.Int64Counter
+	IPPoolInformerConflictCounts       instrument.Int64Counter
 )
 
 // asyncFloat64Gauge is custom otel float64 gauge
@@ -361,8 +369,22 @@ func InitSpiderpoolControllerMetrics(ctx context.Context) error {
 		return err
 	}
 
+	autoPoolCreateOrMarkConflictCounts, err := NewMetricInt64Counter(auto_ippool_create_or_mark_conflict_counts, "create or mark auto-created IPPool conflict counts")
+	if nil != err {
+		return fmt.Errorf("failed to new spiderpool controller metric '%s', error: %v", auto_ippool_create_or_mark_conflict_counts, err)
+	}
+	AutoPoolCreateOrMarkConflictCounts = autoPoolCreateOrMarkConflictCounts
+
+	poolInformerConflictCounts, err := NewMetricInt64Counter(ippool_informer_conflict_counts, "ippool informer operation conflict counts")
+	if nil != err {
+		return fmt.Errorf("failed to new spiderpool controller metric '%s', error: %v", ippool_informer_conflict_counts, err)
+	}
+	IPPoolInformerConflictCounts = poolInformerConflictCounts
+
 	IPGCTotalCounts.Add(ctx, 0)
 	IPGCFailureCounts.Add(ctx, 0)
+	AutoPoolCreateOrMarkConflictCounts.Add(ctx, 0)
+	IPPoolInformerConflictCounts.Add(ctx, 0)
 
 	return nil
 }

--- a/pkg/subnetmanager/config.go
+++ b/pkg/subnetmanager/config.go
@@ -4,19 +4,9 @@
 package subnetmanager
 
 import (
-	"time"
-
 	"github.com/spidernet-io/spiderpool/pkg/config"
 )
 
 type SubnetManagerConfig struct {
-	EnableIPv4 bool
-	EnableIPv6 bool
-
 	config.UpdateCRConfig
-	EnableSubnetDeleteStaleIPPool bool
-	LeaderRetryElectGap           time.Duration
-	RequeueDelayDuration          time.Duration
-	AppControllerWorkers          int
-	MaxWorkqueueLength            int
 }

--- a/pkg/subnetmanager/controllers/controller.go
+++ b/pkg/subnetmanager/controllers/controller.go
@@ -20,7 +20,7 @@ type Controller struct {
 	cleanupFunc   APPInformersDelFunc
 }
 
-func NewSubnetController(reconcile AppInformersAddOrUpdateFunc, cleanup APPInformersDelFunc, logger *zap.Logger) (*Controller, error) {
+func NewApplicationController(reconcile AppInformersAddOrUpdateFunc, cleanup APPInformersDelFunc, logger *zap.Logger) (*Controller, error) {
 	if reconcile == nil {
 		return nil, fmt.Errorf("the controllers informers reconcile function must be specified")
 	}

--- a/pkg/subnetmanager/controllers/utils.go
+++ b/pkg/subnetmanager/controllers/utils.go
@@ -319,7 +319,7 @@ func containsDuplicate(arr []string) bool {
 	return false
 }
 
-// ShouldReclaimIPPool
+// ShouldReclaimIPPool will check pod annotation "ipam.spidernet.io/ippool-reclaim"
 func ShouldReclaimIPPool(anno map[string]string) (bool, error) {
 	reclaimPool, ok := anno[constant.AnnoSpiderSubnetReclaimIPPool]
 	if ok {


### PR DESCRIPTION
1. Decouple application operation for creating auto-created IPPools with SubnetManager.
2. Remove deleting stale auto-created ippool operation with SpiderSubnet feature
3. Add auto-created IPPool creation/mark operation conflicts and ippool informer operation conflicts metrics

Signed-off-by: Icarus9913 <icaruswu66@qq.com>
