### PR TITLE
modify default IP GC workers and make IP GC scan all dual stack concurrency

### DIFF
--- a/cmd/spiderpool-controller/cmd/config.go
+++ b/cmd/spiderpool-controller/cmd/config.go
@@ -62,7 +62,7 @@ var envInfo = []envConf{
 
 	{"SPIDERPOOL_GC_IP_ENABLED", "true", true, nil, &gcIPConfig.EnableGCIP, nil},
 	{"SPIDERPOOL_GC_TERMINATING_POD_IP_ENABLED", "true", true, nil, &gcIPConfig.EnableGCForTerminatingPod, nil},
-	{"SPIDERPOOL_GC_IP_WORKER_NUM", "3", true, nil, nil, &gcIPConfig.ReleaseIPWorkerNum},
+	{"SPIDERPOOL_GC_IP_WORKER_NUM", "1", true, nil, nil, &gcIPConfig.ReleaseIPWorkerNum},
 	{"SPIDERPOOL_GC_CHANNEL_BUFFER", "5000", true, nil, nil, &gcIPConfig.GCIPChannelBuffer},
 	{"SPIDERPOOL_GC_MAX_PODENTRY_DB_CAP", "100000", true, nil, nil, &gcIPConfig.MaxPodEntryDatabaseCap},
 	{"SPIDERPOOL_GC_DEFAULT_INTERVAL_DURATION", "600", true, nil, nil, &gcIPConfig.DefaultGCIntervalDuration},

--- a/pkg/gcmanager/gc_manager.go
+++ b/pkg/gcmanager/gc_manager.go
@@ -136,7 +136,7 @@ func (s *SpiderGC) Start(ctx context.Context) error {
 	// monitor gc signal from CLI or DefaultGCInterval
 	go s.monitorGCSignal(ctx)
 
-	for i := 0; i < s.gcConfig.ReleaseIPWorkerNum; i++ {
+	for i := 1; i <= s.gcConfig.ReleaseIPWorkerNum; i++ {
 		go s.releaseIPPoolIPExecutor(ctx, i)
 	}
 


### PR DESCRIPTION
1. Set the default IP GC trace pod workers to 1.
2. In the past IP GC scan all architecture, we scan the IPPools one by one and this will cost a long time. So, I make the IPPools into IPv4 IPPools and IPv6 IPPools with 2 goroutines, and each IPPools will still be scanned one by one because I'm afraid that If I set up one goroutine for each IPPool will lead to too many goroutines. 

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)