### PR TITLE
fix: The gateway addresses of SpiderSubnet and SpiderIPPool conflict with `spec.ips`

### DIFF
--- a/pkg/ip/iprange.go
+++ b/pkg/ip/iprange.go
@@ -141,6 +141,33 @@ func ContainsIPRange(version types.IPVersion, subnet string, ipRange string) (bo
 	return ipNet.Contains(ips[0]) && ipNet.Contains(ips[n-1]), nil
 }
 
+// IPRangeContainsIP reports whether the IP range includes the IP address.
+// Both must belongto the same IP version.
+func IPRangeContainsIP(version types.IPVersion, ipRange string, ip string) (bool, error) {
+	if err := IsIPRange(version, ipRange); err != nil {
+		return false, err
+	}
+	if err := IsIP(version, ip); err != nil {
+		return false, err
+	}
+
+	ips := strings.Split(ipRange, "-")
+	n := len(ips)
+
+	if n == 1 {
+		return ipRange == ip, nil
+	}
+
+	if n == 2 {
+		if Cmp(net.ParseIP(ips[0]), net.ParseIP(ip)) == 1 ||
+			Cmp(net.ParseIP(ips[1]), net.ParseIP(ip)) == -1 {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
 // IsIPRangeOverlap reports whether the IP address slices of specific IP
 // version parsed from two IP ranges overlap.
 func IsIPRangeOverlap(version types.IPVersion, ipRange1, ipRange2 string) (bool, error) {

--- a/pkg/ip/iprange_test.go
+++ b/pkg/ip/iprange_test.go
@@ -284,6 +284,64 @@ var _ = Describe("IP range", Label("ip_range_test"), func() {
 		})
 	})
 
+	Describe("Test IPRangeContainsIP", func() {
+		When("Verifying", func() {
+			It("inputs invalid IP version", func() {
+				contains, err := spiderpoolip.IPRangeContainsIP(constant.InvalidIPVersion, "172.18.40.1-172.18.40.2", "172.18.40.1")
+				Expect(err).To(MatchError(spiderpoolip.ErrInvalidIPVersion))
+				Expect(contains).To(BeFalse())
+			})
+
+			It("inputs invalid IP range", func() {
+				contains, err := spiderpoolip.IPRangeContainsIP(constant.IPv4, constant.InvalidIPRange, "172.18.40.1")
+				Expect(err).To(MatchError(spiderpoolip.ErrInvalidIPRangeFormat))
+				Expect(contains).To(BeFalse())
+			})
+
+			It("inputs invalid IP", func() {
+				contains, err := spiderpoolip.IPRangeContainsIP(constant.IPv4, "172.18.40.1-172.18.40.2", constant.InvalidIP)
+				Expect(err).To(MatchError(spiderpoolip.ErrInvalidIPFormat))
+				Expect(contains).To(BeFalse())
+			})
+		})
+
+		When("IPv4", func() {
+			It("tests that a IP range contains the IP", func() {
+				contains, err := spiderpoolip.IPRangeContainsIP(constant.IPv4, "172.18.40.1", "172.18.40.1")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(contains).To(BeTrue())
+
+				contains, err = spiderpoolip.IPRangeContainsIP(constant.IPv4, "172.18.40.1-172.18.40.2", "172.18.40.1")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(contains).To(BeTrue())
+			})
+
+			It("test that a IP range does not contain the IP", func() {
+				contains, err := spiderpoolip.IPRangeContainsIP(constant.IPv4, "172.18.40.1-172.18.40.2", "172.18.40.10")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(contains).To(BeFalse())
+			})
+		})
+
+		When("IPv6", func() {
+			It("tests that a IP range contains the IP", func() {
+				contains, err := spiderpoolip.IPRangeContainsIP(constant.IPv6, "abcd:1234::1", "abcd:1234::1")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(contains).To(BeTrue())
+
+				contains, err = spiderpoolip.IPRangeContainsIP(constant.IPv6, "abcd:1234::1-abcd:1234::2", "abcd:1234::1")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(contains).To(BeTrue())
+			})
+
+			It("test that a IP range does not contain the IP", func() {
+				contains, err := spiderpoolip.IPRangeContainsIP(constant.IPv6, "abcd:1234::1-abcd:1234::2", "abcd:1234::a")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(contains).To(BeFalse())
+			})
+		})
+	})
+
 	Describe("Test IsIPRangeOverlap", func() {
 		When("Verifying", func() {
 			It("inputs invalid IP version", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Added some validations for `spec.gateway` to avoid gateway addresses being used by an unrelated Pod.

**Which issue(s) this PR fixes**:
Close #1646 

**make sure your commit is signed off**
Signed-off-by: iiiceoo <ziqian.xue@daocloud.io>