### PR TITLE
SpiderSubnet auto-created IPPool reuse

### DIFF
--- a/charts/spiderpool/crds/spiderpool.spidernet.io_spiderippools.yaml
+++ b/charts/spiderpool/crds/spiderpool.spidernet.io_spiderippools.yaml
@@ -44,6 +44,11 @@ spec:
       jsonPath: .spec.disable
       name: DISABLE
       type: boolean
+    - description: AppNamespace
+      jsonPath: .spec.podAffinity.matchLabels['ipam\.spidernet\.io/app\-namespace']
+      name: APP-NAMESPACE
+      priority: 10
+      type: string
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/pkg/constant/k8s.go
+++ b/pkg/constant/k8s.go
@@ -61,14 +61,26 @@ const (
 	AnnoSpiderSubnets             = AnnotationPre + "/subnets"
 	AnnoSpiderSubnetPoolIPNumber  = AnnotationPre + "/ippool-ip-number"
 	AnnoSpiderSubnetReclaimIPPool = AnnotationPre + "/ippool-reclaim"
-	AnnoSpiderSubnetPoolApp       = AnnotationPre + "/application"
 
-	LabelIPPoolOwnerSpiderSubnet   = AnnotationPre + "/owner-spider-subnet"
-	LabelIPPoolOwnerApplicationUID = AnnotationPre + "/owner-application-uid"
 	LabelIPPoolReclaimIPPool       = AnnoSpiderSubnetReclaimIPPool
+	LabelIPPoolOwnerSpiderSubnet   = AnnotationPre + "/owner-spider-subnet"
+	LabelIPPoolOwnerApplication    = AnnotationPre + "/owner-application"
+	LabelIPPoolOwnerApplicationUID = AnnotationPre + "/owner-application-uid"
+	LabelIPPoolInterface           = AnnotationPre + "/interface"
+	LabelIPPoolIPVersion           = AnnotationPre + "/ip-version"
+	LabelValueIPVersionV4          = "IPv4"
+	LabelValueIPVersionV6          = "IPv6"
 
 	LabelSubnetCIDR = AnnotationPre + "/subnet-cidr"
 	LabelIPPoolCIDR = AnnotationPre + "/ippool-cidr"
+
+	// auto pool special pod affinity matchLabels key
+	AutoPoolPodAffinityAppPrefix     = AnnotationPre
+	AutoPoolPodAffinityAppAPIGroup   = AutoPoolPodAffinityAppPrefix + "/app-api-group"
+	AutoPoolPodAffinityAppAPIVersion = AutoPoolPodAffinityAppPrefix + "/app-api-version"
+	AutoPoolPodAffinityAppKind       = AutoPoolPodAffinityAppPrefix + "/app-kind"
+	AutoPoolPodAffinityAppNS         = AutoPoolPodAffinityAppPrefix + "/app-namespace"
+	AutoPoolPodAffinityAppName       = AutoPoolPodAffinityAppPrefix + "/app-name"
 )
 
 const (

--- a/pkg/gcmanager/gc_manager.go
+++ b/pkg/gcmanager/gc_manager.go
@@ -177,7 +177,6 @@ func (s *SpiderGC) Health() bool {
 	defer cancelFunc()
 
 	if s.leader.IsElected() {
-		logger.Debug("try to check pod informer cache sync")
 		if s.informerFactory == nil {
 			logger.Warn("the IP-GC manager pod informer is not ready")
 			return false

--- a/pkg/ippoolmanager/ippool_informer.go
+++ b/pkg/ippoolmanager/ippool_informer.go
@@ -366,10 +366,10 @@ func (ic *IPPoolController) cleanAutoIPPoolLegacy(ctx context.Context, pool *spi
 
 	if pool.Status.AllocatedIPs == nil {
 		// unpack the IPPool corresponding application type,namespace and name
-		appNamespacedNameStr := pool.Annotations[constant.AnnoSpiderSubnetPoolApp]
+		appNamespacedNameStr := poolLabels[constant.LabelIPPoolOwnerApplication]
 		appNamespacedName, isMatch := applicationinformers.ParseApplicationNamespacedName(appNamespacedNameStr)
 		if !isMatch {
-			return fmt.Errorf("%w: invalid IPPool annotation '%s' value '%s'", constant.ErrWrongInput, constant.AnnoSpiderSubnetPoolApp, appNamespacedNameStr)
+			return fmt.Errorf("%w: invalid IPPool label '%s' value '%s'", constant.ErrWrongInput, constant.LabelIPPoolOwnerApplication, appNamespacedNameStr)
 		}
 
 		enableDelete := false

--- a/pkg/ippoolmanager/ippool_webhook_test.go
+++ b/pkg/ippoolmanager/ippool_webhook_test.go
@@ -1762,7 +1762,7 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 					subnetT.Spec.IPs = append(subnetT.Spec.IPs, "172.18.40.1-172.18.40.2")
 
 					autoPool := ipPoolT.DeepCopy()
-					autoPool.Annotations = map[string]string{constant.AnnoSpiderSubnetPoolApp: applicationinformers.ApplicationNamespacedName(types.AppNamespacedName{
+					autoPool.Labels = map[string]string{constant.LabelIPPoolOwnerApplication: applicationinformers.ApplicationNamespacedName(types.AppNamespacedName{
 						APIVersion: appsv1.SchemeGroupVersion.String(),
 						Kind:       constant.KindDeployment,
 						Namespace:  autoPool.Namespace,
@@ -1776,7 +1776,7 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 					Expect(err).NotTo(HaveOccurred())
 					poolIPPreAllocations := spiderpoolv2beta1.PoolIPPreAllocations{autoPool.Name: spiderpoolv2beta1.PoolIPPreAllocation{
 						IPs:         []string{"172.18.40.1"},
-						Application: pointer.String(autoPool.Annotations[constant.AnnoSpiderSubnetPoolApp]),
+						Application: pointer.String(autoPool.Labels[constant.LabelIPPoolOwnerApplication]),
 					}}
 					subnetAllocatedIPPools, err := convert.MarshalSubnetAllocatedIPPools(poolIPPreAllocations)
 					Expect(err).NotTo(HaveOccurred())
@@ -1799,7 +1799,7 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 					subnetT.Spec.IPs = append(subnetT.Spec.IPs, "172.18.40.1-172.18.40.2")
 
 					autoPool := ipPoolT.DeepCopy()
-					autoPool.Annotations = map[string]string{constant.AnnoSpiderSubnetPoolApp: applicationinformers.ApplicationNamespacedName(types.AppNamespacedName{
+					autoPool.Labels = map[string]string{constant.LabelIPPoolOwnerApplication: applicationinformers.ApplicationNamespacedName(types.AppNamespacedName{
 						APIVersion: appsv1.SchemeGroupVersion.String(),
 						Kind:       constant.KindDeployment,
 						Namespace:  autoPool.Namespace,
@@ -1813,7 +1813,7 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 					Expect(err).NotTo(HaveOccurred())
 					poolIPPreAllocations := spiderpoolv2beta1.PoolIPPreAllocations{autoPool.Name: spiderpoolv2beta1.PoolIPPreAllocation{
 						IPs:         []string{"172.18.40.1"},
-						Application: pointer.String(autoPool.Annotations[constant.AnnoSpiderSubnetPoolApp]),
+						Application: pointer.String(autoPool.Labels[constant.LabelIPPoolOwnerApplication]),
 					}}
 					subnetAllocatedIPPools, err := convert.MarshalSubnetAllocatedIPPools(poolIPPreAllocations)
 					Expect(err).NotTo(HaveOccurred())
@@ -1824,6 +1824,9 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 
 					newAutoPool := autoPool.DeepCopy()
 					anno := newAutoPool.GetAnnotations()
+					if anno == nil {
+						anno = make(map[string]string)
+					}
 					anno["aaa"] = "test"
 					newAutoPool.Annotations = anno
 

--- a/pkg/ippoolmanager/utils.go
+++ b/pkg/ippoolmanager/utils.go
@@ -4,13 +4,64 @@
 package ippoolmanager
 
 import (
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
 	"github.com/spidernet-io/spiderpool/pkg/constant"
 	spiderpoolv2beta1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1"
+	"github.com/spidernet-io/spiderpool/pkg/types"
 )
 
 func IsAutoCreatedIPPool(pool *spiderpoolv2beta1.SpiderIPPool) bool {
-	// only the auto-created IPPool owns the annotation "ipam.spidernet.io/application"
-	poolAnno := pool.GetAnnotations()
-	_, ok := poolAnno[constant.AnnoSpiderSubnetPoolApp]
+	// only the auto-created IPPool owns the annotation "ipam.spidernet.io/owner-application"
+	poolLabels := pool.GetLabels()
+	_, ok := poolLabels[constant.LabelIPPoolOwnerApplication]
 	return ok
+}
+
+func NewAutoPoolPodAffinity(podTopController types.PodTopController) *metav1.LabelSelector {
+	var group, version string
+
+	first, second, hasGroup := strings.Cut(podTopController.APIVersion, "/")
+	if hasGroup {
+		group = first
+		version = second
+	} else {
+		version = first
+	}
+
+	set := labels.Set{
+		constant.AutoPoolPodAffinityAppAPIGroup:   group,
+		constant.AutoPoolPodAffinityAppAPIVersion: version,
+		constant.AutoPoolPodAffinityAppKind:       podTopController.Kind,
+		constant.AutoPoolPodAffinityAppNS:         podTopController.Namespace,
+		constant.AutoPoolPodAffinityAppName:       podTopController.Name,
+	}
+
+	return metav1.SetAsLabelSelector(set)
+}
+
+func IsMatchAutoPoolAffinity(podAffinity *metav1.LabelSelector, podTopController types.PodTopController) bool {
+	if podAffinity == nil {
+		return false
+	}
+
+	group, version, _ := strings.Cut(podTopController.APIVersion, "/")
+	tmpSet := labels.Set{
+		constant.AutoPoolPodAffinityAppAPIGroup:   group,
+		constant.AutoPoolPodAffinityAppAPIVersion: version,
+		constant.AutoPoolPodAffinityAppKind:       podTopController.Kind,
+		constant.AutoPoolPodAffinityAppNS:         podTopController.Namespace,
+		constant.AutoPoolPodAffinityAppName:       podTopController.Name,
+	}
+
+	for k, v := range tmpSet {
+		if podAffinity.MatchLabels[k] != v {
+			return false
+		}
+	}
+
+	return true
 }

--- a/pkg/ippoolmanager/utils_test.go
+++ b/pkg/ippoolmanager/utils_test.go
@@ -1,0 +1,82 @@
+// Copyright 2022 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+
+package ippoolmanager
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	types2 "k8s.io/apimachinery/pkg/types"
+
+	"github.com/spidernet-io/spiderpool/pkg/applicationcontroller/applicationinformers"
+	"github.com/spidernet-io/spiderpool/pkg/constant"
+	spiderpoolv2beta1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1"
+	"github.com/spidernet-io/spiderpool/pkg/types"
+)
+
+var _ = Describe("IPPoolManager-utils", Label("ippool_manager_utils"), func() {
+	Context("IsAutoCreatedIPPool", Labels{"unitest", "IsAutoCreatedIPPool"}, func() {
+		It("normal IPPool", func() {
+			var pool spiderpoolv2beta1.SpiderIPPool
+
+			label := map[string]string{constant.LabelIPPoolOwnerApplication: applicationinformers.ApplicationNamespacedName(types.AppNamespacedName{
+				APIVersion: appsv1.SchemeGroupVersion.String(),
+				Kind:       constant.KindDeployment,
+				Namespace:  "test-ns",
+				Name:       "test-name",
+			})}
+			pool.SetLabels(label)
+
+			isAutoCreatedIPPool := IsAutoCreatedIPPool(&pool)
+			Expect(isAutoCreatedIPPool).To(BeTrue())
+		})
+
+		It("auto-created IPPool", func() {
+			var pool spiderpoolv2beta1.SpiderIPPool
+
+			isAutoCreatedIPPool := IsAutoCreatedIPPool(&pool)
+			Expect(isAutoCreatedIPPool).To(BeFalse())
+		})
+	})
+
+	Context("Test Auto IPPool PodAffinity", Labels{"unitest", "AutoPool-PodAffinity"}, func() {
+		It("match auto-created IPPool affinity", func() {
+			podTopController := types.PodTopController{
+				AppNamespacedName: types.AppNamespacedName{
+					APIVersion: appsv1.SchemeGroupVersion.String(),
+					Kind:       constant.KindDeployment,
+					Namespace:  "test-ns",
+					Name:       "test-name",
+				},
+				UID: types2.UID("a-b-c"),
+				APP: nil,
+			}
+
+			podAffinity := NewAutoPoolPodAffinity(podTopController)
+
+			isMatchAutoPoolAffinity := IsMatchAutoPoolAffinity(podAffinity, podTopController)
+			Expect(isMatchAutoPoolAffinity).To(BeTrue())
+		})
+
+		It("not match auto-created IPPool affinity", func() {
+			podTopController := types.PodTopController{
+				AppNamespacedName: types.AppNamespacedName{
+					APIVersion: appsv1.SchemeGroupVersion.String(),
+					Kind:       constant.KindDeployment,
+					Namespace:  "test-ns",
+					Name:       "test-name",
+				},
+				UID: types2.UID("a-b-c"),
+				APP: nil,
+			}
+
+			podAffinity := NewAutoPoolPodAffinity(podTopController)
+
+			podTopController.Kind = constant.KindStatefulSet
+			isMatchAutoPoolAffinity := IsMatchAutoPoolAffinity(podAffinity, podTopController)
+			Expect(isMatchAutoPoolAffinity).To(BeFalse())
+		})
+	})
+
+})

--- a/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/spiderippool_types.go
+++ b/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/spiderippool_types.go
@@ -90,6 +90,7 @@ type PoolIPAllocation struct {
 // +kubebuilder:printcolumn:JSONPath=".status.totalIPCount",description="totalIPCount",name="TOTAL-IP-COUNT",type=integer
 // +kubebuilder:printcolumn:JSONPath=".spec.default",description="default",name="DEFAULT",type=boolean
 // +kubebuilder:printcolumn:JSONPath=".spec.disable",description="disable",name="DISABLE",type=boolean
+// +kubebuilder:printcolumn:JSONPath=`.spec.podAffinity.matchLabels['ipam\.spidernet\.io/app\-namespace']`,description="AppNamespace",name="APP-NAMESPACE",type=string,priority=10
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +genclient

--- a/pkg/types/k8s.go
+++ b/pkg/types/k8s.go
@@ -104,5 +104,4 @@ type AutoPoolProperty struct {
 	IPVersion       IPVersion
 	IsReclaimIPPool bool
 	IfName          string
-	PodSelector     *metav1.LabelSelector
 }

--- a/test/e2e/kruise/kruise_test.go
+++ b/test/e2e/kruise/kruise_test.go
@@ -19,7 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Third party control:OpenKruise", Label("kruise"), func() {
+var _ = PDescribe("Third party control:OpenKruise", Label("kruise"), func() {
 	var namespace, kruiseCloneSetName, kruiseStatefulSetName, v4SubnetName, v6SubnetName, v4PoolName, v6PoolName string
 	var v4SubnetObject, v6SubnetObject *spiderpool.SpiderSubnet
 	var v4PoolObj, v6PoolObj *spiderpool.SpiderIPPool


### PR DESCRIPTION
⚠ BREAKING CHANGES
This is a new feature for SpdiderSubnet.
In the past, one deployment created with SpiderSubnet feature and we set `ipam.spidernet.io/ippool-reclaim` to keep the IPPool after the deployment object deleted. In this situation, we can use `ipam.spidernet.io/ippool` or `ipam.spidernet.io/ippools` annotation to reuse this IPPool. But in this way, the pool will switch to `normal IPPool` from `Auto IPPool`. 

In order to reuse this IPPool and still make it as a `Auto IPPool` for the same ns,name application. Just for instance, one deployment deployed and the administrator set the Firewall at first. But later the deployment upgrades and wanna redeploy, it will cost a lot to rebuild the IPPool. Because if we try to reuse the previous IPPool with `ipam.spidernet.io/ippool`, it'll can not scale automatically any more. 
If we still wanna use the auto scaled IPPool, we have to delete the previous IPPool and recreate the Auto IPPool and let the administrator to set the Firewall again.
 

But unfortunately, it's a breaking change.

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)


**What this PR does / why we need it**:
new feature

**Which issue(s) this PR fixes**:
close #1650 


