### PR TITLE
forbidden modifying auto-created IPPool by hand

### DIFF
--- a/pkg/ippoolmanager/ippool_subnet_validate.go
+++ b/pkg/ippoolmanager/ippool_subnet_validate.go
@@ -4,8 +4,12 @@
 package ippoolmanager
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"net"
+	"reflect"
+	"sort"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
@@ -13,6 +17,7 @@ import (
 
 	spiderpoolip "github.com/spidernet-io/spiderpool/pkg/ip"
 	spiderpoolv2beta1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1"
+	"github.com/spidernet-io/spiderpool/pkg/utils/convert"
 )
 
 func (iw *IPPoolWebhook) validateCreateIPPoolWhileEnableSpiderSubnet(ctx context.Context, ipPool *spiderpoolv2beta1.SpiderIPPool) field.ErrorList {
@@ -77,6 +82,48 @@ func (iw *IPPoolWebhook) validateSubnetTotalIPsContainsIPPoolTotalIPs(ctx contex
 			ipsField,
 			fmt.Sprintf("add some IP ranges %v that are not contained in controller Subnet %s, total IP addresses of an IPPool are jointly determined by 'spec.ips' and 'spec.excludeIPs'", ranges, subnet.Name),
 		)
+	}
+
+	if IsAutoCreatedIPPool(ipPool) {
+		return validateNewAutoPoolTotalIPsWithinSubnet(ipPool, &subnet)
+	}
+
+	return nil
+}
+
+func validateNewAutoPoolTotalIPsWithinSubnet(pool *spiderpoolv2beta1.SpiderIPPool, subnet *spiderpoolv2beta1.SpiderSubnet) *field.Error {
+	var subnetPreAllocateIPs []net.IP
+
+	poolTotalIPs, err := spiderpoolip.AssembleTotalIPs(*pool.Spec.IPVersion, pool.Spec.IPs, pool.Spec.ExcludeIPs)
+	if nil != err {
+		return field.InternalError(ipsField, fmt.Errorf("failed to assemble the total IP addresses of the Subnet %s: %v", subnet.Name, err))
+	}
+	sort.Slice(poolTotalIPs, func(i, j int) bool {
+		return bytes.Compare(poolTotalIPs[i].To16(), poolTotalIPs[j].To16()) < 0
+	})
+
+	subnetAllocatedIPPools, err := convert.UnmarshalSubnetAllocatedIPPools(subnet.Status.ControlledIPPools)
+	if nil != err {
+		return field.InternalError(subnetField, fmt.Errorf("failed unsharmal SpiderSubnet %s Status.ControlledIPPools: %v", subnet.Name, err))
+	}
+	if subnetAllocatedIPPools != nil {
+		subnetPoolAllocation, ok := subnetAllocatedIPPools[pool.Name]
+		if ok {
+			subnetPoolIPs, err := spiderpoolip.ParseIPRanges(*subnet.Spec.IPVersion, subnetPoolAllocation.IPs)
+			if nil != err {
+				return field.InternalError(subnetField, fmt.Errorf("failed to parse SpiderSubnet %s controlledIPPool %s IPs: %v ", subnet.Name, pool.Name, err))
+			}
+			sort.Slice(subnetPoolIPs, func(i, j int) bool {
+				return bytes.Compare(subnetPoolIPs[i].To16(), subnetPoolIPs[j].To16()) < 0
+			})
+			subnetPreAllocateIPs = subnetPoolIPs
+		}
+	}
+
+	isEqual := reflect.DeepEqual(subnetPreAllocateIPs, poolTotalIPs)
+	if !isEqual {
+		return field.Forbidden(ipsField,
+			"it's illegal to update AutoPool.Spec.IPs that are different from corresponding SpiderSubnet.Status.ControlledIPPools")
 	}
 
 	return nil

--- a/pkg/ippoolmanager/ippool_webhook_test.go
+++ b/pkg/ippoolmanager/ippool_webhook_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/agiledragon/gomonkey/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -22,11 +23,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	"github.com/spidernet-io/spiderpool/pkg/applicationcontroller/applicationinformers"
 	"github.com/spidernet-io/spiderpool/pkg/constant"
 	spiderpoolip "github.com/spidernet-io/spiderpool/pkg/ip"
 	"github.com/spidernet-io/spiderpool/pkg/ippoolmanager"
 	spiderpoolv2beta1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1"
 	"github.com/spidernet-io/spiderpool/pkg/logutils"
+	"github.com/spidernet-io/spiderpool/pkg/types"
 	"github.com/spidernet-io/spiderpool/pkg/utils/convert"
 )
 
@@ -1592,6 +1595,82 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 
 					err = ipPoolWebhook.ValidateUpdate(ctx, ipPoolT, newIPPoolT)
 					Expect(apierrors.IsInvalid(err)).To(BeTrue())
+				})
+
+				It("update auto-created IPPool by hand", func() {
+					subnetT.SetUID(uuid.NewUUID())
+					subnetT.Spec.IPVersion = pointer.Int64(constant.IPv4)
+					subnetT.Spec.Subnet = "172.18.40.0/24"
+					subnetT.Spec.IPs = append(subnetT.Spec.IPs, "172.18.40.1-172.18.40.2")
+
+					autoPool := ipPoolT.DeepCopy()
+					autoPool.Annotations = map[string]string{constant.AnnoSpiderSubnetPoolApp: applicationinformers.ApplicationNamespacedName(types.AppNamespacedName{
+						APIVersion: appsv1.SchemeGroupVersion.String(),
+						Kind:       constant.KindDeployment,
+						Namespace:  autoPool.Namespace,
+						Name:       autoPool.Name,
+					})}
+					autoPool.Spec.IPVersion = pointer.Int64(constant.IPv4)
+					autoPool.Spec.Subnet = "172.18.40.0/24"
+					autoPool.Spec.IPs = append(autoPool.Spec.IPs, "172.18.40.1")
+
+					err := controllerutil.SetControllerReference(subnetT, autoPool, scheme)
+					Expect(err).NotTo(HaveOccurred())
+					poolIPPreAllocations := spiderpoolv2beta1.PoolIPPreAllocations{autoPool.Name: spiderpoolv2beta1.PoolIPPreAllocation{
+						IPs:         []string{"172.18.40.1"},
+						Application: pointer.String(autoPool.Annotations[constant.AnnoSpiderSubnetPoolApp]),
+					}}
+					subnetAllocatedIPPools, err := convert.MarshalSubnetAllocatedIPPools(poolIPPreAllocations)
+					Expect(err).NotTo(HaveOccurred())
+					subnetT.Status.ControlledIPPools = subnetAllocatedIPPools
+
+					err = tracker.Add(subnetT)
+					Expect(err).NotTo(HaveOccurred())
+
+					newAutoPool := autoPool.DeepCopy()
+					newAutoPool.Spec.IPs = append(newAutoPool.Spec.IPs, "172.18.40.2")
+
+					err = ipPoolWebhook.ValidateUpdate(ctx, autoPool, newAutoPool)
+					Expect(apierrors.IsInvalid(err)).To(BeTrue())
+				})
+
+				It("update auto-created IPPool annotation", func() {
+					subnetT.SetUID(uuid.NewUUID())
+					subnetT.Spec.IPVersion = pointer.Int64(constant.IPv4)
+					subnetT.Spec.Subnet = "172.18.40.0/24"
+					subnetT.Spec.IPs = append(subnetT.Spec.IPs, "172.18.40.1-172.18.40.2")
+
+					autoPool := ipPoolT.DeepCopy()
+					autoPool.Annotations = map[string]string{constant.AnnoSpiderSubnetPoolApp: applicationinformers.ApplicationNamespacedName(types.AppNamespacedName{
+						APIVersion: appsv1.SchemeGroupVersion.String(),
+						Kind:       constant.KindDeployment,
+						Namespace:  autoPool.Namespace,
+						Name:       autoPool.Name,
+					})}
+					autoPool.Spec.IPVersion = pointer.Int64(constant.IPv4)
+					autoPool.Spec.Subnet = "172.18.40.0/24"
+					autoPool.Spec.IPs = append(autoPool.Spec.IPs, "172.18.40.1")
+
+					err := controllerutil.SetControllerReference(subnetT, autoPool, scheme)
+					Expect(err).NotTo(HaveOccurred())
+					poolIPPreAllocations := spiderpoolv2beta1.PoolIPPreAllocations{autoPool.Name: spiderpoolv2beta1.PoolIPPreAllocation{
+						IPs:         []string{"172.18.40.1"},
+						Application: pointer.String(autoPool.Annotations[constant.AnnoSpiderSubnetPoolApp]),
+					}}
+					subnetAllocatedIPPools, err := convert.MarshalSubnetAllocatedIPPools(poolIPPreAllocations)
+					Expect(err).NotTo(HaveOccurred())
+					subnetT.Status.ControlledIPPools = subnetAllocatedIPPools
+
+					err = tracker.Add(subnetT)
+					Expect(err).NotTo(HaveOccurred())
+
+					newAutoPool := autoPool.DeepCopy()
+					anno := newAutoPool.GetAnnotations()
+					anno["aaa"] = "test"
+					newAutoPool.Annotations = anno
+
+					err = ipPoolWebhook.ValidateUpdate(ctx, autoPool, newAutoPool)
+					Expect(err).NotTo(HaveOccurred())
 				})
 			})
 


### PR DESCRIPTION
For the auto-created IPPool with SpiderSubnet feature, it's allow to change the Spec.IPs by yourself in the previous version. But it's a little strange to do that, because the spiderpool-controller will turn it back with the auto desired IP number later.

So, I think we should forbidden modifying auto-created IPPool by hand.

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)

**What this PR does / why we need it**:
fix bug

**Which issue(s) this PR fixes**:
https://github.com/spidernet-io/spiderpool/issues/1609

