### PR TITLE
modify ipam fetch subnet IPPool retry operation times and duration

### DIFF
--- a/cmd/spiderpool-agent/cmd/config.go
+++ b/cmd/spiderpool-agent/cmd/config.go
@@ -59,7 +59,8 @@ var envInfo = []envConf{
 	{"SPIDERPOOL_PYROSCOPE_PUSH_SERVER_ADDRESS", "", false, &agentContext.Cfg.PyroscopeAddress, nil, nil},
 	{"SPIDERPOOL_LIMITER_MAX_QUEUE_SIZE", "1000", true, nil, nil, &agentContext.Cfg.LimiterMaxQueueSize},
 	{"SPIDERPOOL_ENABLED_STATEFULSET", "true", true, nil, &agentContext.Cfg.EnableStatefulSet, nil},
-	{"SPIDERPOOL_WAIT_SUBNET_POOL_TIME_IN_SECOND", "2", false, nil, nil, &agentContext.Cfg.WaitSubnetPoolTime},
+	{"SPIDERPOOL_WAIT_SUBNET_POOL_TIME_IN_SECOND", "1", false, nil, nil, &agentContext.Cfg.WaitSubnetPoolTime},
+	{"SPIDERPOOL_WAIT_SUBNET_POOL_MAX_RETRIES", "50", false, nil, nil, &agentContext.Cfg.WaitSubnetPoolMaxRetries},
 	{"GOLANG_ENV_MAXPROCS", "8", false, nil, nil, &agentContext.Cfg.GoMaxProcs},
 	{"GIT_COMMIT_VERSION", "", false, &agentContext.Cfg.CommitVersion, nil, nil},
 	{"GIT_COMMIT_TIME", "", false, &agentContext.Cfg.CommitTime, nil, nil},
@@ -88,6 +89,7 @@ type Config struct {
 	WorkloadEndpointMaxHistoryRecords int
 	IPPoolMaxAllocatedIPs             int
 	WaitSubnetPoolTime                int
+	WaitSubnetPoolMaxRetries          int
 
 	LimiterMaxQueueSize int
 

--- a/cmd/spiderpool-agent/cmd/daemon.go
+++ b/cmd/spiderpool-agent/cmd/daemon.go
@@ -137,7 +137,7 @@ func DaemonMain() {
 			ClusterDefaultIPv6IPPool: agentContext.Cfg.ClusterDefaultIPv6IPPool,
 			EnableSpiderSubnet:       agentContext.Cfg.EnableSpiderSubnet,
 			EnableStatefulSet:        agentContext.Cfg.EnableStatefulSet,
-			OperationRetries:         agentContext.Cfg.UpdateCRMaxRetries,
+			OperationRetries:         agentContext.Cfg.WaitSubnetPoolMaxRetries,
 			OperationGapDuration:     time.Duration(agentContext.Cfg.WaitSubnetPoolTime) * time.Second,
 			LimiterConfig:            limiter.LimiterConfig{MaxQueueSize: &agentContext.Cfg.LimiterMaxQueueSize},
 		},

--- a/cmd/spiderpool-controller/cmd/config.go
+++ b/cmd/spiderpool-controller/cmd/config.go
@@ -85,6 +85,7 @@ var envInfo = []envConf{
 	{"SPIDERPOOL_WORKQUEUE_RETRY_DELAY_DURATION", "5", true, nil, nil, &controllerContext.Cfg.WorkQueueRequeueDelayDuration},
 	{"SPIDERPOOL_IPPOOL_INFORMER_WORKERS", "3", true, nil, nil, &controllerContext.Cfg.IPPoolInformerWorkers},
 	{"SPIDERPOOL_WORKQUEUE_MAX_RETRIES", "500", true, nil, nil, &controllerContext.Cfg.WorkQueueMaxRetries},
+	{"SPIDERPOOL_IPPOOL_INFORMER_RESYNC_PERIOD", "300", false, nil, nil, &controllerContext.Cfg.IPPoolInformerResyncPeriod},
 }
 
 type Config struct {
@@ -124,6 +125,7 @@ type Config struct {
 	// if IPPoolWorkQueueRequeueDelayDuration is negative number, we would not requeue it
 	WorkQueueRequeueDelayDuration int
 
+	IPPoolInformerResyncPeriod       int
 	IPPoolInformerWorkers            int
 	IPPoolInformerMaxWorkQueueLength int
 

--- a/cmd/spiderpool-controller/cmd/crd_manager.go
+++ b/cmd/spiderpool-controller/cmd/crd_manager.go
@@ -36,7 +36,10 @@ func newCRDManager() (ctrl.Manager, error) {
 		return nil, err
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	config := ctrl.GetConfigOrDie()
+	config.QPS = 50
+	config.Burst = 100
+	mgr, err := ctrl.NewManager(config, ctrl.Options{
 		Scheme:                 scheme,
 		Port:                   port,
 		CertDir:                path.Dir(controllerContext.Cfg.TlsServerCertPath),

--- a/cmd/spiderpool-controller/cmd/daemon.go
+++ b/cmd/spiderpool-controller/cmd/daemon.go
@@ -411,6 +411,7 @@ func setupInformers() {
 			MaxWorkqueueLength:            controllerContext.Cfg.IPPoolInformerMaxWorkQueueLength,
 			WorkQueueRequeueDelayDuration: time.Duration(controllerContext.Cfg.WorkQueueRequeueDelayDuration) * time.Second,
 			WorkQueueMaxRetries:           controllerContext.Cfg.WorkQueueMaxRetries,
+			ResyncPeriod:                  time.Duration(controllerContext.Cfg.IPPoolInformerResyncPeriod) * time.Second,
 		},
 		controllerContext.CRDManager.GetClient(),
 		controllerContext.RIPManager,

--- a/pkg/ippoolmanager/ippool_manager.go
+++ b/pkg/ippoolmanager/ippool_manager.go
@@ -269,19 +269,6 @@ func (im *ipPoolManager) UpdateAllocatedIPs(ctx context.Context, poolName string
 	return nil
 }
 
-func (im *ipPoolManager) CreateIPPool(ctx context.Context, pool *spiderpoolv1.SpiderIPPool) error {
-	err := im.client.Create(ctx, pool)
-	if nil != err {
-		if apierrors.IsAlreadyExists(err) {
-			return nil
-		}
-
-		return fmt.Errorf("failed to create IPPool '%s', error: %v", pool.Name, err)
-	}
-
-	return nil
-}
-
 func (im *ipPoolManager) DeleteAllIPPools(ctx context.Context, pool *spiderpoolv1.SpiderIPPool, opts ...client.DeleteAllOfOption) error {
 	err := im.client.DeleteAllOf(ctx, pool, opts...)
 	if client.IgnoreNotFound(err) != nil {

--- a/pkg/subnetmanager/app_controller.go
+++ b/pkg/subnetmanager/app_controller.go
@@ -727,7 +727,7 @@ func (sac *SubnetAppController) createOrMarkIPPool(ctx context.Context, podSubne
 		} else if len(poolList.Items) == 1 {
 			pool := poolList.Items[0]
 			log.Sugar().Debugf("found SpiderSubnet '%s' IPPool '%s' with matchLabel '%v', check it whether need to be scaled", subnetName, pool.Name, matchLabel)
-			_, err = sac.subnetMgr.CheckScaleIPPool(ctx, &pool, subnetName, ipNum)
+			err = sac.subnetMgr.CheckScaleIPPool(ctx, &pool, subnetName, ipNum)
 		} else {
 			err = fmt.Errorf("%w: it's invalid that SpiderSubnet '%s' owns multiple matchLabel '%v' corresponding IPPools '%v' for one specify application",
 				constant.ErrWrongInput, subnetName, matchLabel, poolList.Items)

--- a/test/e2e/reservedip/reservedip_test.go
+++ b/test/e2e/reservedip/reservedip_test.go
@@ -5,6 +5,7 @@ package reservedip_test
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	v1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -169,7 +170,7 @@ var _ = Describe("test reservedIP", Label("reservedIP"), func() {
 			}
 
 			// Get the Pod creation failure Event
-			ctx, cancel := context.WithTimeout(context.Background(), common.EventOccurTimeout)
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 			defer cancel()
 			for _, pod := range podlist.Items {
 				Expect(frame.WaitExceptEventOccurred(ctx, common.OwnerPod, pod.Name, pod.Namespace, common.CNIFailedToSetUpNetwork)).To(Succeed())


### PR DESCRIPTION
1.modify ipam fetch subnet auto-created IPPool retry times and retry duration (Previously, the ipam component will leave 6s for those pods that use SpiderSubnet feature. The IPPool informer will scale the IPPools one by one to avoid conflict. So, if someone create multiple applications in a short time, some IPPool will wait for the previous IPPool scaled up.)

2.add IPPool informer resync filter for watching SpiderSubnet object corresponding IPPools. (In the previous version, we will enqueue SpiderSubnet corresponding IPPools once the SpiderSubnet changed. For the design, we make the IPPool and SpiderSubnet asynchronous because there's one situation that the SpiderSubnet's IPs are used out and the Auto-created IPPool allocation will fail immediately. And in the asynchronous architecture, once the SpiderSubnet scales up its IPs, we will notify the corresponding to scale up as soon as possible. Consequently, it's appropriate to notify the IPPool if the SpiderSubnet's allocatable IPs are increased.)

3.add resync for ippool informer (this will add all IPPools into the workqueue)

Signed-off-by: Icarus9913 <icaruswu66@qq.com>