### PR TITLE
fix: create empty cluster default IPPool when we enable SpiderSubnet feature

### DIFF
--- a/cmd/spiderpool-agent/cmd/daemon.go
+++ b/cmd/spiderpool-agent/cmd/daemon.go
@@ -144,6 +144,9 @@ func DaemonMain() {
 		WaitSubnetPoolRetries: agentContext.Cfg.UpdateCRMaxRetries,
 		WaitSubnetPoolTime:    time.Duration(agentContext.Cfg.WaitSubnetPoolTime) * time.Second,
 	}, agentContext.IPPoolManager, agentContext.WEManager, agentContext.NodeManager, agentContext.NSManager, agentContext.PodManager, agentContext.StsManager, agentContext.SubnetManager)
+	if nil != err {
+		logger.Fatal(err.Error())
+	}
 	agentContext.IPAM = ipam
 
 	go func() {

--- a/cmd/spiderpool-init/cmd/root.go
+++ b/cmd/spiderpool-init/cmd/root.go
@@ -154,9 +154,15 @@ func Execute() {
 			ObjectMeta: metav1.ObjectMeta{Name: Config.PoolV4Name},
 			Spec: spiderpoolv1.IPPoolSpec{
 				Subnet: Config.PoolV4Subnet,
-				IPs:    Config.PoolV4IPRanges,
 			},
 		}
+
+		// if we create SpiderSubnet CR object, we'll create an empty default IPPool.
+		// Otherwise, we'll create a truly useful default IPPool
+		if len(Config.SubnetV4Name) == 0 {
+			pool.Spec.IPs = Config.PoolV4IPRanges
+		}
+
 		if len(Config.PoolV4Gateway) > 0 {
 			pool.Spec.Gateway = &Config.PoolV4Gateway
 		}
@@ -198,9 +204,15 @@ func Execute() {
 			ObjectMeta: metav1.ObjectMeta{Name: Config.PoolV6Name},
 			Spec: spiderpoolv1.IPPoolSpec{
 				Subnet: Config.PoolV6Subnet,
-				IPs:    Config.PoolV6IPRanges,
 			},
 		}
+
+		// if we create SpiderSubnet CR object, we'll create an empty default IPPool.
+		// Otherwise, we'll create a truly useful default IPPool
+		if len(Config.SubnetV6Name) == 0 {
+			pool.Spec.IPs = Config.PoolV6IPRanges
+		}
+
 		if len(Config.PoolV6Gateway) > 0 {
 			pool.Spec.Gateway = &Config.PoolV6Gateway
 		}

--- a/test/Makefile
+++ b/test/Makefile
@@ -55,7 +55,7 @@ endif
 		MULTUS_CNI_NAMESPACE=$(MULTUS_CNI_NAMESPACE) \
 		MULTUS_ADDITIONAL_CNI_NAME=$(MULTUS_ADDITIONAL_CNI_NAME) \
 		MULTUS_DEFAULT_CNI_NAME=$(MULTUS_DEFAULT_CNI_NAME) \
-		scripts/installTestPod.sh $(E2E_KUBECONFIG)
+		scripts/installTestPod.sh $(E2E_KUBECONFIG) $(E2E_SPIDERPOOL_ENABLE_SUBNET)
 	@echo ""
 	@echo "-----------------------------------------------------------------------------------------------------"
 	@echo "       ip family: $(E2E_IP_FAMILY)"

--- a/test/scripts/installTestPod.sh
+++ b/test/scripts/installTestPod.sh
@@ -4,11 +4,13 @@
 # Copyright Authors of Spider
 
 E2E_KUBECONFIG="$1"
+E2E_SPIDERPOOL_ENABLE_SUBNET="$2"
 
 [ -z "$E2E_KUBECONFIG" ] && echo "error, miss E2E_KUBECONFIG " && exit 1
 [ ! -f "$E2E_KUBECONFIG" ] && echo "error, could not find file $E2E_KUBECONFIG " && exit 1
 echo "$CURRENT_FILENAME : E2E_KUBECONFIG $E2E_KUBECONFIG "
 
+[ -z "$E2E_SPIDERPOOL_ENABLE_SUBNET" ] && echo "not found E2E_SPIDERPOOL_ENABLE_SUBNET, default to set it false " &&  E2E_SPIDERPOOL_ENABLE_SUBNET=false
 
 NAME=test-pod
 cat <<EOF | kubectl apply --kubeconfig ${E2E_KUBECONFIG} -f -
@@ -27,7 +29,9 @@ spec:
   template:
     metadata:
       annotations:
-        k8s.v1.cni.cncf.io/networks: ${MULTUS_CNI_NAMESPACE}/${MULTUS_ADDITIONAL_CNI_NAME}
+        $(if [[ "${E2E_SPIDERPOOL_ENABLE_SUBNET}" == "false" ]];then
+        echo "k8s.v1.cni.cncf.io/networks: ${MULTUS_CNI_NAMESPACE}/${MULTUS_ADDITIONAL_CNI_NAME}"
+        fi)
       name: $NAME
       labels:
         app: $NAME


### PR DESCRIPTION
Previously, we'll create cluster default IPPool and holds all cluster default subnet's IPs. And others can not fetch any useable IPs from cluster default subnet. So, we change it to create an empty cluster default IPPool once we enable to use SpiderSubnet feature to create one cluster default SpiderSubnet object in helm installation.

Reference: https://github.com/spidernet-io/spiderpool/pull/1205
Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)

**What this PR does / why we need it**:
fix bug

**Which issue(s) this PR fixes**:
https://github.com/spidernet-io/spiderpool/issues/1099
