### PR TITLE
fix: The log of merging `spec.ips` and `spec.excludeIPs` in the mutating webhook is not accurate

### DIFF
--- a/pkg/ippoolmanager/ippool_mutate.go
+++ b/pkg/ippoolmanager/ippool_mutate.go
@@ -74,8 +74,9 @@ func (iw *IPPoolWebhook) mutateIPPool(ctx context.Context, ipPool *spiderpoolv2b
 			return fmt.Errorf("failed to merge 'spec.ips': %v", err)
 		}
 
+		ips := ipPool.Spec.IPs
 		ipPool.Spec.IPs = mergedIPs
-		logger.Sugar().Debugf("Merge 'spec.ips':\n%v\n\nto:\n\n%v", ipPool.Spec.IPs, mergedIPs)
+		logger.Sugar().Debugf("Merge 'spec.ips' %v to %v", ips, mergedIPs)
 	}
 
 	if len(ipPool.Spec.ExcludeIPs) > 1 {
@@ -84,8 +85,9 @@ func (iw *IPPoolWebhook) mutateIPPool(ctx context.Context, ipPool *spiderpoolv2b
 			return fmt.Errorf("failed to merge 'spec.excludeIPs': %v", err)
 		}
 
+		excludeIPs := ipPool.Spec.ExcludeIPs
 		ipPool.Spec.ExcludeIPs = mergedExcludeIPs
-		logger.Sugar().Debugf("Merge 'spec.excludeIPs':\n%v\n\nto:\n\n%v", ipPool.Spec.ExcludeIPs, mergedExcludeIPs)
+		logger.Sugar().Debugf("Merge 'spec.excludeIPs' %v to %v", excludeIPs, mergedExcludeIPs)
 	}
 
 	return nil

--- a/pkg/reservedipmanager/reservedip_mutate.go
+++ b/pkg/reservedipmanager/reservedip_mutate.go
@@ -49,8 +49,9 @@ func (rw *ReservedIPWebhook) mutateReservedIP(ctx context.Context, rIP *spiderpo
 			return fmt.Errorf("failed to merge 'spec.ips': %v", err)
 		}
 
+		ips := rIP.Spec.IPs
 		rIP.Spec.IPs = mergedIPs
-		logger.Sugar().Debugf("Merge 'spec.ips':\n%v\n\nto:\n\n%v", rIP.Spec.IPs, mergedIPs)
+		logger.Sugar().Debugf("Merge 'spec.ips' %v to %v", ips, mergedIPs)
 	}
 
 	return nil

--- a/pkg/subnetmanager/subnet_mutate.go
+++ b/pkg/subnetmanager/subnet_mutate.go
@@ -64,8 +64,9 @@ func (sw *SubnetWebhook) mutateSubnet(ctx context.Context, subnet *spiderpoolv2b
 			return fmt.Errorf("failed to merge 'spec.ips': %v", err)
 		}
 
+		ips := subnet.Spec.IPs
 		subnet.Spec.IPs = mergedIPs
-		logger.Sugar().Debugf("Merge 'spec.ips':\n%v\n\nto:\n\n%v", subnet.Spec.IPs, mergedIPs)
+		logger.Sugar().Debugf("Merge 'spec.ips' %v to %v", ips, mergedIPs)
 	}
 
 	if len(subnet.Spec.ExcludeIPs) > 1 {
@@ -74,8 +75,9 @@ func (sw *SubnetWebhook) mutateSubnet(ctx context.Context, subnet *spiderpoolv2b
 			return fmt.Errorf("failed to merge 'spec.excludeIPs': %v", err)
 		}
 
+		excludeIPs := subnet.Spec.ExcludeIPs
 		subnet.Spec.ExcludeIPs = mergedExcludeIPs
-		logger.Sugar().Debugf("Merge 'spec.excludeIPs':\n%v\n\nto:\n\n%v", subnet.Spec.ExcludeIPs, mergedExcludeIPs)
+		logger.Sugar().Debugf("Merge 'spec.excludeIPs' %v to  %v", excludeIPs, mergedExcludeIPs)
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: iiiceoo <ziqian.xue@daocloud.io>