### PR TITLE
fix application controller empty APIVersion string

### DIFF
--- a/pkg/applicationcontroller/app_controller.go
+++ b/pkg/applicationcontroller/app_controller.go
@@ -623,7 +623,8 @@ func (sac *SubnetAppController) syncHandler(appKey appWorkQueueKey, log *zap.Log
 		podSelector = deployment.Spec.Selector
 		appReplicas = applicationinformers.GetAppReplicas(deployment.Spec.Replicas)
 		app = deployment.DeepCopy()
-		apiVersion = deployment.APIVersion
+		// deployment.APIVersion is empty string
+		apiVersion = appsv1.SchemeGroupVersion.String()
 
 	case constant.KindReplicaSet:
 		replicaSet, err := sac.replicaSetLister.ReplicaSets(namespace).Get(name)
@@ -639,7 +640,8 @@ func (sac *SubnetAppController) syncHandler(appKey appWorkQueueKey, log *zap.Log
 		podSelector = replicaSet.Spec.Selector
 		appReplicas = applicationinformers.GetAppReplicas(replicaSet.Spec.Replicas)
 		app = replicaSet.DeepCopy()
-		apiVersion = replicaSet.APIVersion
+		// replicaSet.APIVersion is empty string
+		apiVersion = appsv1.SchemeGroupVersion.String()
 
 	case constant.KindDaemonSet:
 		daemonSet, err := sac.daemonSetLister.DaemonSets(namespace).Get(name)
@@ -655,7 +657,8 @@ func (sac *SubnetAppController) syncHandler(appKey appWorkQueueKey, log *zap.Log
 		podSelector = daemonSet.Spec.Selector
 		appReplicas = int(daemonSet.Status.DesiredNumberScheduled)
 		app = daemonSet.DeepCopy()
-		apiVersion = daemonSet.APIVersion
+		// daemonSet.APIVersion is empty string
+		apiVersion = appsv1.SchemeGroupVersion.String()
 
 	case constant.KindStatefulSet:
 		statefulSet, err := sac.statefulSetLister.StatefulSets(namespace).Get(name)
@@ -671,7 +674,8 @@ func (sac *SubnetAppController) syncHandler(appKey appWorkQueueKey, log *zap.Log
 		podSelector = statefulSet.Spec.Selector
 		appReplicas = applicationinformers.GetAppReplicas(statefulSet.Spec.Replicas)
 		app = statefulSet.DeepCopy()
-		apiVersion = statefulSet.APIVersion
+		// statefulSet.APIVersion is empty string
+		apiVersion = appsv1.SchemeGroupVersion.String()
 
 	case constant.KindJob:
 		job, err := sac.jobLister.Jobs(namespace).Get(name)
@@ -687,7 +691,8 @@ func (sac *SubnetAppController) syncHandler(appKey appWorkQueueKey, log *zap.Log
 		podSelector = job.Spec.Selector
 		appReplicas = applicationinformers.CalculateJobPodNum(job.Spec.Parallelism, job.Spec.Completions)
 		app = job.DeepCopy()
-		apiVersion = job.APIVersion
+		// job.APIVersion is empty string
+		apiVersion = batchv1.SchemeGroupVersion.String()
 
 	case constant.KindCronJob:
 		cronJob, err := sac.cronJobLister.CronJobs(namespace).Get(name)
@@ -703,7 +708,8 @@ func (sac *SubnetAppController) syncHandler(appKey appWorkQueueKey, log *zap.Log
 		podSelector = cronJob.Spec.JobTemplate.Spec.Selector
 		appReplicas = applicationinformers.CalculateJobPodNum(cronJob.Spec.JobTemplate.Spec.Parallelism, cronJob.Spec.JobTemplate.Spec.Completions)
 		app = cronJob.DeepCopy()
-		apiVersion = cronJob.APIVersion
+		// cronJob.APIVersion is empty string
+		apiVersion = batchv1.SchemeGroupVersion.String()
 
 	default:
 		return fmt.Errorf("%w: unexpected appWorkQueueKey in workQueue '%+v'", constant.ErrWrongInput, appKey)


### PR DESCRIPTION
In the application controller, we found the `deployment.APIVersion` is empty string once we get the deployment object yaml. 
Consequently, we can just set it with `appsv1.SchemeGroupVersion.String()` directly

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)
