### PR TITLE
make IP GC pod informer mechanism requeue if it failed to release IP

### DIFF
--- a/cmd/spiderpool-controller/cmd/config.go
+++ b/cmd/spiderpool-controller/cmd/config.go
@@ -70,6 +70,7 @@ var envInfo = []envConf{
 	{"SPIDERPOOL_GC_SIGNAL_TIMEOUT_DURATION", "3", true, nil, nil, &gcIPConfig.GCSignalTimeoutDuration},
 	{"SPIDERPOOL_GC_HTTP_REQUEST_TIME_GAP", "1", true, nil, nil, &gcIPConfig.GCSignalGapDuration},
 	{"SPIDERPOOL_GC_ADDITIONAL_GRACE_DELAY", "0", true, nil, nil, &gcIPConfig.AdditionalGraceDelay},
+	{"SPIDERPOOL_GC_PODENTRY_MAX_RETRIES", "5", true, nil, nil, &gcIPConfig.WorkQueueMaxRetries},
 	{"SPIDERPOOL_POD_NAMESPACE", "", true, &controllerContext.Cfg.ControllerPodNamespace, nil, nil},
 	{"SPIDERPOOL_POD_NAME", "", true, &controllerContext.Cfg.ControllerPodName, nil, nil},
 	{"SPIDERPOOL_LEADER_DURATION", "15", true, nil, nil, &controllerContext.Cfg.LeaseDuration},

--- a/pkg/gcmanager/gc_manager.go
+++ b/pkg/gcmanager/gc_manager.go
@@ -29,6 +29,7 @@ type GarbageCollectionConfig struct {
 	ReleaseIPWorkerNum     int
 	GCIPChannelBuffer      int
 	MaxPodEntryDatabaseCap int
+	WorkQueueMaxRetries    int
 
 	DefaultGCIntervalDuration int
 	TracePodGapDuration       int

--- a/pkg/gcmanager/pod_cache.go
+++ b/pkg/gcmanager/pod_cache.go
@@ -29,13 +29,13 @@ type PodEntry struct {
 	Namespace string
 	NodeName  string
 
-	EntryUpdateTime time.Time
-
+	EntryUpdateTime     time.Time
 	TracingStartTime    time.Time
 	TracingGracefulTime time.Duration
 	TracingStopTime     time.Time
 
 	PodTracingReason types.PodStatus
+	NumRequeues      int
 }
 
 // PodDatabase represents controller PodEntry database
@@ -108,7 +108,8 @@ func (p *PodDatabase) ApplyPodEntry(podEntry *PodEntry) error {
 	if podCache.TracingStartTime != podEntry.TracingStartTime ||
 		podCache.TracingGracefulTime != podEntry.TracingGracefulTime ||
 		podCache.TracingStopTime != podEntry.TracingStopTime ||
-		podCache.PodTracingReason != podEntry.PodTracingReason {
+		podCache.PodTracingReason != podEntry.PodTracingReason ||
+		podCache.NumRequeues != podEntry.NumRequeues {
 		p.pods[ktypes.NamespacedName{Namespace: podCache.Namespace, Name: podCache.PodName}] = *podEntry
 		p.Unlock()
 		logger.Sugar().Debugf("podEntry '%s/%s' has changed, the old '%+v' and the new is '%+v'",

--- a/pkg/gcmanager/pod_informer.go
+++ b/pkg/gcmanager/pod_informer.go
@@ -122,7 +122,7 @@ func (s *SpiderGC) onPodDel(obj interface{}) {
 	}
 
 	pod := obj.(*corev1.Pod)
-	logger.Sugar().Infof("onPodDel: receive pod '%s/%s' deleted event", pod.Namespace, pod.Name)
+	logger.Sugar().Debugf("onPodDel: receive pod '%s/%s' deleted event", pod.Namespace, pod.Name)
 	podEntry, err := s.buildPodEntry(nil, pod, true)
 	if nil != err {
 		logger.Sugar().Errorf("onPodDel: failed to build Pod Entry '%s/%s', error: %v", pod.Namespace, pod.Name, err)

--- a/pkg/gcmanager/tracePod_worker.go
+++ b/pkg/gcmanager/tracePod_worker.go
@@ -5,17 +5,22 @@ package gcmanager
 
 import (
 	"context"
+	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/spidernet-io/spiderpool/pkg/constant"
 	"github.com/spidernet-io/spiderpool/pkg/metric"
 	"github.com/spidernet-io/spiderpool/pkg/types"
 	"github.com/spidernet-io/spiderpool/pkg/utils/convert"
 )
+
+var errRequeue = fmt.Errorf("requeue")
 
 // tracePodWorker will circle traverse PodEntry database
 func (s *SpiderGC) tracePodWorker(ctx context.Context) {
@@ -56,7 +61,6 @@ func (s *SpiderGC) handlePodEntryForTracingTimeOut(podEntry *PodEntry) {
 	select {
 	case s.gcIPPoolIPSignal <- podEntry:
 		logger.Sugar().Debugf("sending signal to gc pod '%s/%s' IP", podEntry.Namespace, podEntry.PodName)
-		s.PodDB.DeletePodEntry(podEntry.Namespace, podEntry.PodName)
 
 	case <-time.After(time.Duration(s.gcConfig.GCSignalTimeoutDuration) * time.Second):
 		logger.Sugar().Errorf("failed to gc IP, gcSignal:len=%d, event:'%s/%s' will be dropped", len(s.gcSignal), podEntry.Namespace, podEntry.PodName)
@@ -65,77 +69,99 @@ func (s *SpiderGC) handlePodEntryForTracingTimeOut(podEntry *PodEntry) {
 
 // releaseIPPoolIPExecutor receive signals to execute gc IP
 func (s *SpiderGC) releaseIPPoolIPExecutor(ctx context.Context, workerIndex int) {
-	loggerReleaseIP := logger.With(zap.Any("IPPoolIP_Worker", workerIndex))
-	loggerReleaseIP.Info("Starting running 'releaseIPPoolIPExecutor'")
+	log := logger.With(zap.Any("IPPoolIP_Worker", workerIndex))
+	log.Info("Starting running 'releaseIPPoolIPExecutor'")
 
 	for {
 		select {
 		case podCache := <-s.gcIPPoolIPSignal:
-			endpoint, err := s.wepMgr.GetEndpointByName(ctx, podCache.Namespace, podCache.PodName, constant.UseCache)
-			if nil != err {
-				if apierrors.IsNotFound(err) {
-					loggerReleaseIP.Sugar().Infof("SpiderEndpoint '%s/%s' not found, maybe already cleaned by ScanAll", podCache.Namespace, podCache.PodName)
-					continue
-				}
-
-				loggerReleaseIP.Sugar().Errorf("failed to get SpiderEndpoint '%s/%s', error: %v", podCache.Namespace, podCache.PodName, err)
-				continue
-			}
-
-			// we need to gather the pod corresponding SpiderEndpoint allocation data to get the used history IPs.
-			podUsedIPs := convert.GroupIPAllocationDetails(endpoint.Status.Current.UID, endpoint.Status.Current.IPs)
-			tickets := podUsedIPs.Pools()
-			err = s.gcLimiter.AcquireTicket(ctx, tickets...)
-			if nil != err {
-				logger.Sugar().Errorf("failed to get IP GC limiter tickets, error: %v", err)
-			}
-
-			wg := sync.WaitGroup{}
-			wg.Add(len(podUsedIPs))
-			// release pod used history IPs
-			for tmpPoolName, tmpIPs := range podUsedIPs {
-				go func(poolName string, ips []types.IPAndUID) {
-					defer wg.Done()
-
-					loggerReleaseIP.Sugar().Infof("pod '%s/%s used IPs '%+v' from pool '%s', begin to release",
-						podCache.Namespace, podCache.PodName, ips, poolName)
-
-					err := s.ippoolMgr.ReleaseIP(ctx, poolName, ips)
-					if nil != err {
-						metric.IPGCFailureCounts.Add(ctx, 1)
-						loggerReleaseIP.Sugar().Errorf("failed to release pool '%s' IPs '%+v' in SpiderEndpoint '%s/%s', error: %v",
-							poolName, ips, podCache.Namespace, podCache.PodName, err)
-					}
-					metric.IPGCTotalCounts.Add(ctx, 1)
-				}(tmpPoolName, tmpIPs)
-			}
-			wg.Wait()
-
-			// we need to release tickets after we finish this ip gc task
-			s.gcLimiter.ReleaseTicket(ctx, tickets...)
-			loggerReleaseIP.Sugar().Infof("release IPPoolIP task '%+v' successfully", *podCache)
-
-			// delete StatefulSet wep (other controller wep has OwnerReference, its lifecycle is same with pod)
-			if endpoint.Status.OwnerControllerType == constant.KindStatefulSet && endpoint.DeletionTimestamp == nil {
-				err = s.wepMgr.DeleteEndpoint(ctx, endpoint)
+			err := func() error {
+				endpoint, err := s.wepMgr.GetEndpointByName(ctx, podCache.Namespace, podCache.PodName, constant.UseCache)
 				if nil != err {
-					loggerReleaseIP.Sugar().Errorf("failed to delete StatefulSet wep '%s/%s', error: '%v'",
-						podCache.Namespace, podCache.PodName, err)
-					continue
+					if apierrors.IsNotFound(err) {
+						log.Sugar().Infof("SpiderEndpoint '%s/%s' not found, maybe already cleaned by cmdDel or ScanAll",
+							podCache.Namespace, podCache.PodName)
+						return nil
+					}
+
+					log.Sugar().Errorf("failed to get SpiderEndpoint '%s/%s', error: %v", podCache.Namespace, podCache.PodName, err)
+					return err
 				}
-			}
 
-			err = s.wepMgr.RemoveFinalizer(ctx, endpoint)
-			if nil != err {
-				loggerReleaseIP.Sugar().Errorf("failed to remove wep '%s/%s' finalizer, error: '%v'",
-					podCache.Namespace, podCache.PodName, err)
-				continue
-			}
-			loggerReleaseIP.Sugar().Infof("remove wep '%s/%s' finalizer '%s' successfully",
-				podCache.Namespace, podCache.PodName, constant.SpiderFinalizer)
+				// we need to gather the pod corresponding SpiderEndpoint allocation data to get the used history IPs.
+				podUsedIPs := convert.GroupIPAllocationDetails(endpoint.Status.Current.UID, endpoint.Status.Current.IPs)
+				tickets := podUsedIPs.Pools()
+				err = s.gcLimiter.AcquireTicket(ctx, tickets...)
+				if nil != err {
+					log.Sugar().Errorf("failed to get IP GC limiter tickets, error: %v", err)
+				}
+				defer s.gcLimiter.ReleaseTicket(ctx, tickets...)
 
+				var isReleaseFailed atomic.Bool
+				wg := sync.WaitGroup{}
+				wg.Add(len(podUsedIPs))
+				// release pod used history IPs
+				for tmpPoolName, tmpIPs := range podUsedIPs {
+					go func(poolName string, ips []types.IPAndUID) {
+						defer wg.Done()
+
+						log.Sugar().Infof("pod '%s/%s used IPs '%+v' from pool '%s', begin to release",
+							podCache.Namespace, podCache.PodName, ips, poolName)
+
+						err := s.ippoolMgr.ReleaseIP(ctx, poolName, ips)
+						if nil != err {
+							isReleaseFailed.Store(true)
+							metric.IPGCFailureCounts.Add(ctx, 1)
+							log.Sugar().Errorf("failed to release pool '%s' IPs '%+v' in SpiderEndpoint '%s/%s', error: %v",
+								poolName, ips, podCache.Namespace, podCache.PodName, err)
+						}
+						metric.IPGCTotalCounts.Add(ctx, 1)
+					}(tmpPoolName, tmpIPs)
+				}
+				wg.Wait()
+
+				if isReleaseFailed.Load() {
+					log.Debug("there are releasing failure in this round, we want to get a try next time")
+					return errRequeue
+				}
+
+				// delete StatefulSet wep (other controller wep has OwnerReference, its lifecycle is same with pod)
+				if endpoint.Status.OwnerControllerType == constant.KindStatefulSet && endpoint.DeletionTimestamp == nil {
+					err = s.wepMgr.DeleteEndpoint(ctx, endpoint)
+					if nil != err {
+						log.Sugar().Errorf("failed to delete StatefulSet wep '%s/%s', error: '%v'",
+							podCache.Namespace, podCache.PodName, err)
+						return err
+					}
+				}
+
+				err = s.wepMgr.RemoveFinalizer(ctx, endpoint)
+				if nil != err {
+					log.Sugar().Errorf("failed to remove wep '%s/%s' finalizer, error: '%v'",
+						podCache.Namespace, podCache.PodName, err)
+					return err
+				}
+				log.Sugar().Infof("remove wep '%s/%s' finalizer '%s' successfully",
+					podCache.Namespace, podCache.PodName, constant.SpiderFinalizer)
+
+				return nil
+			}()
+
+			if nil != err && podCache.NumRequeues < s.gcConfig.WorkQueueMaxRetries {
+				log.Sugar().Debugf("requeue PodEntry '%s/%s' and get a retry next time", podCache.Namespace, podCache.PodName)
+
+				podCache.EntryUpdateTime = metav1.Now().UTC()
+				podCache.NumRequeues++
+				err := s.PodDB.ApplyPodEntry(podCache)
+				if nil != err {
+					log.Error(err.Error())
+					s.PodDB.DeletePodEntry(podCache.Namespace, podCache.PodName)
+				}
+			} else {
+				s.PodDB.DeletePodEntry(podCache.Namespace, podCache.PodName)
+			}
 		case <-ctx.Done():
-			loggerReleaseIP.Info("receive ctx done, stop running releaseIPPoolIPExecutor")
+			log.Info("receive ctx done, stop running releaseIPPoolIPExecutor")
 			return
 		}
 	}


### PR DESCRIPTION
The spiderpool with the previous version, the IP GC `pod informer` mechanism will only try to release IP once.
In a big cluster, for instance if you have one deployment with 1000 replicas and you gonna delete the deployment. There will be one situation the CNI cmdDel was called with IP GC `pod informer` worker are concurrent. (The kubernetes controller would not delete the whole 1000 pods at the same time.)
In this case, the `pod informer` worker release IP will also meet conflict and we need the IP GC `scan all` mechanism to release the legacy IPs in the end.

So, I just let the IP GC `pod informer` worker release operation several times when it meets conflict. This will make IP GC more efficient.

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)