### PR TITLE
add apiversion check for statefulset pod

### DIFF
--- a/pkg/applicationcontroller/app_controller.go
+++ b/pkg/applicationcontroller/app_controller.go
@@ -939,7 +939,6 @@ func (sac *SubnetAppController) controllerDeleteHandler() applicationinformers.A
 
 		// clean up all legacy IPPools that matched with the application UID
 		err := sac.client.DeleteAllOf(ctx, &spiderpoolv2beta1.SpiderIPPool{}, client.MatchingLabels{
-			constant.LabelIPPoolOwnerApplication:    applicationinformers.AppLabelValue(appKind, app.GetNamespace(), app.GetName()),
 			constant.LabelIPPoolOwnerApplicationUID: string(app.GetUID()),
 			constant.LabelIPPoolReclaimIPPool:       constant.True,
 		})

--- a/pkg/applicationcontroller/applicationinformers/utils.go
+++ b/pkg/applicationcontroller/applicationinformers/utils.go
@@ -36,23 +36,23 @@ func SubnetPoolName(controllerKind, controllerNS, controllerName string, ipVersi
 		strings.ToLower(controllerKind), strings.ToLower(controllerNS), strings.ToLower(controllerName), ipVersion, ifName, strings.ToLower(lastOne))
 }
 
-// AppLabelValue will joint the application type, namespace and name as a label value, then we need unpack it for tracing
+// ApplicationNamespacedName will joint the application apiVersion, application type, namespace and name as a string, then we need unpack it for tracing
 // [ns and object name constraint Ref]: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
-// [label value ref]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
-// Because the label value enable you to use '_', then we can use it as the slash.
-// So, for tracing it back, we set format is "{appKind}_{appNS}_{appName}"
-func AppLabelValue(appKind string, appNS, appName string) string {
-	return fmt.Sprintf("%s_%s_%s", appKind, appNS, appName)
+// We set format is "{apiVersion}:{appKind}:{appNS}:{appName}"
+func ApplicationNamespacedName(appNamespacedName types.AppNamespacedName) string {
+	return fmt.Sprintf("%s:%s:%s:%s", appNamespacedName.APIVersion, appNamespacedName.Kind, appNamespacedName.Namespace, appNamespacedName.Name)
 }
 
-// ParseAppLabelValue will unpack the application label value, its corresponding function is AppLabelValue
-func ParseAppLabelValue(str string) (appKind, appNS, appName string, isFound bool) {
-	typeKind, after, found := strings.Cut(str, "_")
-	if found {
-		isFound = found
-		appKind = typeKind
-
-		appNS, appName, _ = strings.Cut(after, "_")
+// ParseApplicationNamespacedName will unpack the appNamespacedNameKey, its corresponding function is ApplicationNamespacedName
+func ParseApplicationNamespacedName(appNamespacedNameKey string) (appNamespacedName types.AppNamespacedName, isMatch bool) {
+	split := strings.Split(appNamespacedNameKey, ":")
+	if len(split) == 4 {
+		return types.AppNamespacedName{
+			APIVersion: split[0],
+			Kind:       split[1],
+			Namespace:  split[2],
+			Name:       split[3],
+		}, true
 	}
 
 	return

--- a/pkg/constant/k8s.go
+++ b/pkg/constant/k8s.go
@@ -4,6 +4,9 @@
 package constant
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 
 	"github.com/spidernet-io/spiderpool/pkg/types"
@@ -31,6 +34,7 @@ const (
 )
 
 var K8sKinds = []string{KindPod, KindDeployment, KindReplicaSet, KindDaemonSet, KindStatefulSet, KindJob, KindCronJob}
+var K8sAPIVersions = []string{corev1.SchemeGroupVersion.String(), appsv1.SchemeGroupVersion.String(), batchv1.SchemeGroupVersion.String()}
 
 const (
 	PodRunning     types.PodStatus = "Running"
@@ -57,16 +61,11 @@ const (
 	AnnoSpiderSubnets             = AnnotationPre + "/subnets"
 	AnnoSpiderSubnetPoolIPNumber  = AnnotationPre + "/ippool-ip-number"
 	AnnoSpiderSubnetReclaimIPPool = AnnotationPre + "/ippool-reclaim"
+	AnnoSpiderSubnetPoolApp       = AnnotationPre + "/application"
 
 	LabelIPPoolOwnerSpiderSubnet   = AnnotationPre + "/owner-spider-subnet"
-	LabelIPPoolOwnerApplication    = AnnotationPre + "/owner-application"
 	LabelIPPoolOwnerApplicationUID = AnnotationPre + "/owner-application-uid"
-	LabelIPPoolInterface           = AnnotationPre + "/interface"
 	LabelIPPoolReclaimIPPool       = AnnoSpiderSubnetReclaimIPPool
-	LabelIPPoolVersion             = AnnotationPre + "/ippool-version"
-	LabelIPPoolVersionV4           = "IPv4"
-	LabelIPPoolVersionV6           = "IPv6"
-	LabelAutoPoolDesiredIPNumber   = AnnotationPre + "/auto-ippool-desired-ip-number"
 
 	LabelSubnetCIDR = AnnotationPre + "/subnet-cidr"
 	LabelIPPoolCIDR = AnnotationPre + "/ippool-cidr"

--- a/pkg/ipam/allocate.go
+++ b/pkg/ipam/allocate.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -55,7 +56,7 @@ func (i *ipam) Allocate(ctx context.Context, addArgs *models.IpamAddArgs) (*mode
 		logger.Debug("No Endpoint")
 	}
 
-	if i.config.EnableStatefulSet && podTopController.Kind == constant.KindStatefulSet {
+	if i.config.EnableStatefulSet && podTopController.APIVersion == appsv1.SchemeGroupVersion.String() && podTopController.Kind == constant.KindStatefulSet {
 		logger.Info("Try to retrieve the IP allocation of StatefulSet")
 		addResp, err := i.retrieveStsIPAllocation(ctx, *addArgs.IfName, pod, endpoint)
 		if err != nil {

--- a/pkg/ippoolmanager/utils.go
+++ b/pkg/ippoolmanager/utils.go
@@ -10,8 +10,8 @@ import (
 
 // TODO(Icarus9913): Deprecated.
 func IsAutoCreatedIPPool(pool *spiderpoolv2beta1.SpiderIPPool) bool {
-	// only the auto-created IPPool owns the label "ipam.spidernet.io/owner-application"
-	poolLabels := pool.GetLabels()
-	_, ok := poolLabels[constant.LabelIPPoolOwnerApplication]
+	// only the auto-created IPPool owns the annotation "ipam.spidernet.io/application"
+	poolAnno := pool.GetAnnotations()
+	_, ok := poolAnno[constant.AnnoSpiderSubnetPoolApp]
 	return ok
 }

--- a/pkg/subnetmanager/subnet_informer.go
+++ b/pkg/subnetmanager/subnet_informer.go
@@ -24,10 +24,12 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/strings/slices"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/spidernet-io/spiderpool/pkg/applicationcontroller/applicationinformers"
 	"github.com/spidernet-io/spiderpool/pkg/constant"
 	"github.com/spidernet-io/spiderpool/pkg/election"
 	spiderpoolip "github.com/spidernet-io/spiderpool/pkg/ip"
@@ -376,7 +378,7 @@ func (sc *SubnetController) syncControlledIPPoolIPs(ctx context.Context, subnet 
 	for poolName, preAllocation := range preAllocations {
 		// Only auto-created IPPools have the field 'Application'.
 		if preAllocation.Application != nil {
-			appNamespacedName, isMatch := ParseApplicationNamespacedName(*preAllocation.Application)
+			appNamespacedName, isMatch := applicationinformers.ParseApplicationNamespacedName(*preAllocation.Application)
 			if !isMatch {
 				logger.Sugar().Errorf("Invalid application record %s of IPPool %s, remove the pre-allocation from Subnet", *preAllocation.Application, poolName)
 				continue
@@ -496,22 +498,27 @@ func (sc *SubnetController) removeFinalizer(ctx context.Context, subnet *spiderp
 func (sc *SubnetController) isAppExist(ctx context.Context, appNamespacedName spiderpooltypes.AppNamespacedName) (bool, error) {
 	var object client.Object
 	isThirdController := false
-	switch appNamespacedName.Kind {
-	case constant.KindPod:
-		object = &corev1.Pod{}
-	case constant.KindDeployment:
-		object = &appsv1.Deployment{}
-	case constant.KindReplicaSet:
-		object = &appsv1.ReplicaSet{}
-	case constant.KindDaemonSet:
-		object = &appsv1.DaemonSet{}
-	case constant.KindStatefulSet:
-		object = &appsv1.StatefulSet{}
-	case constant.KindJob:
-		object = &batchv1.Job{}
-	case constant.KindCronJob:
-		object = &batchv1.CronJob{}
-	default:
+
+	if slices.Contains(constant.K8sAPIVersions, appNamespacedName.APIVersion) {
+		switch appNamespacedName.Kind {
+		case constant.KindPod:
+			object = &corev1.Pod{}
+		case constant.KindDeployment:
+			object = &appsv1.Deployment{}
+		case constant.KindReplicaSet:
+			object = &appsv1.ReplicaSet{}
+		case constant.KindDaemonSet:
+			object = &appsv1.DaemonSet{}
+		case constant.KindStatefulSet:
+			object = &appsv1.StatefulSet{}
+		case constant.KindJob:
+			object = &batchv1.Job{}
+		case constant.KindCronJob:
+			object = &batchv1.CronJob{}
+		default:
+			isThirdController = true
+		}
+	} else {
 		isThirdController = true
 	}
 


### PR DESCRIPTION
1. In issue https://github.com/spidernet-io/spiderpool/issues/1486, I found that the IPPool-informer regards the openKruise StatefulSet as Kubernetes appsv1 Statefulset. 
If one pod's top controller is StatefulSet, we should make sure that the StatefulSet object is `apps/v1` group version

2. I removed the IPPool label `ipam.spidernet.io/owner-application`  and add one annotation `ipam.spidernet.io/application`.  Only the Application auto-created IPPools (SpiderSubnet feature) will hold this annotation, and it records the corresponding application apiVersion, kind, namespace, name. The format of this value is "{apiVersion}:{appKind}:{appNS}:{appName}"

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)