### PR TITLE
fix: SpiderSubnet or SpiderIPPool can use `spec.routes` to configure duplicate routes or default route

### DIFF
--- a/pkg/ippoolmanager/ippool_validate.go
+++ b/pkg/ippoolmanager/ippool_validate.go
@@ -327,7 +327,30 @@ func validateIPPoolGateway(version types.IPVersion, subnet string, gateway *stri
 }
 
 func validateIPPoolRoutes(version types.IPVersion, subnet string, routes []spiderpoolv2beta1.Route) *field.Error {
+	if len(routes) == 0 {
+		return nil
+	}
+
+	dstSet := make(map[string]bool, len(routes))
 	for i, r := range routes {
+		if version == constant.IPv4 && r.Dst == "0.0.0.0/0" ||
+			version == constant.IPv6 && r.Dst == "::/0" {
+			return field.Invalid(
+				routesField.Index(i).Child("dst"),
+				r.Dst,
+				"please specify 'spec.gateway' to configure the default route",
+			)
+		}
+
+		if _, ok := dstSet[r.Dst]; ok {
+			return field.Invalid(
+				routesField.Index(i).Child("dst"),
+				r.Dst,
+				"duplicate route with the same dst",
+			)
+		}
+		dstSet[r.Dst] = true
+
 		if err := spiderpoolip.IsCIDR(version, r.Dst); err != nil {
 			return field.Invalid(
 				routesField.Index(i).Child("dst"),

--- a/pkg/subnetmanager/subnet_webhook_test.go
+++ b/pkg/subnetmanager/subnet_webhook_test.go
@@ -608,6 +608,50 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 			})
 
 			When("Validating 'spec.routes'", func() {
+				It("inputs default route", func() {
+					subnetT.Spec.IPVersion = pointer.Int64(constant.IPv4)
+					subnetT.Spec.Subnet = "172.18.40.0/24"
+					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+						[]string{
+							"172.18.40.2-172.18.40.3",
+							"172.18.40.10",
+						}...,
+					)
+					subnetT.Spec.Routes = append(subnetT.Spec.Routes,
+						spiderpoolv2beta1.Route{
+							Dst: "0.0.0.0/0",
+							Gw:  "172.18.40.1",
+						},
+					)
+
+					err := subnetWebhook.ValidateCreate(ctx, subnetT)
+					Expect(apierrors.IsInvalid(err)).To(BeTrue())
+				})
+
+				It("inputs duplicate routes", func() {
+					subnetT.Spec.IPVersion = pointer.Int64(constant.IPv4)
+					subnetT.Spec.Subnet = "172.18.40.0/24"
+					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+						[]string{
+							"172.18.40.2-172.18.40.3",
+							"172.18.40.10",
+						}...,
+					)
+					subnetT.Spec.Routes = append(subnetT.Spec.Routes,
+						spiderpoolv2beta1.Route{
+							Dst: "192.168.40.0/24",
+							Gw:  "172.18.40.1",
+						},
+						spiderpoolv2beta1.Route{
+							Dst: "192.168.40.0/24",
+							Gw:  "172.18.40.2",
+						},
+					)
+
+					err := subnetWebhook.ValidateCreate(ctx, subnetT)
+					Expect(apierrors.IsInvalid(err)).To(BeTrue())
+				})
+
 				It("inputs invalid destination", func() {
 					subnetT.Spec.IPVersion = pointer.Int64(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
@@ -904,6 +948,56 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 			})
 
 			When("Validating 'spec.routes'", func() {
+				It("appends default route", func() {
+					subnetT.Spec.IPVersion = pointer.Int64(constant.IPv4)
+					subnetT.Spec.Subnet = "172.18.40.0/24"
+					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+						[]string{
+							"172.18.40.2-172.18.40.3",
+							"172.18.40.10",
+						}...,
+					)
+
+					newSubnetT := subnetT.DeepCopy()
+					newSubnetT.Spec.Routes = append(newSubnetT.Spec.Routes,
+						spiderpoolv2beta1.Route{
+							Dst: "0.0.0.0/0",
+							Gw:  "172.18.40.1",
+						},
+					)
+
+					err := subnetWebhook.ValidateUpdate(ctx, subnetT, newSubnetT)
+					Expect(apierrors.IsInvalid(err)).To(BeTrue())
+				})
+
+				It("appends default route", func() {
+					subnetT.Spec.IPVersion = pointer.Int64(constant.IPv4)
+					subnetT.Spec.Subnet = "172.18.40.0/24"
+					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+						[]string{
+							"172.18.40.2-172.18.40.3",
+							"172.18.40.10",
+						}...,
+					)
+					subnetT.Spec.Routes = append(subnetT.Spec.Routes,
+						spiderpoolv2beta1.Route{
+							Dst: "192.168.40.0/24",
+							Gw:  "172.18.40.1",
+						},
+					)
+
+					newSubnetT := subnetT.DeepCopy()
+					newSubnetT.Spec.Routes = append(newSubnetT.Spec.Routes,
+						spiderpoolv2beta1.Route{
+							Dst: "192.168.40.0/24",
+							Gw:  "172.18.40.2",
+						},
+					)
+
+					err := subnetWebhook.ValidateUpdate(ctx, subnetT, newSubnetT)
+					Expect(apierrors.IsInvalid(err)).To(BeTrue())
+				})
+
 				It("appends route with invalid destination", func() {
 					subnetT.Spec.IPVersion = pointer.Int64(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"

--- a/test/e2e/subnet/subnet_test.go
+++ b/test/e2e/subnet/subnet_test.go
@@ -475,7 +475,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 		})
 	})
 
-	Context("Validity of fields in subnet.spec", func() {
+	PContext("Validity of fields in subnet.spec", func() {
 		var fixedIPNumber string = "+0"
 		var deployOriginiaNum int32 = 1
 		var deployName string


### PR DESCRIPTION
close #1620

Signed-off-by: iiiceoo <ziqian.xue@daocloud.io>