### PR TITLE
fix IP GC health inaccurate check

### DIFF
--- a/cmd/spiderpool-controller/cmd/runtime_status.go
+++ b/cmd/spiderpool-controller/cmd/runtime_status.go
@@ -41,7 +41,7 @@ func (g *_httpGetControllerReadiness) Handle(params runtime.GetRuntimeReadinessP
 	}
 
 	if len(g.Leader.GetLeader()) == 0 {
-		logger.Warn("failed to check spiderpool-controller readiness probe: there's not leader in the current cluster, please wait for a while")
+		logger.Warn("failed to check spiderpool-controller readiness probe: there's no leader in the current cluster, please wait for a while")
 		return runtime.NewGetRuntimeReadinessInternalServerError()
 	}
 
@@ -52,7 +52,6 @@ func (g *_httpGetControllerReadiness) Handle(params runtime.GetRuntimeReadinessP
 		}
 	}
 
-	logger.Info("check spiderpool-controller readiness probe successfully")
 	return runtime.NewGetRuntimeReadinessOK()
 }
 

--- a/pkg/gcmanager/gc_manager.go
+++ b/pkg/gcmanager/gc_manager.go
@@ -178,7 +178,17 @@ func (s *SpiderGC) Health() bool {
 	ctx, cancelFunc := context.WithTimeout(context.TODO(), waitForCacheSyncTimeout)
 	defer cancelFunc()
 
-	if s.informerFactory != nil {
+	if len(s.leader.GetLeader()) == 0 {
+		logger.Warn("no leader in the current cluster, the IP-GC manager is still not started")
+		return false
+	}
+
+	if s.leader.IsElected() {
+		if s.informerFactory == nil {
+			logger.Warn("the IP-GC manager pod informer is not ready")
+			return false
+		}
+
 		waitForCacheSync := s.informerFactory.WaitForCacheSync(ctx.Done())
 		for _, isCacheSync := range waitForCacheSync {
 			if !isCacheSync {


### PR DESCRIPTION
Because of the inaccurate IP GC health check, the spiderpool-controller readiness probe check leads to inadequate ready.

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)


**What this PR does / why we need it**:
fix bug

**Which issue(s) this PR fixes**:
https://github.com/spidernet-io/spiderpool/issues/1612
