### PR TITLE
add limiter for IP GC pod informer architecture

### DIFF
--- a/cmd/spiderpool-controller/cmd/config.go
+++ b/cmd/spiderpool-controller/cmd/config.go
@@ -62,7 +62,7 @@ var envInfo = []envConf{
 
 	{"SPIDERPOOL_GC_IP_ENABLED", "true", true, nil, &gcIPConfig.EnableGCIP, nil},
 	{"SPIDERPOOL_GC_TERMINATING_POD_IP_ENABLED", "true", true, nil, &gcIPConfig.EnableGCForTerminatingPod, nil},
-	{"SPIDERPOOL_GC_IP_WORKER_NUM", "1", true, nil, nil, &gcIPConfig.ReleaseIPWorkerNum},
+	{"SPIDERPOOL_GC_IP_WORKER_NUM", "3", true, nil, nil, &gcIPConfig.ReleaseIPWorkerNum},
 	{"SPIDERPOOL_GC_CHANNEL_BUFFER", "5000", true, nil, nil, &gcIPConfig.GCIPChannelBuffer},
 	{"SPIDERPOOL_GC_MAX_PODENTRY_DB_CAP", "100000", true, nil, nil, &gcIPConfig.MaxPodEntryDatabaseCap},
 	{"SPIDERPOOL_GC_DEFAULT_INTERVAL_DURATION", "600", true, nil, nil, &gcIPConfig.DefaultGCIntervalDuration},

--- a/cmd/spiderpool-controller/cmd/daemon.go
+++ b/cmd/spiderpool-controller/cmd/daemon.go
@@ -351,9 +351,16 @@ func initGCManager(ctx context.Context) {
 	}
 	controllerContext.GCManager = gcManager
 
-	if err := controllerContext.GCManager.Start(ctx); err != nil {
-		logger.Fatal(err.Error())
-	}
+	go func() {
+		errCh := controllerContext.GCManager.Start(ctx)
+		select {
+		case err := <-errCh:
+			logger.Fatal(err.Error())
+		case <-ctx.Done():
+			logger.Error("global ctx down!")
+			return
+		}
+	}()
 }
 
 func initSpiderControllerLeaderElect(ctx context.Context) {


### PR DESCRIPTION
I added limiter to IP GC trace pod worker function, this could make it use several workers and concurrency.
Additionally, I improved the trace pod worker IP release operation, the previous codes would release IP one by one. But now, it would release those different IPPool IPs  concurrently.

Reference PR: https://github.com/spidernet-io/spiderpool/pull/1525

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)