### PR TITLE
supplement spiderpool controller readiness probe

### DIFF
--- a/cmd/spiderpool-controller/cmd/daemon.go
+++ b/cmd/spiderpool-controller/cmd/daemon.go
@@ -212,7 +212,7 @@ func WatchSignal(sigCh chan os.Signal) {
 
 func initControllerServiceManagers(ctx context.Context) {
 	logger.Debug("Begin to initialize spiderpool-controller leader election")
-	initSpiderControllerLeaderElect(controllerContext.InnerCtx)
+	initSpiderControllerLeaderElect(ctx)
 
 	logger.Debug("Begin to initialize Node manager")
 	nodeManager, err := nodemanager.NewNodeManager(

--- a/cmd/spiderpool-controller/cmd/runtime_status.go
+++ b/cmd/spiderpool-controller/cmd/runtime_status.go
@@ -40,6 +40,18 @@ func (g *_httpGetControllerReadiness) Handle(params runtime.GetRuntimeReadinessP
 		return runtime.NewGetRuntimeReadinessInternalServerError()
 	}
 
+	if len(g.Leader.GetLeader()) == 0 {
+		logger.Warn("there's not leader in the current cluster, please wait for a while")
+		return runtime.NewGetRuntimeReadinessInternalServerError()
+	}
+
+	if g.Leader.IsElected() {
+		if !g.GCManager.Health() {
+			logger.Sugar().Warnf("the IP GC is still not ready, please wait for a while")
+			return runtime.NewGetRuntimeReadinessInternalServerError()
+		}
+	}
+
 	return runtime.NewGetRuntimeReadinessOK()
 }
 

--- a/pkg/election/lease_election.go
+++ b/pkg/election/lease_election.go
@@ -26,6 +26,7 @@ type SpiderLeaseElector interface {
 	Run(ctx context.Context, clientSet kubernetes.Interface) error
 	// IsElected returns a boolean value to check current Elector whether is a leader
 	IsElected() bool
+	GetLeader() string
 }
 
 type SpiderLeader struct {
@@ -172,4 +173,8 @@ func (sl *SpiderLeader) tryToElect(ctx context.Context) {
 
 		time.Sleep(sl.leaderRetryElectGap)
 	}
+}
+
+func (sl *SpiderLeader) GetLeader() string {
+	return sl.leaderElector.GetLeader()
 }

--- a/pkg/election/lease_election_test.go
+++ b/pkg/election/lease_election_test.go
@@ -108,6 +108,7 @@ var _ = Describe("Leader Election", Label("unitest", "election_test"), func() {
 
 			// wait for us to become leader
 			Eventually(spiderLeaseElector.IsElected).WithTimeout(5 * time.Second).Should(BeTrue())
+			Expect(spiderLeaseElector.GetLeader()).Should(Equal(globalParams.leaseLockIdentity))
 
 			cancel()
 			Eventually(ctx.Done()).WithTimeout(1 * time.Second).Should(BeClosed())

--- a/pkg/election/mock/lease_election_mock.go
+++ b/pkg/election/mock/lease_election_mock.go
@@ -38,6 +38,20 @@ func (m *MockSpiderLeaseElector) EXPECT() *MockSpiderLeaseElectorMockRecorder {
 	return m.recorder
 }
 
+// GetLeader mocks base method.
+func (m *MockSpiderLeaseElector) GetLeader() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLeader")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetLeader indicates an expected call of GetLeader.
+func (mr *MockSpiderLeaseElectorMockRecorder) GetLeader() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLeader", reflect.TypeOf((*MockSpiderLeaseElector)(nil).GetLeader))
+}
+
 // IsElected mocks base method.
 func (m *MockSpiderLeaseElector) IsElected() bool {
 	m.ctrl.T.Helper()

--- a/pkg/gcmanager/pod_informer.go
+++ b/pkg/gcmanager/pod_informer.go
@@ -59,6 +59,7 @@ func (s *SpiderGC) startPodInformer(ctx context.Context) {
 			innerCancel()
 			continue
 		}
+		s.informerFactory = informerFactory
 		informerFactory.Start(innerCtx.Done())
 
 		<-innerCtx.Done()


### PR DESCRIPTION
I supplement spiderpool-controller readiness probe. 
For those backup spiderpool-controller pod, after it detects there's a master in the cluster it will be ready.
For the master spiderpool-controller pod, only it gets the master elector and wait for IP GC informer factory cache synced, it will be ready.

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)