### PR TITLE
optimize the getTopController method source codes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,7 @@ unitest-tests: check_test_label
 	$(QUIET) $(ROOT_DIR)/tools/scripts/ginkgo.sh \
 		--cover --coverprofile=./coverage.out --covermode set \
 		--json-report unitestreport.json \
-		-randomize-suites -randomize-all --keep-going  --timeout=1h  -p \
+		-randomize-suites -randomize-all --keep-going  --timeout=1h  -p -gcflags=all=-l \
 		-vv  -r $(ROOT_DIR)/pkg $(ROOT_DIR)/cmd
 	$(QUIET) go tool cover -html=./coverage.out -o coverage-all.html
 

--- a/pkg/podmanager/pod_manager.go
+++ b/pkg/podmanager/pod_manager.go
@@ -124,37 +124,26 @@ func (pm *podManager) GetPodTopController(ctx context.Context, pod *corev1.Pod) 
 		}
 
 		replicasetOwner := metav1.GetControllerOf(&replicaset)
-		if replicasetOwner != nil {
-			if replicasetOwner.APIVersion == appsv1.SchemeGroupVersion.String() && replicasetOwner.Kind == constant.KindDeployment {
-				var deployment appsv1.Deployment
-				err = pm.client.Get(ctx, apitypes.NamespacedName{Namespace: replicaset.Namespace, Name: replicasetOwner.Name}, &deployment)
-				if nil != err {
-					return types.PodTopController{}, fmt.Errorf("%w: %v", ownerErr, err)
-				}
-				return types.PodTopController{
-					AppNamespacedName: types.AppNamespacedName{
-						// deployment.APIVersion is empty string
-						APIVersion: appsv1.SchemeGroupVersion.String(),
-						Kind:       constant.KindDeployment,
-						Namespace:  deployment.Namespace,
-						Name:       deployment.Name,
-					},
-					UID: deployment.UID,
-					APP: &deployment,
-				}, nil
+		// kubernetes deployment
+		if replicasetOwner != nil && (replicasetOwner.APIVersion == appsv1.SchemeGroupVersion.String() && replicasetOwner.Kind == constant.KindDeployment) {
+			var deployment appsv1.Deployment
+			err = pm.client.Get(ctx, apitypes.NamespacedName{Namespace: replicaset.Namespace, Name: replicasetOwner.Name}, &deployment)
+			if nil != err {
+				return types.PodTopController{}, fmt.Errorf("%w: %v", ownerErr, err)
 			}
-
-			logger.Sugar().Warnf("the controller type '%s' of pod '%s/%s' is unknown", replicasetOwner.Kind, pod.Namespace, pod.Name)
 			return types.PodTopController{
 				AppNamespacedName: types.AppNamespacedName{
-					APIVersion: replicasetOwner.APIVersion,
-					Kind:       replicasetOwner.Kind,
-					Namespace:  pod.Namespace,
-					Name:       replicasetOwner.Name,
+					// deployment.APIVersion is empty string
+					APIVersion: appsv1.SchemeGroupVersion.String(),
+					Kind:       constant.KindDeployment,
+					Namespace:  deployment.Namespace,
+					Name:       deployment.Name,
 				},
-				UID: replicasetOwner.UID,
+				UID: deployment.UID,
+				APP: &deployment,
 			}, nil
 		}
+		// we don't care if the replicaSet object has a third-party controller, we just return the replicaSet directly.
 		return types.PodTopController{
 			AppNamespacedName: types.AppNamespacedName{
 				APIVersion: appsv1.SchemeGroupVersion.String(),
@@ -173,36 +162,25 @@ func (pm *podManager) GetPodTopController(ctx context.Context, pod *corev1.Pod) 
 			return types.PodTopController{}, fmt.Errorf("%w: %v", ownerErr, err)
 		}
 		jobOwner := metav1.GetControllerOf(&job)
-		if jobOwner != nil {
-			if jobOwner.APIVersion == batchv1.SchemeGroupVersion.String() && jobOwner.Kind == constant.KindCronJob {
-				var cronJob batchv1.CronJob
-				err = pm.client.Get(ctx, apitypes.NamespacedName{Namespace: job.Namespace, Name: jobOwner.Name}, &cronJob)
-				if nil != err {
-					return types.PodTopController{}, fmt.Errorf("%w: %v", ownerErr, err)
-				}
-				return types.PodTopController{
-					AppNamespacedName: types.AppNamespacedName{
-						APIVersion: batchv1.SchemeGroupVersion.String(),
-						Kind:       constant.KindCronJob,
-						Namespace:  cronJob.Namespace,
-						Name:       cronJob.Name,
-					},
-					UID: cronJob.UID,
-					APP: &cronJob,
-				}, nil
+		// cronJob
+		if jobOwner != nil && (jobOwner.APIVersion == batchv1.SchemeGroupVersion.String() && jobOwner.Kind == constant.KindCronJob) {
+			var cronJob batchv1.CronJob
+			err = pm.client.Get(ctx, apitypes.NamespacedName{Namespace: job.Namespace, Name: jobOwner.Name}, &cronJob)
+			if nil != err {
+				return types.PodTopController{}, fmt.Errorf("%w: %v", ownerErr, err)
 			}
-
-			logger.Sugar().Warnf("the controller type '%s' of pod '%s/%s' is unknown", jobOwner.Kind, pod.Namespace, pod.Name)
 			return types.PodTopController{
 				AppNamespacedName: types.AppNamespacedName{
-					APIVersion: jobOwner.APIVersion,
-					Kind:       jobOwner.Kind,
-					Namespace:  job.Namespace,
-					Name:       jobOwner.Name,
+					APIVersion: batchv1.SchemeGroupVersion.String(),
+					Kind:       constant.KindCronJob,
+					Namespace:  cronJob.Namespace,
+					Name:       cronJob.Name,
 				},
-				UID: jobOwner.UID,
+				UID: cronJob.UID,
+				APP: &cronJob,
 			}, nil
 		}
+		// we don't care if the job object has a third-party controller, we just return the job directly.
 		return types.PodTopController{
 			AppNamespacedName: types.AppNamespacedName{
 				APIVersion: batchv1.SchemeGroupVersion.String(),


### PR DESCRIPTION
In the previous source codes, if the kubernetes replicaset is controlled by a third-party controller, I'll return the third-party controller when podManager `GetPodTopController` method is called. (same with kubernetes job).

Deep into consideration, I think that there's no need to care about the replicaset third-party controller because the pod behavior is controlled by the replicaset.

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)