### PR TITLE
fix: The Pod UID of the record in the SpiderIPPool is not updated after the StatefulSet's Pod is recreated

### DIFF
--- a/pkg/ippoolmanager/ippool_manager.go
+++ b/pkg/ippoolmanager/ippool_manager.go
@@ -285,6 +285,7 @@ func (im *ipPoolManager) UpdateAllocatedIPs(ctx context.Context, poolName string
 			if record, ok := allocatedRecords[iu.IP]; ok {
 				if record.PodUID != iu.UID {
 					record.PodUID = iu.UID
+					allocatedRecords[iu.IP] = record
 					recreate = true
 				}
 			}


### PR DESCRIPTION
Signed-off-by: iiiceoo <ziqian.xue@daocloud.io>