### PR TITLE
support CNI V1.0.0

### DIFF
--- a/cmd/spiderpool/cmd/cni_types.go
+++ b/cmd/spiderpool/cmd/cni_types.go
@@ -27,10 +27,11 @@ const (
 	CniVersion030 = "0.3.0"
 	CniVersion031 = "0.3.1"
 	CniVersion040 = "0.4.0"
+	CniVersion100 = "1.0.0"
 )
 
 // SupportCNIVersions indicate the CNI version that spiderpool support.
-var SupportCNIVersions = []string{CniVersion030, CniVersion031, CniVersion040}
+var SupportCNIVersions = []string{CniVersion030, CniVersion031, CniVersion040, CniVersion100}
 
 const DefaultLogLevelStr = logutils.LogInfoLevelStr
 


### PR DESCRIPTION
According to the [CNI Spec](https://github.com/containernetworking/cni/blob/spec-v1.0.0/SPEC.md), compared with the previous versions, the additional features are aimed at Main CNI not IPAM. 
So, we can just support CNI V1.0.0 directly.

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)


**What this PR does / why we need it**:
new feature

