### PR TITLE
fix: Subnet status IPPool allocations disappears but the IPPool still exist

### DIFF
--- a/pkg/subnetmanager/subnet_informer.go
+++ b/pkg/subnetmanager/subnet_informer.go
@@ -398,8 +398,11 @@ func (sc *SubnetController) syncControlledIPPoolIPs(ctx context.Context, subnet 
 			}
 
 			if !exist {
-				logger.Sugar().Infof("The Application %v corresponding to the auto-created IPPool %s no longer exists, remove the pre-allocation from Subnet", appNamespacedName, poolName)
-				continue
+				_, err := sc.IPPoolsLister.Get(poolName)
+				if apierrors.IsNotFound(err) {
+					logger.Sugar().Infof("The Application %v corresponding to the auto-created IPPool %s no longer exists, remove the pre-allocation from Subnet", appNamespacedName, poolName)
+					continue
+				}
 			}
 
 			autoIPPoolIPs, err := spiderpoolip.ParseIPRanges(*subnet.Spec.IPVersion, preAllocation.IPs)


### PR DESCRIPTION
Add one more check after we checked the application not exist in SpiderSubnet informers. When the application doesn't exist, we still need to check whether the IPPool exists and decide to update the SpiderSubnet status allocations.

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)

**What this PR does / why we need it**:
fix bug

**Which issue(s) this PR fixes**:


