### PR TITLE
fix build-push-action produces unknown arch

### DIFF
--- a/.github/workflows/build-image-base.yaml
+++ b/.github/workflows/build-image-base.yaml
@@ -113,6 +113,7 @@ jobs:
           context: ./${{ env.IMAGE_ROOT_PATH }}/${{ env.IMAGE_NAME }}
           file: ./${{ env.IMAGE_ROOT_PATH }}/${{ env.IMAGE_NAME }}/Dockerfile
           push: true
+          provenance: false
           github-token: ${{ secrets.WELAN_PAT }}
           platforms: ${{ env.BUILD_PLATFORM }}
           tags: |

--- a/.github/workflows/build-image-ci.yaml
+++ b/.github/workflows/build-image-ci.yaml
@@ -154,6 +154,7 @@ jobs:
           # re-pushing the image tags when we only want to re-create the Golang
           # docker cache after the workflow "Image CI Cache Cleaner" was terminated.
           push: ${{ steps.tag.outputs.push }}
+          provenance: false
           platforms: linux/amd64,linux/arm64
           github-token: ${{ secrets.WELAN_PAT }}
           tags: |
@@ -205,6 +206,7 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           push: ${{ steps.tag.outputs.push }}
+          provenance: false
           github-token: ${{ secrets.WELAN_PAT }}
           platforms: linux/amd64,linux/arm64
           tags: |

--- a/.github/workflows/call-release-image.yaml
+++ b/.github/workflows/call-release-image.yaml
@@ -89,6 +89,7 @@ jobs:
           file: ${{ matrix.dockerfile }}
           github-token: ${{ secrets.WELAN_PAT }}
           push: true
+          provenance: false
           platforms: ${{ env.BUILD_PLATFORM }}
           tags: |
             ${{ env.ONLINE_REGISTER }}/${{ github.repository }}/${{ matrix.name }}${{ steps.ref.outputs.suffix }}:${{ steps.ref.outputs.imagetag }}


### PR DESCRIPTION

**What this PR does / why we need it**:
![image](https://user-images.githubusercontent.com/10629406/231191239-860e45c2-cb7c-4ea1-b8ae-3287ee71e651.png)
The multi-architecture image produced by build-push-action will contain an image of the unknown architecture.
The solution is: https://github.com/docker/build-push-action/issues/820#issuecomment-1484092146
**Which issue(s) this PR fixes**:
https://github.com/docker/build-push-action/issues/820

**Special notes for your reviewer**:

**make sure your commit is signed off**
