### PR TITLE
support third-party auto-created pool delete

### DIFF
--- a/charts/spiderpool/templates/role.yaml
+++ b/charts/spiderpool/templates/role.yaml
@@ -35,6 +35,8 @@ rules:
   - '*'
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/cmd/spiderpool-controller/cmd/daemon.go
+++ b/cmd/spiderpool-controller/cmd/daemon.go
@@ -433,6 +433,7 @@ func setupInformers() {
 			ResyncPeriod:                  time.Duration(controllerContext.Cfg.IPPoolInformerResyncPeriod) * time.Second,
 		},
 		controllerContext.CRDManager.GetClient(),
+		controllerContext.DynamicClient,
 	)
 	err = ipPoolController.SetupInformer(controllerContext.InnerCtx, crdClient, controllerContext.Leader)
 	if nil != err {
@@ -444,11 +445,11 @@ func setupInformers() {
 		if err := (&subnetmanager.SubnetController{
 			Client:                  controllerContext.CRDManager.GetClient(),
 			APIReader:               controllerContext.CRDManager.GetAPIReader(),
-			DynamicClient:           controllerContext.DynamicClient,
 			LeaderRetryElectGap:     time.Duration(controllerContext.Cfg.LeaseRetryGap) * time.Second,
 			ResyncPeriod:            time.Duration(controllerContext.Cfg.SubnetResyncPeriod) * time.Second,
 			SubnetControllerWorkers: controllerContext.Cfg.SubnetInformerWorkers,
 			MaxWorkqueueLength:      controllerContext.Cfg.SubnetInformerMaxWorkqueueLength,
+			DynamicClient:           controllerContext.DynamicClient,
 		}).SetupInformer(controllerContext.InnerCtx, crdClient, controllerContext.Leader); err != nil {
 			logger.Fatal(err.Error())
 		}

--- a/pkg/applicationcontroller/applicationinformers/utils.go
+++ b/pkg/applicationcontroller/applicationinformers/utils.go
@@ -4,6 +4,7 @@
 package applicationinformers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -12,8 +13,19 @@ import (
 	"strings"
 
 	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/utils/pointer"
+	"k8s.io/utils/strings/slices"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/spidernet-io/spiderpool/pkg/constant"
 	spiderpoolip "github.com/spidernet-io/spiderpool/pkg/ip"
@@ -337,4 +349,86 @@ func ShouldReclaimIPPool(anno map[string]string) (bool, error) {
 
 	// no specified reclaim-IPPool, default to set it true
 	return true, nil
+}
+
+// IsAppExist will check the application whether exists or not. If it exists, it will return the application corresponding UID
+func IsAppExist(ctx context.Context, cacheClient client.Client, dynamicClient dynamic.Interface, appNamespacedName types.AppNamespacedName) (isExist bool, appUID apitypes.UID, err error) {
+	var object client.Object
+	isThird := false
+
+	if slices.Contains(constant.K8sAPIVersions, appNamespacedName.APIVersion) {
+		switch appNamespacedName.Kind {
+		case constant.KindPod:
+			object = &corev1.Pod{}
+		case constant.KindDeployment:
+			object = &appsv1.Deployment{}
+		case constant.KindReplicaSet:
+			object = &appsv1.ReplicaSet{}
+		case constant.KindDaemonSet:
+			object = &appsv1.DaemonSet{}
+		case constant.KindStatefulSet:
+			object = &appsv1.StatefulSet{}
+		case constant.KindJob:
+			object = &batchv1.Job{}
+		case constant.KindCronJob:
+			object = &batchv1.CronJob{}
+		default:
+			isThird = true
+		}
+	} else {
+		isThird = true
+	}
+
+	var unstructuredObject *unstructured.Unstructured
+	if isThird {
+		gvr, e := GenerateGVR(appNamespacedName)
+		if nil != e {
+			return false, "", e
+		}
+		unstructuredObject, err = dynamicClient.Resource(gvr).Namespace(appNamespacedName.Namespace).Get(ctx, appNamespacedName.Name, metav1.GetOptions{})
+	} else {
+		err = cacheClient.Get(ctx, apitypes.NamespacedName{Namespace: appNamespacedName.Namespace, Name: appNamespacedName.Name}, object)
+	}
+
+	if nil != err {
+		// if the application is no longer exist, we should delete the IPPool
+		if apierrors.IsNotFound(err) {
+			return false, "", nil
+		}
+
+		return false, "", err
+	}
+
+	if unstructuredObject != nil {
+		appUID = unstructuredObject.GetUID()
+	} else {
+		appUID = object.GetUID()
+	}
+
+	return true, appUID, nil
+}
+
+func GenerateGVR(appNamespacedName types.AppNamespacedName) (schema.GroupVersionResource, error) {
+	gv, err := schema.ParseGroupVersion(appNamespacedName.APIVersion)
+	if nil != err {
+		return schema.GroupVersionResource{}, err
+	}
+
+	gvk := gv.WithKind(appNamespacedName.Kind)
+	gvrPlural, _ := meta.UnsafeGuessKindToResource(gvk)
+
+	return gvrPlural, nil
+}
+
+func IsThirdController(appNamespacedName types.AppNamespacedName) bool {
+	isThird := false
+	if slices.Contains(constant.K8sAPIVersions, appNamespacedName.APIVersion) {
+		if !slices.Contains(constant.K8sKinds, appNamespacedName.Kind) {
+			isThird = true
+		}
+	} else {
+		isThird = true
+	}
+
+	return isThird
 }

--- a/pkg/ipam/pool_selections.go
+++ b/pkg/ipam/pool_selections.go
@@ -148,7 +148,7 @@ func (i *ipam) getPoolFromSubnetAnno(ctx context.Context, pod *corev1.Pod, nic s
 				pool, err = i.applyThirdControllerAutoPool(ctx, subnetName, poolName, podController, types.AutoPoolProperty{
 					DesiredIPNumber: poolIPNum,
 					IPVersion:       ipVersion,
-					IsReclaimIPPool: false,
+					IsReclaimIPPool: subnetAnnoConfig.ReclaimIPPool,
 					IfName:          nic,
 					PodSelector:     nil,
 				})

--- a/pkg/ippoolmanager/ippool_informer.go
+++ b/pkg/ippoolmanager/ippool_informer.go
@@ -11,16 +11,13 @@ import (
 	"time"
 
 	"go.uber.org/zap"
-	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	apitypes "k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/pointer"
-	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -41,6 +38,7 @@ var informerLogger *zap.Logger
 type IPPoolController struct {
 	IPPoolControllerConfig
 	client        client.Client
+	dynamicClient dynamic.Interface
 	poolLister    listers.SpiderIPPoolLister
 	poolSynced    cache.InformerSynced
 	poolWorkqueue workqueue.RateLimitingInterface
@@ -56,12 +54,13 @@ type IPPoolControllerConfig struct {
 	ResyncPeriod                  time.Duration
 }
 
-func NewIPPoolController(poolControllerConfig IPPoolControllerConfig, client client.Client) *IPPoolController {
+func NewIPPoolController(poolControllerConfig IPPoolControllerConfig, client client.Client, dynamicClient dynamic.Interface) *IPPoolController {
 	informerLogger = logutils.Logger.Named("SpiderIPPool-Informer")
 
 	c := &IPPoolController{
 		IPPoolControllerConfig: poolControllerConfig,
 		client:                 client,
+		dynamicClient:          dynamicClient,
 	}
 
 	return c
@@ -359,7 +358,7 @@ func (ic *IPPoolController) removeFinalizer(ctx context.Context, pool *spiderpoo
 	return nil
 }
 
-// cleanAutoIPPoolLegacy checks whether the given IPPool should be deleted or not, and the return params can show the IPPool is deleted or not
+// cleanAutoIPPoolLegacy checks whether the given IPPool should be deleted or not
 func (ic *IPPoolController) cleanAutoIPPoolLegacy(ctx context.Context, pool *spiderpoolv2beta1.SpiderIPPool) error {
 	if pool.DeletionTimestamp != nil {
 		return nil
@@ -373,25 +372,7 @@ func (ic *IPPoolController) cleanAutoIPPoolLegacy(ctx context.Context, pool *spi
 		return nil
 	}
 
-	check := false
 	if pool.Status.AllocatedIPs == nil {
-		check = true
-	} else {
-		var poolIPAllocations spiderpoolv2beta1.PoolIPAllocations
-		err := json.Unmarshal([]byte(*pool.Status.AllocatedIPs), &poolIPAllocations)
-		if nil != err {
-			return fmt.Errorf("%w: failed to parse IPPool %s Status AllocatedIPs: %v",
-				constant.ErrWrongInput, pool.Name, err)
-		}
-
-		// Once an application was deleted we can make sure that the corresponding IPPool's IPs will be cleaned up because we have IP GC.
-		// If the IPPool is cleaned, we'll check whether the IPPool's corresponding application is existed or not and process it.
-		if len(poolIPAllocations) == 0 {
-			check = true
-		}
-	}
-
-	if check {
 		// 	// unpack the IPPool corresponding application type,namespace and name
 		appNamespacedNameStr := pool.Annotations[constant.AnnoSpiderSubnetPoolApp]
 		appNamespacedName, isMatch := applicationinformers.ParseApplicationNamespacedName(appNamespacedNameStr)
@@ -399,50 +380,25 @@ func (ic *IPPoolController) cleanAutoIPPoolLegacy(ctx context.Context, pool *spi
 			return fmt.Errorf("%w: invalid IPPool annotation '%s' value '%s'", constant.ErrWrongInput, constant.AnnoSpiderSubnetPoolApp, appNamespacedNameStr)
 		}
 
-		var object client.Object
-		if slices.Contains(constant.K8sAPIVersions, appNamespacedName.APIVersion) {
-			switch appNamespacedName.Kind {
-			case constant.KindDeployment:
-				object = &appsv1.Deployment{}
-			case constant.KindReplicaSet:
-				object = &appsv1.ReplicaSet{}
-			case constant.KindDaemonSet:
-				object = &appsv1.DaemonSet{}
-			case constant.KindStatefulSet:
-				object = &appsv1.StatefulSet{}
-			case constant.KindJob:
-				object = &batchv1.Job{}
-			case constant.KindCronJob:
-				object = &batchv1.CronJob{}
-			default:
-				// third-party controllers IPPools need to be cleaned up by the users
-				return nil
-			}
-		} else {
-			// third-party controllers IPPools need to be cleaned up by the users
-			return nil
-		}
-
 		enableDelete := false
 		// check the IPPool's corresponding application whether is existed or not
 		informerLogger.Sugar().Debugf("try to get auto-created IPPool '%s' corresponding application '%s/%s/%s'",
 			pool.Name, appNamespacedName.Kind, appNamespacedName.Namespace, appNamespacedName.Name)
-		err := ic.client.Get(ctx, apitypes.NamespacedName{Namespace: appNamespacedName.Namespace, Name: appNamespacedName.Name}, object)
+		isAppExist, appUID, err := applicationinformers.IsAppExist(ctx, ic.client, ic.dynamicClient, appNamespacedName)
 		if nil != err {
-			// if the application is no longer exist, we should delete the IPPool
-			if apierrors.IsNotFound(err) {
-				informerLogger.Sugar().Warnf("auto-created IPPool '%s' corresponding application '%s/%s/%s' is no longer exist, try to gc IPPool",
-					pool.Name, appNamespacedName.Kind, appNamespacedName.Namespace, appNamespacedName.Name)
-				enableDelete = true
-			} else {
-				return fmt.Errorf("failed to get auto-created IPPool '%s' corresponding application '%s/%s/%s': %w",
-					pool.Name, appNamespacedName.Kind, appNamespacedName.Namespace, appNamespacedName.Name, err)
-			}
+			return fmt.Errorf("failed to get auto-created IPPool '%s' corresponding application '%s/%s/%s': %w",
+				pool.Name, appNamespacedName.Kind, appNamespacedName.Namespace, appNamespacedName.Name, err)
+		}
+
+		// mismatch application UID
+		if !isAppExist {
+			informerLogger.Sugar().Warnf("auto-created IPPool '%s' corresponding application '%s/%s/%s' no longer exist, try to delete IPPool",
+				pool.Name, appNamespacedName.Kind, appNamespacedName.Namespace, appNamespacedName.Name)
+			enableDelete = true
 		} else {
-			// mismatch application UID
-			if string(object.GetUID()) != poolLabels[constant.LabelIPPoolOwnerApplicationUID] {
-				informerLogger.Sugar().Warnf("auto-created IPPool '%v' mismatches application '%s/%s/%s' UID '%s', try to gc IPPool",
-					pool, appNamespacedName.Kind, appNamespacedName.Namespace, appNamespacedName.Name, object.GetUID())
+			if string(appUID) != poolLabels[constant.LabelIPPoolOwnerApplicationUID] {
+				informerLogger.Sugar().Warnf("auto-created IPPool '%s' mismatches application '%s/%s/%s' UID '%s', try to delete IPPool",
+					pool.Name, appNamespacedName.Kind, appNamespacedName.Namespace, appNamespacedName.Name, appUID)
 				enableDelete = true
 			}
 		}
@@ -450,7 +406,7 @@ func (ic *IPPoolController) cleanAutoIPPoolLegacy(ctx context.Context, pool *spi
 		if enableDelete {
 			err := ic.client.Delete(ctx, pool)
 			if client.IgnoreNotFound(err) != nil {
-				return err
+				return fmt.Errorf("failed to delete legacy auto-created IPPool %s: %w", pool.Name, err)
 			}
 			return nil
 		}

--- a/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/rbac.go
+++ b/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/rbac.go
@@ -13,6 +13,6 @@
 // +kubebuilder:rbac:groups="apps",resources=statefulsets;deployments;replicasets;daemonsets,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups="batch",resources=jobs;cronjobs,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups="",resources=nodes;namespaces;endpoints;pods,verbs=get;list;watch;update
-// +kubebuilder:rbac:groups="*",resources="*",verbs=get
+// +kubebuilder:rbac:groups="*",resources="*",verbs=get;list;watch
 
 package v2beta1

--- a/pkg/subnetmanager/subnet_informer.go
+++ b/pkg/subnetmanager/subnet_informer.go
@@ -7,25 +7,22 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
-	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/utils/strings/slices"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -54,9 +51,8 @@ const (
 var InformerLogger *zap.Logger
 
 type SubnetController struct {
-	Client        client.Client
-	APIReader     client.Reader
-	DynamicClient dynamic.Interface
+	Client    client.Client
+	APIReader client.Reader
 
 	SubnetsLister listers.SpiderSubnetLister
 	IPPoolsLister listers.SpiderIPPoolLister
@@ -73,6 +69,16 @@ type SubnetController struct {
 	ResyncPeriod            time.Duration
 	SubnetControllerWorkers int
 	MaxWorkqueueLength      int
+
+	DynamicClient    dynamic.Interface
+	dynamicFactory   dynamicinformer.DynamicSharedInformerFactory
+	dynamicWorkqueue workqueue.RateLimitingInterface
+	recordedResource sync.Map
+}
+
+type thirdControllerKey struct {
+	MetaNamespaceKey string
+	AppUID           types.UID
 }
 
 func (sc *SubnetController) SetupInformer(ctx context.Context, client clientset.Interface, leader election.SpiderLeaseElector) error {
@@ -115,6 +121,10 @@ func (sc *SubnetController) SetupInformer(ctx context.Context, client clientset.
 					time.Sleep(sc.LeaderRetryElectGap)
 				}
 			}()
+
+			InformerLogger.Info("Initialize Dynamic informer")
+			sc.dynamicFactory = dynamicinformer.NewDynamicSharedInformerFactory(sc.DynamicClient, 0)
+			sc.dynamicWorkqueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Dynamic-Objects")
 
 			InformerLogger.Info("Initialize Subnet informer")
 			informerFactory := externalversions.NewSharedInformerFactory(client, sc.ResyncPeriod)
@@ -234,6 +244,7 @@ func (sc *SubnetController) enqueueSubnetOnIPPoolChange(obj interface{}) {
 func (sc *SubnetController) run(ctx context.Context, workers int) error {
 	defer utilruntime.HandleCrash()
 	defer sc.Workqueue.ShutDown()
+	defer sc.dynamicWorkqueue.ShutDown()
 
 	logger := logutils.FromContext(ctx)
 	logger.Info("Starting Subnet informer")
@@ -247,6 +258,9 @@ func (sc *SubnetController) run(ctx context.Context, workers int) error {
 	for i := 0; i < workers; i++ {
 		go wait.UntilWithContext(ctx, sc.runWorker, time.Second)
 	}
+
+	logger.Info("Starting dynamic informer worker")
+	go wait.UntilWithContext(ctx, sc.runDynamicWorker, time.Second)
 
 	logger.Info("Started workers")
 	<-ctx.Done()
@@ -280,6 +294,55 @@ func (sc *SubnetController) processNextWorkItem(ctx context.Context) bool {
 	logger.Info("Succeed to SYNC")
 
 	sc.Workqueue.Forget(obj)
+
+	return true
+}
+
+func (sc *SubnetController) runDynamicWorker(ctx context.Context) {
+	for sc.processDynamicNextWorkItem(ctx) {
+	}
+}
+
+func (sc *SubnetController) processDynamicNextWorkItem(ctx context.Context) bool {
+	obj, shutdown := sc.dynamicWorkqueue.Get()
+	if shutdown {
+		return false
+	}
+
+	log := logutils.FromContext(ctx)
+	process := func(obj interface{}) error {
+		defer sc.dynamicWorkqueue.Done(obj)
+
+		key, ok := obj.(thirdControllerKey)
+		if !ok {
+			sc.dynamicWorkqueue.Forget(obj)
+			return fmt.Errorf("expected thirdControllerKey in workQueue but got '%+v'", obj)
+		}
+
+		err := sc.Client.DeleteAllOf(ctx, &spiderpoolv2beta1.SpiderIPPool{}, client.MatchingLabels{
+			constant.LabelIPPoolOwnerApplicationUID: string(key.AppUID),
+			constant.LabelIPPoolReclaimIPPool:       constant.True,
+		})
+		if nil != err {
+			if apierrors.IsNotFound(err) {
+				log.Sugar().Debugf("third-party controller %+v corresponding auto-created IPPools already deleted", key)
+				sc.dynamicWorkqueue.Forget(obj)
+				return nil
+			}
+
+			sc.dynamicWorkqueue.AddRateLimited(obj)
+			return fmt.Errorf("error deleting third-party controller %+v corresponding auto-created IPPools: %w, requeuing", key, err)
+		}
+
+		sc.dynamicWorkqueue.Forget(obj)
+		log.Sugar().Infof("delete third-party controller %+v corresponding auto-created IPPools successfully", key)
+		return nil
+	}
+
+	err := process(obj)
+	if nil != err {
+		log.Error(err.Error())
+	}
 
 	return true
 }
@@ -389,18 +452,28 @@ func (sc *SubnetController) syncControlledIPPoolIPs(ctx context.Context, subnet 
 			appNamespacedName, isMatch := applicationinformers.ParseApplicationNamespacedName(*preAllocation.Application)
 			if !isMatch {
 				logger.Sugar().Errorf("Invalid application record %s of IPPool %s, remove the pre-allocation from Subnet", *preAllocation.Application, poolName)
+				// discard this invalid allocation for subnet.status
 				continue
 			}
 
-			exist, err := sc.isAppExist(ctx, appNamespacedName)
+			exist, _, err := applicationinformers.IsAppExist(ctx, sc.Client, sc.DynamicClient, appNamespacedName)
 			if err != nil {
-				return fmt.Errorf("failed to check whether the application %v corresponding to the auto-created IPPool %s exists: %v", appNamespacedName, poolName, err)
+				return fmt.Errorf("failed to check whether the application %v corresponding to the auto-created IPPool %s exists: %w", appNamespacedName, poolName, err)
 			}
 
-			if !exist {
+			if exist {
+				// if it's a third-party controller, we'll watch its deletion hook function to GC SpiderSubnet.status
+				if applicationinformers.IsThirdController(appNamespacedName) {
+					err := sc.monitorThirdController(ctx, appNamespacedName)
+					if nil != err {
+						return fmt.Errorf("failed to monitor third-party application %v for auto-created IPPool %s: %w", appNamespacedName, poolName, err)
+					}
+				}
+			} else {
 				_, err := sc.IPPoolsLister.Get(poolName)
 				if apierrors.IsNotFound(err) {
 					logger.Sugar().Infof("The Application %v corresponding to the auto-created IPPool %s no longer exists, remove the pre-allocation from Subnet", appNamespacedName, poolName)
+					// discard the legacy allocation for subnet.status
 					continue
 				}
 			}
@@ -408,6 +481,7 @@ func (sc *SubnetController) syncControlledIPPoolIPs(ctx context.Context, subnet 
 			autoIPPoolIPs, err := spiderpoolip.ParseIPRanges(*subnet.Spec.IPVersion, preAllocation.IPs)
 			if err != nil {
 				logger.Sugar().Errorf("Invalid IP ranges of IPPool %s, remove the pre-allocation from Subnet", poolName)
+				// discard this invalid allocation
 				continue
 			}
 			tmpCount += len(autoIPPoolIPs)
@@ -509,64 +583,46 @@ func (sc *SubnetController) removeFinalizer(ctx context.Context, subnet *spiderp
 	return nil
 }
 
-func (sc *SubnetController) isAppExist(ctx context.Context, appNamespacedName spiderpooltypes.AppNamespacedName) (bool, error) {
-	var object client.Object
-	isThirdController := false
+func (sc *SubnetController) monitorThirdController(ctx context.Context, appNamespacedName spiderpooltypes.AppNamespacedName) error {
+	log := logutils.FromContext(ctx)
 
-	if slices.Contains(constant.K8sAPIVersions, appNamespacedName.APIVersion) {
-		switch appNamespacedName.Kind {
-		case constant.KindPod:
-			object = &corev1.Pod{}
-		case constant.KindDeployment:
-			object = &appsv1.Deployment{}
-		case constant.KindReplicaSet:
-			object = &appsv1.ReplicaSet{}
-		case constant.KindDaemonSet:
-			object = &appsv1.DaemonSet{}
-		case constant.KindStatefulSet:
-			object = &appsv1.StatefulSet{}
-		case constant.KindJob:
-			object = &batchv1.Job{}
-		case constant.KindCronJob:
-			object = &batchv1.CronJob{}
-		default:
-			isThirdController = true
-		}
-	} else {
-		isThirdController = true
-	}
-
-	var err error
-	if isThirdController {
-		gvr, e := generateGVR(appNamespacedName)
-		if nil != e {
-			return false, e
-		}
-		_, err = sc.DynamicClient.Resource(gvr).Namespace(appNamespacedName.Namespace).Get(ctx, appNamespacedName.Name, metav1.GetOptions{})
-	} else {
-		err = sc.Client.Get(ctx, types.NamespacedName{Namespace: appNamespacedName.Namespace, Name: appNamespacedName.Name}, object)
-	}
-
+	gvr, err := applicationinformers.GenerateGVR(appNamespacedName)
 	if nil != err {
-		// if the application is no longer exist, we should delete the IPPool
-		if apierrors.IsNotFound(err) {
-			return false, nil
-		} else {
-			return false, err
+		return err
+	}
+
+	_, ok := sc.recordedResource.Load(gvr)
+	if !ok {
+		log.Sugar().Infof("try to watch third-party controller %v delete hook for corresponding auto-created IPPools", appNamespacedName)
+		informer := sc.dynamicFactory.ForResource(gvr).Informer()
+		_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			DeleteFunc: func(obj interface{}) {
+				key, err := cache.MetaNamespaceKeyFunc(obj)
+				if nil != err {
+					log.Sugar().Errorf("failed to parse object '%+v' meta key", obj)
+					return
+				}
+				log.Sugar().Infof("received third-party controller %s delete event, enqueue it", key)
+				sc.dynamicWorkqueue.Add(thirdControllerKey{
+					MetaNamespaceKey: key,
+					AppUID:           obj.(*unstructured.Unstructured).GetUID(),
+				})
+			},
+		})
+		if nil != err {
+			return err
 		}
+
+		sc.recordedResource.Store(gvr, struct{}{})
+		go func() {
+			log.Sugar().Debugf("start third-party controller %v informer", appNamespacedName)
+			informer.Run(ctx.Done())
+
+			// if stopped, let's clean up the cache directly
+			log.Sugar().Errorf("the third-party controller %v informer stopped")
+			sc.recordedResource.Delete(gvr)
+		}()
 	}
 
-	return true, nil
-}
-
-func generateGVR(appNamespacedName spiderpooltypes.AppNamespacedName) (schema.GroupVersionResource, error) {
-	gv, err := schema.ParseGroupVersion(appNamespacedName.APIVersion)
-	if nil != err {
-		return schema.GroupVersionResource{}, err
-	}
-
-	gvk := gv.WithKind(appNamespacedName.Kind)
-	gvrPlural, _ := meta.UnsafeGuessKindToResource(gvk)
-
-	return gvrPlural, nil
+	return nil
 }

--- a/pkg/subnetmanager/subnet_manager.go
+++ b/pkg/subnetmanager/subnet_manager.go
@@ -147,6 +147,8 @@ func (sm *subnetManager) ReconcileAutoIPPool(ctx context.Context, pool *spiderpo
 		poolLabels[constant.LabelIPPoolCIDR] = cidrLabelValue
 		if autoPoolProperty.IsReclaimIPPool {
 			poolLabels[constant.LabelIPPoolReclaimIPPool] = constant.True
+		} else {
+			poolLabels[constant.LabelIPPoolReclaimIPPool] = constant.False
 		}
 		pool.Labels = poolLabels
 		pool.Annotations = poolAnno

--- a/test/e2e/kruise/kruise_test.go
+++ b/test/e2e/kruise/kruise_test.go
@@ -232,16 +232,16 @@ var _ = Describe("Third party control:OpenKruise", Label("kruise"), func() {
 				Refer https://github.com/spidernet-io/spiderpool/blob/main/docs/usage/third-party-controller.md for details.
 		*/
 		// TODO(tao.yang, Missing check for ippool to be automatically recycled)
-		GinkgoWriter.Println("delete ippool.")
-		if frame.Info.IpV4Enabled {
-			for _, v := range v4PoolNameList {
-				Expect(common.DeleteIPPoolByName(frame, v)).NotTo(HaveOccurred())
-			}
-		}
-		if frame.Info.IpV6Enabled {
-			for _, v := range v6PoolNameList {
-				Expect(common.DeleteIPPoolByName(frame, v)).NotTo(HaveOccurred())
-			}
-		}
+		//GinkgoWriter.Println("delete ippool.")
+		//if frame.Info.IpV4Enabled {
+		//	for _, v := range v4PoolNameList {
+		//		Expect(common.DeleteIPPoolByName(frame, v)).NotTo(HaveOccurred())
+		//	}
+		//}
+		//if frame.Info.IpV6Enabled {
+		//	for _, v := range v6PoolNameList {
+		//		Expect(common.DeleteIPPoolByName(frame, v)).NotTo(HaveOccurred())
+		//	}
+		//}
 	})
 })

--- a/vendor/k8s.io/client-go/dynamic/dynamicinformer/informer.go
+++ b/vendor/k8s.io/client-go/dynamic/dynamicinformer/informer.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamicinformer
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamiclister"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+// NewDynamicSharedInformerFactory constructs a new instance of dynamicSharedInformerFactory for all namespaces.
+func NewDynamicSharedInformerFactory(client dynamic.Interface, defaultResync time.Duration) DynamicSharedInformerFactory {
+	return NewFilteredDynamicSharedInformerFactory(client, defaultResync, metav1.NamespaceAll, nil)
+}
+
+// NewFilteredDynamicSharedInformerFactory constructs a new instance of dynamicSharedInformerFactory.
+// Listers obtained via this factory will be subject to the same filters as specified here.
+func NewFilteredDynamicSharedInformerFactory(client dynamic.Interface, defaultResync time.Duration, namespace string, tweakListOptions TweakListOptionsFunc) DynamicSharedInformerFactory {
+	return &dynamicSharedInformerFactory{
+		client:           client,
+		defaultResync:    defaultResync,
+		namespace:        namespace,
+		informers:        map[schema.GroupVersionResource]informers.GenericInformer{},
+		startedInformers: make(map[schema.GroupVersionResource]bool),
+		tweakListOptions: tweakListOptions,
+	}
+}
+
+type dynamicSharedInformerFactory struct {
+	client        dynamic.Interface
+	defaultResync time.Duration
+	namespace     string
+
+	lock      sync.Mutex
+	informers map[schema.GroupVersionResource]informers.GenericInformer
+	// startedInformers is used for tracking which informers have been started.
+	// This allows Start() to be called multiple times safely.
+	startedInformers map[schema.GroupVersionResource]bool
+	tweakListOptions TweakListOptionsFunc
+}
+
+var _ DynamicSharedInformerFactory = &dynamicSharedInformerFactory{}
+
+func (f *dynamicSharedInformerFactory) ForResource(gvr schema.GroupVersionResource) informers.GenericInformer {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	key := gvr
+	informer, exists := f.informers[key]
+	if exists {
+		return informer
+	}
+
+	informer = NewFilteredDynamicInformer(f.client, gvr, f.namespace, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	f.informers[key] = informer
+
+	return informer
+}
+
+// Start initializes all requested informers.
+func (f *dynamicSharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	for informerType, informer := range f.informers {
+		if !f.startedInformers[informerType] {
+			go informer.Informer().Run(stopCh)
+			f.startedInformers[informerType] = true
+		}
+	}
+}
+
+// WaitForCacheSync waits for all started informers' cache were synced.
+func (f *dynamicSharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[schema.GroupVersionResource]bool {
+	informers := func() map[schema.GroupVersionResource]cache.SharedIndexInformer {
+		f.lock.Lock()
+		defer f.lock.Unlock()
+
+		informers := map[schema.GroupVersionResource]cache.SharedIndexInformer{}
+		for informerType, informer := range f.informers {
+			if f.startedInformers[informerType] {
+				informers[informerType] = informer.Informer()
+			}
+		}
+		return informers
+	}()
+
+	res := map[schema.GroupVersionResource]bool{}
+	for informType, informer := range informers {
+		res[informType] = cache.WaitForCacheSync(stopCh, informer.HasSynced)
+	}
+	return res
+}
+
+// NewFilteredDynamicInformer constructs a new informer for a dynamic type.
+func NewFilteredDynamicInformer(client dynamic.Interface, gvr schema.GroupVersionResource, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions TweakListOptionsFunc) informers.GenericInformer {
+	return &dynamicInformer{
+		gvr: gvr,
+		informer: cache.NewSharedIndexInformer(
+			&cache.ListWatch{
+				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+					if tweakListOptions != nil {
+						tweakListOptions(&options)
+					}
+					return client.Resource(gvr).Namespace(namespace).List(context.TODO(), options)
+				},
+				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+					if tweakListOptions != nil {
+						tweakListOptions(&options)
+					}
+					return client.Resource(gvr).Namespace(namespace).Watch(context.TODO(), options)
+				},
+			},
+			&unstructured.Unstructured{},
+			resyncPeriod,
+			indexers,
+		),
+	}
+}
+
+type dynamicInformer struct {
+	informer cache.SharedIndexInformer
+	gvr      schema.GroupVersionResource
+}
+
+var _ informers.GenericInformer = &dynamicInformer{}
+
+func (d *dynamicInformer) Informer() cache.SharedIndexInformer {
+	return d.informer
+}
+
+func (d *dynamicInformer) Lister() cache.GenericLister {
+	return dynamiclister.NewRuntimeObjectShim(dynamiclister.New(d.informer.GetIndexer(), d.gvr))
+}

--- a/vendor/k8s.io/client-go/dynamic/dynamicinformer/interface.go
+++ b/vendor/k8s.io/client-go/dynamic/dynamicinformer/interface.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamicinformer
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/informers"
+)
+
+// DynamicSharedInformerFactory provides access to a shared informer and lister for dynamic client
+type DynamicSharedInformerFactory interface {
+	Start(stopCh <-chan struct{})
+	ForResource(gvr schema.GroupVersionResource) informers.GenericInformer
+	WaitForCacheSync(stopCh <-chan struct{}) map[schema.GroupVersionResource]bool
+}
+
+// TweakListOptionsFunc defines the signature of a helper function
+// that wants to provide more listing options to API
+type TweakListOptionsFunc func(*metav1.ListOptions)

--- a/vendor/k8s.io/client-go/dynamic/dynamiclister/interface.go
+++ b/vendor/k8s.io/client-go/dynamic/dynamiclister/interface.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamiclister
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// Lister helps list resources.
+type Lister interface {
+	// List lists all resources in the indexer.
+	List(selector labels.Selector) (ret []*unstructured.Unstructured, err error)
+	// Get retrieves a resource from the indexer with the given name
+	Get(name string) (*unstructured.Unstructured, error)
+	// Namespace returns an object that can list and get resources in a given namespace.
+	Namespace(namespace string) NamespaceLister
+}
+
+// NamespaceLister helps list and get resources.
+type NamespaceLister interface {
+	// List lists all resources in the indexer for a given namespace.
+	List(selector labels.Selector) (ret []*unstructured.Unstructured, err error)
+	// Get retrieves a resource from the indexer for a given namespace and name.
+	Get(name string) (*unstructured.Unstructured, error)
+}

--- a/vendor/k8s.io/client-go/dynamic/dynamiclister/lister.go
+++ b/vendor/k8s.io/client-go/dynamic/dynamiclister/lister.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamiclister
+
+import (
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+)
+
+var _ Lister = &dynamicLister{}
+var _ NamespaceLister = &dynamicNamespaceLister{}
+
+// dynamicLister implements the Lister interface.
+type dynamicLister struct {
+	indexer cache.Indexer
+	gvr     schema.GroupVersionResource
+}
+
+// New returns a new Lister.
+func New(indexer cache.Indexer, gvr schema.GroupVersionResource) Lister {
+	return &dynamicLister{indexer: indexer, gvr: gvr}
+}
+
+// List lists all resources in the indexer.
+func (l *dynamicLister) List(selector labels.Selector) (ret []*unstructured.Unstructured, err error) {
+	err = cache.ListAll(l.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*unstructured.Unstructured))
+	})
+	return ret, err
+}
+
+// Get retrieves a resource from the indexer with the given name
+func (l *dynamicLister) Get(name string) (*unstructured.Unstructured, error) {
+	obj, exists, err := l.indexer.GetByKey(name)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, errors.NewNotFound(l.gvr.GroupResource(), name)
+	}
+	return obj.(*unstructured.Unstructured), nil
+}
+
+// Namespace returns an object that can list and get resources from a given namespace.
+func (l *dynamicLister) Namespace(namespace string) NamespaceLister {
+	return &dynamicNamespaceLister{indexer: l.indexer, namespace: namespace, gvr: l.gvr}
+}
+
+// dynamicNamespaceLister implements the NamespaceLister interface.
+type dynamicNamespaceLister struct {
+	indexer   cache.Indexer
+	namespace string
+	gvr       schema.GroupVersionResource
+}
+
+// List lists all resources in the indexer for a given namespace.
+func (l *dynamicNamespaceLister) List(selector labels.Selector) (ret []*unstructured.Unstructured, err error) {
+	err = cache.ListAllByNamespace(l.indexer, l.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*unstructured.Unstructured))
+	})
+	return ret, err
+}
+
+// Get retrieves a resource from the indexer for a given namespace and name.
+func (l *dynamicNamespaceLister) Get(name string) (*unstructured.Unstructured, error) {
+	obj, exists, err := l.indexer.GetByKey(l.namespace + "/" + name)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, errors.NewNotFound(l.gvr.GroupResource(), name)
+	}
+	return obj.(*unstructured.Unstructured), nil
+}

--- a/vendor/k8s.io/client-go/dynamic/dynamiclister/shim.go
+++ b/vendor/k8s.io/client-go/dynamic/dynamiclister/shim.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamiclister
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+)
+
+var _ cache.GenericLister = &dynamicListerShim{}
+var _ cache.GenericNamespaceLister = &dynamicNamespaceListerShim{}
+
+// dynamicListerShim implements the cache.GenericLister interface.
+type dynamicListerShim struct {
+	lister Lister
+}
+
+// NewRuntimeObjectShim returns a new shim for Lister.
+// It wraps Lister so that it implements cache.GenericLister interface
+func NewRuntimeObjectShim(lister Lister) cache.GenericLister {
+	return &dynamicListerShim{lister: lister}
+}
+
+// List will return all objects across namespaces
+func (s *dynamicListerShim) List(selector labels.Selector) (ret []runtime.Object, err error) {
+	objs, err := s.lister.List(selector)
+	if err != nil {
+		return nil, err
+	}
+
+	ret = make([]runtime.Object, len(objs))
+	for index, obj := range objs {
+		ret[index] = obj
+	}
+	return ret, err
+}
+
+// Get will attempt to retrieve assuming that name==key
+func (s *dynamicListerShim) Get(name string) (runtime.Object, error) {
+	return s.lister.Get(name)
+}
+
+func (s *dynamicListerShim) ByNamespace(namespace string) cache.GenericNamespaceLister {
+	return &dynamicNamespaceListerShim{
+		namespaceLister: s.lister.Namespace(namespace),
+	}
+}
+
+// dynamicNamespaceListerShim implements the NamespaceLister interface.
+// It wraps NamespaceLister so that it implements cache.GenericNamespaceLister interface
+type dynamicNamespaceListerShim struct {
+	namespaceLister NamespaceLister
+}
+
+// List will return all objects in this namespace
+func (ns *dynamicNamespaceListerShim) List(selector labels.Selector) (ret []runtime.Object, err error) {
+	objs, err := ns.namespaceLister.List(selector)
+	if err != nil {
+		return nil, err
+	}
+
+	ret = make([]runtime.Object, len(objs))
+	for index, obj := range objs {
+		ret[index] = obj
+	}
+	return ret, err
+}
+
+// Get will attempt to retrieve by namespace and name
+func (ns *dynamicNamespaceListerShim) Get(name string) (runtime.Object, error) {
+	return ns.namespaceLister.Get(name)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -780,6 +780,8 @@ k8s.io/client-go/applyconfigurations/storage/v1beta1
 k8s.io/client-go/discovery
 k8s.io/client-go/discovery/fake
 k8s.io/client-go/dynamic
+k8s.io/client-go/dynamic/dynamicinformer
+k8s.io/client-go/dynamic/dynamiclister
 k8s.io/client-go/informers
 k8s.io/client-go/informers/admissionregistration
 k8s.io/client-go/informers/admissionregistration/v1


### PR DESCRIPTION
This pr will make third-party controller use SpiderSubnet feature to create auto-created IPPools can be deleted if the application deleted

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)

**What this PR does / why we need it**:
new feature

