### PR TITLE
fix metric record

### DIFF
--- a/pkg/ippoolmanager/ippool_informer.go
+++ b/pkg/ippoolmanager/ippool_informer.go
@@ -264,14 +264,6 @@ func (ic *IPPoolController) processNextWorkItem() bool {
 }
 
 func (ic *IPPoolController) handleIPPool(ctx context.Context, pool *spiderpoolv2beta1.SpiderIPPool) (err error) {
-	defer func() {
-		if err == nil {
-			attr := attribute.String(constant.KindSpiderIPPool, pool.Name)
-			metric.IPPoolTotalIPCounts.Add(ctx, *pool.Status.TotalIPCount, attr)
-			metric.IPPoolAvailableIPCounts.Add(ctx, (*pool.Status.TotalIPCount)-(*pool.Status.AllocatedIPCount), attr)
-		}
-	}()
-
 	// checkout the Auto-created IPPools whether need to scale or clean up legacies
 	if ic.EnableSpiderSubnet && IsAutoCreatedIPPool(pool) {
 		err := ic.cleanAutoIPPoolLegacy(ctx, pool)
@@ -285,6 +277,10 @@ func (ic *IPPoolController) handleIPPool(ctx context.Context, pool *spiderpoolv2
 	if nil != err {
 		return err
 	}
+
+	attr := attribute.String(constant.KindSpiderIPPool, pool.Name)
+	metric.IPPoolTotalIPCounts.Add(ctx, *pool.Status.TotalIPCount, attr)
+	metric.IPPoolAvailableIPCounts.Add(ctx, (*pool.Status.TotalIPCount)-(*pool.Status.AllocatedIPCount), attr)
 
 	return nil
 }

--- a/pkg/subnetmanager/subnet_informer.go
+++ b/pkg/subnetmanager/subnet_informer.go
@@ -354,13 +354,6 @@ func (sc *SubnetController) syncHandler(ctx context.Context, subnetName string) 
 	}
 
 	subnetCopy := subnet.DeepCopy()
-	defer func() {
-		if err == nil {
-			attr := attribute.String(constant.KindSpiderSubnet, subnetName)
-			metric.SubnetTotalIPCounts.Add(ctx, *subnetCopy.Status.TotalIPCount, attr)
-			metric.SubnetAvailableIPCounts.Add(ctx, (*subnetCopy.Status.TotalIPCount)-(*subnetCopy.Status.AllocatedIPCount), attr)
-		}
-	}()
 
 	if err := sc.syncMetadata(ctx, subnetCopy); err != nil {
 		return fmt.Errorf("failed to sync metadata of Subnet: %v", err)
@@ -379,6 +372,10 @@ func (sc *SubnetController) syncHandler(ctx context.Context, subnetName string) 
 			return fmt.Errorf("failed to remove finalizer: %v", err)
 		}
 	}
+
+	attr := attribute.String(constant.KindSpiderSubnet, subnetName)
+	metric.SubnetTotalIPCounts.Add(ctx, *subnetCopy.Status.TotalIPCount, attr)
+	metric.SubnetAvailableIPCounts.Add(ctx, (*subnetCopy.Status.TotalIPCount)-(*subnetCopy.Status.AllocatedIPCount), attr)
 
 	return nil
 }


### PR DESCRIPTION
The reason of the panic is wrong golang defer usage.
```golang
defer func() {
if err == nil {
	attr := attribute.String(constant.KindSpiderIPPool, pool.Name)
	metric.IPPoolTotalIPCounts.Add(ctx, *pool.Status.TotalIPCount, attr)
	metric.IPPoolAvailableIPCounts.Add(ctx, (*pool.Status.TotalIPCount)-(*pool.Status.AllocatedIPCount), attr)
}
}()
```
At the top of the function, the `*pool.Status.TotalIPCount` is nil even I set value for it later.



Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)

**What this PR does / why we need it**:
fix bug

**Which issue(s) this PR fixes**:
close #1682 

