### PR TITLE
fix auto-pool shrink failure issue

### DIFF
--- a/cmd/spiderpool-controller/cmd/daemon.go
+++ b/cmd/spiderpool-controller/cmd/daemon.go
@@ -445,6 +445,7 @@ func setupInformers() {
 		logger.Info("Begin to set up auto-created IPPool controller")
 		subnetAppController, err := applicationcontroller.NewSubnetAppController(
 			controllerContext.CRDManager.GetClient(),
+			controllerContext.CRDManager.GetAPIReader(),
 			controllerContext.SubnetManager,
 			applicationcontroller.SubnetAppControllerConfig{
 				EnableIPv4:                    controllerContext.Cfg.EnableIPv4,

--- a/pkg/ipam/pool_selections.go
+++ b/pkg/ipam/pool_selections.go
@@ -176,6 +176,7 @@ func (i *ipam) getPoolFromSubnetAnno(ctx context.Context, pod *corev1.Pod, nic s
 			// found
 			logger.Sugar().Debugf("found SpiderSubnet '%s' IPPool '%v' ", subnetName, pool)
 
+			// TODO(Icarus9913): If shrink failed, it'll cost the whole loop
 			// we fetched Auto-created IPPool but it doesn't have any IPs, just wait for a while and let the IPPool informer to allocate IPs for it
 			if !isPoolIPsDesired(pool, poolIPNum) {
 				logger.Sugar().Warnf("fetch SubnetIPPool %d times: retrieved IPPool '%s' but doesn't have the desiredIPNumber IPs, wait for a second and get a retry", j, poolName)


### PR DESCRIPTION
In SpiderSubnet feature, we'll acquire IPs from SpiderSubnet object to apply the auto-created IPPool. But there are 2 API operations in the whole operation, so if the first API operation succeed but the second failed,  just like the issue mentioned. We need to correct the SpiderSubnet status.

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)

**What this PR does / why we need it**:
fix bug

**Which issue(s) this PR fixes**:
https://github.com/spidernet-io/spiderpool/issues/1520
