### PR TITLE
fix Auto IPPool label value over maximum length limit

### DIFF
--- a/pkg/applicationcontroller/app_controller.go
+++ b/pkg/applicationcontroller/app_controller.go
@@ -756,10 +756,13 @@ func (sac *SubnetAppController) applyAutoIPPool(ctx context.Context, podSubnetCo
 		var tmpPool *spiderpoolv2beta1.SpiderIPPool
 		tmpPoolList := &spiderpoolv2beta1.SpiderIPPoolList{}
 		matchLabels := client.MatchingLabels{
-			constant.LabelIPPoolOwnerSpiderSubnet: subnetName,
-			constant.LabelIPPoolOwnerApplication:  applicationinformers.ApplicationNamespacedName(podController.AppNamespacedName),
-			constant.LabelIPPoolIPVersion:         ipVersionStr,
-			constant.LabelIPPoolInterface:         ifName,
+			constant.LabelIPPoolOwnerSpiderSubnet:         subnetName,
+			constant.LabelIPPoolOwnerApplicationGV:        applicationinformers.ApplicationLabelGV(podController.APIVersion),
+			constant.LabelIPPoolOwnerApplicationKind:      podController.Kind,
+			constant.LabelIPPoolOwnerApplicationNamespace: podController.Namespace,
+			constant.LabelIPPoolOwnerApplicationName:      podController.Name,
+			constant.LabelIPPoolIPVersion:                 ipVersionStr,
+			constant.LabelIPPoolInterface:                 ifName,
 		}
 
 		err := sac.apiReader.List(ctx, tmpPoolList, matchLabels)

--- a/pkg/applicationcontroller/applicationinformers/utils.go
+++ b/pkg/applicationcontroller/applicationinformers/utils.go
@@ -61,6 +61,37 @@ func AutoPoolName(controllerName string, ipVersion types.IPVersion, ifName strin
 	return fmt.Sprintf("auto%d-%s-%s-%s", ipVersion, strings.ToLower(controllerName), strings.ToLower(ifName), strings.ToLower(lastOne))
 }
 
+// ApplicationLabelGV switches the kubernetes APIVersion from "/" link format to "_" link format for kubernetes label value usage.
+func ApplicationLabelGV(apiVersion string) string {
+	// Kubernetes API Group might be empty, ref: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#api-versions
+	first, second, hasGroup := strings.Cut(apiVersion, "/")
+	if hasGroup {
+		return fmt.Sprintf("%s_%s", first, second)
+	}
+
+	return first
+}
+
+// ParseApplicationGVStr will parse a label value string back to apiVersion format string, its corresponding function is ApplicationLabelGV.
+func ParseApplicationGVStr(str string) (apiVersion string, isMatch bool) {
+	split := strings.Split(str, "_")
+
+	// no API Group
+	if len(split) == 1 {
+		return schema.GroupVersion{
+			Group:   "",
+			Version: split[0],
+		}.String(), true
+	} else if len(split) == 2 {
+		return schema.GroupVersion{
+			Group:   split[0],
+			Version: split[1],
+		}.String(), true
+	}
+
+	return
+}
+
 // ApplicationNamespacedName will joint the application apiVersion, application type, namespace and name as a string, then we need unpack it for tracing
 // [ns and object name constraint Ref]: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
 // We set format is "{apiVersion}:{appKind}:{appNS}:{appName}"

--- a/pkg/constant/k8s.go
+++ b/pkg/constant/k8s.go
@@ -62,14 +62,17 @@ const (
 	AnnoSpiderSubnetPoolIPNumber  = AnnotationPre + "/ippool-ip-number"
 	AnnoSpiderSubnetReclaimIPPool = AnnotationPre + "/ippool-reclaim"
 
-	LabelIPPoolReclaimIPPool       = AnnoSpiderSubnetReclaimIPPool
-	LabelIPPoolOwnerSpiderSubnet   = AnnotationPre + "/owner-spider-subnet"
-	LabelIPPoolOwnerApplication    = AnnotationPre + "/owner-application"
-	LabelIPPoolOwnerApplicationUID = AnnotationPre + "/owner-application-uid"
-	LabelIPPoolInterface           = AnnotationPre + "/interface"
-	LabelIPPoolIPVersion           = AnnotationPre + "/ip-version"
-	LabelValueIPVersionV4          = "IPv4"
-	LabelValueIPVersionV6          = "IPv6"
+	LabelIPPoolReclaimIPPool             = AnnoSpiderSubnetReclaimIPPool
+	LabelIPPoolOwnerSpiderSubnet         = AnnotationPre + "/owner-spider-subnet"
+	LabelIPPoolOwnerApplicationGV        = AnnotationPre + "/owner-application-gv"
+	LabelIPPoolOwnerApplicationKind      = AnnotationPre + "/owner-application-kind"
+	LabelIPPoolOwnerApplicationNamespace = AnnotationPre + "/owner-application-namespace"
+	LabelIPPoolOwnerApplicationName      = AnnotationPre + "/owner-application-name"
+	LabelIPPoolOwnerApplicationUID       = AnnotationPre + "/owner-application-uid"
+	LabelIPPoolInterface                 = AnnotationPre + "/interface"
+	LabelIPPoolIPVersion                 = AnnotationPre + "/ip-version"
+	LabelValueIPVersionV4                = "IPv4"
+	LabelValueIPVersionV6                = "IPv6"
 
 	LabelSubnetCIDR = AnnotationPre + "/subnet-cidr"
 	LabelIPPoolCIDR = AnnotationPre + "/ippool-cidr"

--- a/pkg/ippoolmanager/ippool_informer_test.go
+++ b/pkg/ippoolmanager/ippool_informer_test.go
@@ -27,7 +27,6 @@ import (
 	spiderpoolfake "github.com/spidernet-io/spiderpool/pkg/k8s/client/clientset/versioned/fake"
 	"github.com/spidernet-io/spiderpool/pkg/k8s/client/informers/externalversions"
 	"github.com/spidernet-io/spiderpool/pkg/metric"
-	"github.com/spidernet-io/spiderpool/pkg/types"
 )
 
 var _ = Describe("IPPool-informer", Label("unitest"), Ordered, func() {
@@ -130,13 +129,11 @@ var _ = Describe("IPPool-informer", Label("unitest"), Ordered, func() {
 				tmpPool := pool.DeepCopy()
 				tmpPool.Name = "auto4-deploy-abc"
 				labels := map[string]string{
-					constant.LabelIPPoolOwnerApplication: applicationinformers.ApplicationNamespacedName(types.AppNamespacedName{
-						APIVersion: appsv1.SchemeGroupVersion.String(),
-						Kind:       constant.KindDeployment,
-						Namespace:  "test-ns",
-						Name:       "test-name",
-					}),
-					constant.LabelIPPoolReclaimIPPool: constant.True,
+					constant.LabelIPPoolOwnerApplicationGV:        applicationinformers.ApplicationLabelGV(appsv1.SchemeGroupVersion.String()),
+					constant.LabelIPPoolOwnerApplicationKind:      constant.KindDeployment,
+					constant.LabelIPPoolOwnerApplicationNamespace: "test-ns",
+					constant.LabelIPPoolOwnerApplicationName:      "test-name",
+					constant.LabelIPPoolReclaimIPPool:             constant.True,
 				}
 				tmpPool.SetLabels(labels)
 
@@ -168,13 +165,11 @@ var _ = Describe("IPPool-informer", Label("unitest"), Ordered, func() {
 				now := metav1.Now()
 				tmpPool.DeletionTimestamp = now.DeepCopy()
 				labels := map[string]string{
-					constant.LabelIPPoolOwnerApplication: applicationinformers.ApplicationNamespacedName(types.AppNamespacedName{
-						APIVersion: appsv1.SchemeGroupVersion.String(),
-						Kind:       constant.KindDeployment,
-						Namespace:  "test-ns",
-						Name:       "test-name",
-					}),
-					constant.LabelIPPoolReclaimIPPool: constant.True,
+					constant.LabelIPPoolOwnerApplicationGV:        applicationinformers.ApplicationLabelGV(appsv1.SchemeGroupVersion.String()),
+					constant.LabelIPPoolOwnerApplicationKind:      constant.KindDeployment,
+					constant.LabelIPPoolOwnerApplicationNamespace: "test-ns",
+					constant.LabelIPPoolOwnerApplicationName:      "test-name",
+					constant.LabelIPPoolReclaimIPPool:             constant.True,
 				}
 				tmpPool.SetLabels(labels)
 				controllerutil.AddFinalizer(tmpPool, constant.SpiderFinalizer)

--- a/pkg/ippoolmanager/ippool_webhook_test.go
+++ b/pkg/ippoolmanager/ippool_webhook_test.go
@@ -1762,12 +1762,12 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 					subnetT.Spec.IPs = append(subnetT.Spec.IPs, "172.18.40.1-172.18.40.2")
 
 					autoPool := ipPoolT.DeepCopy()
-					autoPool.Labels = map[string]string{constant.LabelIPPoolOwnerApplication: applicationinformers.ApplicationNamespacedName(types.AppNamespacedName{
-						APIVersion: appsv1.SchemeGroupVersion.String(),
-						Kind:       constant.KindDeployment,
-						Namespace:  autoPool.Namespace,
-						Name:       autoPool.Name,
-					})}
+					autoPool.Labels = map[string]string{
+						constant.LabelIPPoolOwnerApplicationGV:        applicationinformers.ApplicationLabelGV(appsv1.SchemeGroupVersion.String()),
+						constant.LabelIPPoolOwnerApplicationKind:      constant.KindDeployment,
+						constant.LabelIPPoolOwnerApplicationNamespace: "test-ns",
+						constant.LabelIPPoolOwnerApplicationName:      "test-name",
+					}
 					autoPool.Spec.IPVersion = pointer.Int64(constant.IPv4)
 					autoPool.Spec.Subnet = "172.18.40.0/24"
 					autoPool.Spec.IPs = append(autoPool.Spec.IPs, "172.18.40.1")
@@ -1775,8 +1775,13 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 					err := controllerutil.SetControllerReference(subnetT, autoPool, scheme)
 					Expect(err).NotTo(HaveOccurred())
 					poolIPPreAllocations := spiderpoolv2beta1.PoolIPPreAllocations{autoPool.Name: spiderpoolv2beta1.PoolIPPreAllocation{
-						IPs:         []string{"172.18.40.1"},
-						Application: pointer.String(autoPool.Labels[constant.LabelIPPoolOwnerApplication]),
+						IPs: []string{"172.18.40.1"},
+						Application: pointer.String(applicationinformers.ApplicationNamespacedName(types.AppNamespacedName{
+							APIVersion: appsv1.SchemeGroupVersion.String(),
+							Kind:       constant.KindDeployment,
+							Namespace:  "test-ns",
+							Name:       "test-name",
+						})),
 					}}
 					subnetAllocatedIPPools, err := convert.MarshalSubnetAllocatedIPPools(poolIPPreAllocations)
 					Expect(err).NotTo(HaveOccurred())
@@ -1799,12 +1804,12 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 					subnetT.Spec.IPs = append(subnetT.Spec.IPs, "172.18.40.1-172.18.40.2")
 
 					autoPool := ipPoolT.DeepCopy()
-					autoPool.Labels = map[string]string{constant.LabelIPPoolOwnerApplication: applicationinformers.ApplicationNamespacedName(types.AppNamespacedName{
-						APIVersion: appsv1.SchemeGroupVersion.String(),
-						Kind:       constant.KindDeployment,
-						Namespace:  autoPool.Namespace,
-						Name:       autoPool.Name,
-					})}
+					autoPool.Labels = map[string]string{
+						constant.LabelIPPoolOwnerApplicationGV:        applicationinformers.ApplicationLabelGV(appsv1.SchemeGroupVersion.String()),
+						constant.LabelIPPoolOwnerApplicationKind:      constant.KindDeployment,
+						constant.LabelIPPoolOwnerApplicationNamespace: "test-ns",
+						constant.LabelIPPoolOwnerApplicationName:      "test-name",
+					}
 					autoPool.Spec.IPVersion = pointer.Int64(constant.IPv4)
 					autoPool.Spec.Subnet = "172.18.40.0/24"
 					autoPool.Spec.IPs = append(autoPool.Spec.IPs, "172.18.40.1")
@@ -1812,8 +1817,13 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 					err := controllerutil.SetControllerReference(subnetT, autoPool, scheme)
 					Expect(err).NotTo(HaveOccurred())
 					poolIPPreAllocations := spiderpoolv2beta1.PoolIPPreAllocations{autoPool.Name: spiderpoolv2beta1.PoolIPPreAllocation{
-						IPs:         []string{"172.18.40.1"},
-						Application: pointer.String(autoPool.Labels[constant.LabelIPPoolOwnerApplication]),
+						IPs: []string{"172.18.40.1"},
+						Application: pointer.String(applicationinformers.ApplicationNamespacedName(types.AppNamespacedName{
+							APIVersion: appsv1.SchemeGroupVersion.String(),
+							Kind:       constant.KindDeployment,
+							Namespace:  "test-ns",
+							Name:       "test-name",
+						})),
 					}}
 					subnetAllocatedIPPools, err := convert.MarshalSubnetAllocatedIPPools(poolIPPreAllocations)
 					Expect(err).NotTo(HaveOccurred())

--- a/pkg/ippoolmanager/utils.go
+++ b/pkg/ippoolmanager/utils.go
@@ -17,7 +17,7 @@ import (
 func IsAutoCreatedIPPool(pool *spiderpoolv2beta1.SpiderIPPool) bool {
 	// only the auto-created IPPool owns the annotation "ipam.spidernet.io/owner-application"
 	poolLabels := pool.GetLabels()
-	_, ok := poolLabels[constant.LabelIPPoolOwnerApplication]
+	_, ok := poolLabels[constant.LabelIPPoolOwnerApplicationName]
 	return ok
 }
 

--- a/pkg/ippoolmanager/utils_test.go
+++ b/pkg/ippoolmanager/utils_test.go
@@ -9,7 +9,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	types2 "k8s.io/apimachinery/pkg/types"
 
-	"github.com/spidernet-io/spiderpool/pkg/applicationcontroller/applicationinformers"
 	"github.com/spidernet-io/spiderpool/pkg/constant"
 	spiderpoolv2beta1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1"
 	"github.com/spidernet-io/spiderpool/pkg/types"
@@ -20,12 +19,7 @@ var _ = Describe("IPPoolManager-utils", Label("ippool_manager_utils"), func() {
 		It("normal IPPool", func() {
 			var pool spiderpoolv2beta1.SpiderIPPool
 
-			label := map[string]string{constant.LabelIPPoolOwnerApplication: applicationinformers.ApplicationNamespacedName(types.AppNamespacedName{
-				APIVersion: appsv1.SchemeGroupVersion.String(),
-				Kind:       constant.KindDeployment,
-				Namespace:  "test-ns",
-				Name:       "test-name",
-			})}
+			label := map[string]string{constant.LabelIPPoolOwnerApplicationName: "test-name"}
 			pool.SetLabels(label)
 
 			isAutoCreatedIPPool := IsAutoCreatedIPPool(&pool)

--- a/pkg/subnetmanager/subnet_manager.go
+++ b/pkg/subnetmanager/subnet_manager.go
@@ -147,10 +147,13 @@ func (sm *subnetManager) ReconcileAutoIPPool(ctx context.Context, pool *spiderpo
 
 		{
 			poolLabels := map[string]string{
-				constant.LabelIPPoolOwnerSpiderSubnet:   subnet.Name,
-				constant.LabelIPPoolOwnerApplication:    applicationinformers.ApplicationNamespacedName(podController.AppNamespacedName),
-				constant.LabelIPPoolOwnerApplicationUID: string(podController.UID),
-				constant.LabelIPPoolInterface:           autoPoolProperty.IfName,
+				constant.LabelIPPoolOwnerSpiderSubnet:         subnet.Name,
+				constant.LabelIPPoolOwnerApplicationGV:        applicationinformers.ApplicationLabelGV(podController.APIVersion),
+				constant.LabelIPPoolOwnerApplicationKind:      podController.Kind,
+				constant.LabelIPPoolOwnerApplicationNamespace: podController.Namespace,
+				constant.LabelIPPoolOwnerApplicationName:      podController.Name,
+				constant.LabelIPPoolOwnerApplicationUID:       string(podController.UID),
+				constant.LabelIPPoolInterface:                 autoPoolProperty.IfName,
 			}
 			// label IPPoolCIDR
 			cidrLabelValue, err := spiderpoolip.CIDRToLabelValue(*pool.Spec.IPVersion, pool.Spec.Subnet)

--- a/test/e2e/kruise/kruise_test.go
+++ b/test/e2e/kruise/kruise_test.go
@@ -19,7 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = PDescribe("Third party control:OpenKruise", Label("kruise"), func() {
+var _ = Describe("Third party control:OpenKruise", Label("kruise"), func() {
 	var namespace, kruiseCloneSetName, kruiseStatefulSetName, v4SubnetName, v6SubnetName, v4PoolName, v6PoolName string
 	var v4SubnetObject, v6SubnetObject *spiderpool.SpiderSubnet
 	var v4PoolObj, v6PoolObj *spiderpool.SpiderIPPool


### PR DESCRIPTION
Change auto-created IPPool application NamespacedName label because of value max length limitation. 
In the past,  we would assemble the auto pool corresponding application APIVersion, kind, NS and name to one string. But the kubernetes limit the label value max length to 63.

And I realized the kubernetes metadata name length also limits to 63. So I separate it.



Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)

**What this PR does / why we need it**:
fix bug

**Which issue(s) this PR fixes**:
close #1747 

