### PR TITLE
aggreate orphan pod auto-created IPPools deletion operation with SpiderSubnet feature

### DIFF
--- a/charts/spiderpool/templates/role.yaml
+++ b/charts/spiderpool/templates/role.yaml
@@ -86,6 +86,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch

--- a/pkg/ippoolmanager/ippool_manager.go
+++ b/pkg/ippoolmanager/ippool_manager.go
@@ -31,8 +31,7 @@ type IPPoolManager interface {
 	AllocateIP(ctx context.Context, poolName, containerID, nic string, pod *corev1.Pod, podController types.PodTopController) (*models.IPConfig, error)
 	ReleaseIP(ctx context.Context, poolName string, ipAndCIDs []types.IPAndCID) error
 	UpdateAllocatedIPs(ctx context.Context, poolName string, ipAndCIDs []types.IPAndCID) error
-	CreateIPPool(ctx context.Context, pool *spiderpoolv1.SpiderIPPool) error
-	DeleteIPPool(ctx context.Context, pool *spiderpoolv1.SpiderIPPool) error
+	DeleteAllIPPools(ctx context.Context, pool *spiderpoolv1.SpiderIPPool, opts ...client.DeleteAllOfOption) error
 	UpdateDesiredIPNumber(ctx context.Context, pool *spiderpoolv1.SpiderIPPool, ipNum int) error
 }
 
@@ -283,8 +282,8 @@ func (im *ipPoolManager) CreateIPPool(ctx context.Context, pool *spiderpoolv1.Sp
 	return nil
 }
 
-func (im *ipPoolManager) DeleteIPPool(ctx context.Context, pool *spiderpoolv1.SpiderIPPool) error {
-	err := im.client.Delete(ctx, pool)
+func (im *ipPoolManager) DeleteAllIPPools(ctx context.Context, pool *spiderpoolv1.SpiderIPPool, opts ...client.DeleteAllOfOption) error {
+	err := im.client.DeleteAllOf(ctx, pool, opts...)
 	if client.IgnoreNotFound(err) != nil {
 		return err
 	}

--- a/pkg/k8s/apis/spiderpool.spidernet.io/v1/rbac.go
+++ b/pkg/k8s/apis/spiderpool.spidernet.io/v1/rbac.go
@@ -3,7 +3,7 @@
 
 // +kubebuilder:rbac:groups=spiderpool.spidernet.io,resources=spidersubnets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=spiderpool.spidernet.io,resources=spidersubnets/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=spiderpool.spidernet.io,resources=spiderippools,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=spiderpool.spidernet.io,resources=spiderippools,verbs=get;list;watch;create;update;patch;delete;deletecollection
 // +kubebuilder:rbac:groups=spiderpool.spidernet.io,resources=spiderippools/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=spiderpool.spidernet.io,resources=spiderendpoints,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=spiderpool.spidernet.io,resources=spiderendpoints/status,verbs=get;update;patch

--- a/pkg/subnetmanager/subnet_manager.go
+++ b/pkg/subnetmanager/subnet_manager.go
@@ -122,7 +122,7 @@ func (sm *subnetManager) AllocateEmptyIPPool(ctx context.Context, subnetName str
 	}
 
 	logger.Sugar().Infof("try to create IPPool '%v'", sp)
-	err = sm.ipPoolManager.CreateIPPool(ctx, sp)
+	err = sm.client.Create(ctx, sp)
 	if nil != err {
 		return nil, err
 	}


### PR DESCRIPTION
In the previous version, we'll try to get All corresponding IPPools and delete them if one orphan pod was deleting in SpiderSubnet feature.

Now, we can just use DeleteAll method to delete them directly. That can decrease several Network requests. 

Signed-off-by: Icarus9913 <icaruswu66@qq.com>
