### PR TITLE
add cluster subnet flexible ip number support

### DIFF
--- a/charts/spiderpool/README.md
+++ b/charts/spiderpool/README.md
@@ -131,20 +131,21 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 
 ### clusterDefaultPool parameters
 
-| Name                                   | Description                                                                     | Value               |
-| -------------------------------------- | ------------------------------------------------------------------------------- | ------------------- |
-| `clusterDefaultPool.installIPv4IPPool` | install ipv4 spiderpool instance. It is required to set feature.enableIPv4=true | `false`             |
-| `clusterDefaultPool.installIPv6IPPool` | install ipv6 spiderpool instance. It is required to set feature.enableIPv6=true | `false`             |
-| `clusterDefaultPool.ipv4IPPoolName`    | the name of ipv4 spiderpool instance                                            | `default-v4-ippool` |
-| `clusterDefaultPool.ipv6IPPoolName`    | the name of ipv6 spiderpool instance                                            | `default-v6-ippool` |
-| `clusterDefaultPool.ipv4SubnetName`    | the name of ipv4 spidersubnet instance                                          | `default-v4-subnet` |
-| `clusterDefaultPool.ipv6SubnetName`    | the name of ipv6 spidersubnet instance                                          | `default-v6-subnet` |
-| `clusterDefaultPool.ipv4Subnet`        | the subnet of ipv4 spiderpool instance                                          | `""`                |
-| `clusterDefaultPool.ipv6Subnet`        | the subnet of ipv6 spiderpool instance                                          | `""`                |
-| `clusterDefaultPool.ipv4IPRanges`      | the available IP of ipv4 spiderpool instance                                    | `[]`                |
-| `clusterDefaultPool.ipv6IPRanges`      | the available IP of ipv6 spiderpool instance                                    | `[]`                |
-| `clusterDefaultPool.ipv4Gateway`       | the gateway of ipv4 subnet                                                      | `""`                |
-| `clusterDefaultPool.ipv6Gateway`       | the gateway of ipv6 subnet                                                      | `""`                |
+| Name                                               | Description                                                                     | Value               |
+| -------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------- |
+| `clusterDefaultPool.installIPv4IPPool`             | install ipv4 spiderpool instance. It is required to set feature.enableIPv4=true | `false`             |
+| `clusterDefaultPool.installIPv6IPPool`             | install ipv6 spiderpool instance. It is required to set feature.enableIPv6=true | `false`             |
+| `clusterDefaultPool.ipv4IPPoolName`                | the name of ipv4 spiderpool instance                                            | `default-v4-ippool` |
+| `clusterDefaultPool.ipv6IPPoolName`                | the name of ipv6 spiderpool instance                                            | `default-v6-ippool` |
+| `clusterDefaultPool.ipv4SubnetName`                | the name of ipv4 spidersubnet instance                                          | `default-v4-subnet` |
+| `clusterDefaultPool.ipv6SubnetName`                | the name of ipv6 spidersubnet instance                                          | `default-v6-subnet` |
+| `clusterDefaultPool.ipv4Subnet`                    | the subnet of ipv4 spiderpool instance                                          | `""`                |
+| `clusterDefaultPool.ipv6Subnet`                    | the subnet of ipv6 spiderpool instance                                          | `""`                |
+| `clusterDefaultPool.ipv4IPRanges`                  | the available IP of ipv4 spiderpool instance                                    | `[]`                |
+| `clusterDefaultPool.ipv6IPRanges`                  | the available IP of ipv6 spiderpool instance                                    | `[]`                |
+| `clusterDefaultPool.ipv4Gateway`                   | the gateway of ipv4 subnet                                                      | `""`                |
+| `clusterDefaultPool.ipv6Gateway`                   | the gateway of ipv6 subnet                                                      | `""`                |
+| `clusterDefaultPool.subnetDefaultFlexibleIPNumber` | the default flexible IP number of SpiderSubnet feature auto-created IPPools     | `1`                 |
 
 
 ### spiderpoolAgent parameters

--- a/charts/spiderpool/templates/configmap.yaml
+++ b/charts/spiderpool/templates/configmap.yaml
@@ -20,3 +20,8 @@ data:
     enableIPv6: {{ .Values.feature.enableIPv6 }}
     enableStatefulSet: {{ .Values.feature.enableStatefulSet }}
     enableSpiderSubnet: {{ .Values.feature.enableSpiderSubnet }}
+    {{- if .Values.feature.enableSpiderSubnet }}
+    clusterSubnetDefaultFlexibleIPNumber: {{ .Values.clusterDefaultPool.subnetDefaultFlexibleIPNumber }}
+    {{- else}}
+    clusterSubnetDefaultFlexibleIPNumber: 0
+    {{- end }}

--- a/charts/spiderpool/values.yaml
+++ b/charts/spiderpool/values.yaml
@@ -116,6 +116,9 @@ clusterDefaultPool:
   ## @param clusterDefaultPool.ipv6Gateway the gateway of ipv6 subnet
   ipv6Gateway: ""
 
+  ## @param clusterDefaultPool.subnetDefaultFlexibleIPNumber the default flexible IP number of SpiderSubnet feature auto-created IPPools
+  subnetDefaultFlexibleIPNumber: 1
+
 ## @section spiderpoolAgent parameters
 ##
 spiderpoolAgent:

--- a/cmd/spiderpool-controller/cmd/config.go
+++ b/cmd/spiderpool-controller/cmd/config.go
@@ -138,15 +138,11 @@ type Config struct {
 	WorkQueueRequeueDelayDuration    int
 
 	// configmap
-	EnableIPv4                        bool     `yaml:"enableIPv4"`
-	EnableIPv6                        bool     `yaml:"enableIPv6"`
-	EnableStatefulSet                 bool     `yaml:"enableStatefulSet"`
-	EnableSpiderSubnet                bool     `yaml:"enableSpiderSubnet"`
-	ClusterDefaultIPv4IPPool          []string `yaml:"clusterDefaultIPv4IPPool"`
-	ClusterDefaultIPv6IPPool          []string `yaml:"clusterDefaultIPv6IPPool"`
-	ClusterDefaultIPv4Subnet          []string `yaml:"clusterDefaultIPv4Subnet"`
-	ClusterDefaultIPv6Subnet          []string `yaml:"clusterDefaultIPv6Subnet"`
-	ClusterSubnetDefaultFlexibleIPNum int      `yaml:"clusterSubnetDefaultFlexibleIPNumber"`
+	EnableIPv4                        bool `yaml:"enableIPv4"`
+	EnableIPv6                        bool `yaml:"enableIPv6"`
+	EnableStatefulSet                 bool `yaml:"enableStatefulSet"`
+	EnableSpiderSubnet                bool `yaml:"enableSpiderSubnet"`
+	ClusterSubnetDefaultFlexibleIPNum int  `yaml:"clusterSubnetDefaultFlexibleIPNumber"`
 }
 
 type ControllerContext struct {

--- a/cmd/spiderpool-controller/cmd/daemon.go
+++ b/cmd/spiderpool-controller/cmd/daemon.go
@@ -20,6 +20,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/spidernet-io/spiderpool/pkg/applicationcontroller"
+	"github.com/spidernet-io/spiderpool/pkg/applicationcontroller/applicationinformers"
 	"github.com/spidernet-io/spiderpool/pkg/constant"
 	"github.com/spidernet-io/spiderpool/pkg/election"
 	"github.com/spidernet-io/spiderpool/pkg/event"
@@ -331,6 +332,9 @@ func initControllerServiceManagers(ctx context.Context) {
 		}).SetupWebhookWithManager(controllerContext.CRDManager); err != nil {
 			logger.Fatal(err.Error())
 		}
+
+		logger.Sugar().Debugf("Begin to initialize cluster Subnet default flexible IP number to %d", controllerContext.Cfg.ClusterSubnetDefaultFlexibleIPNum)
+		*applicationinformers.ClusterSubnetDefaultFlexibleIPNumber = controllerContext.Cfg.ClusterSubnetDefaultFlexibleIPNum
 	} else {
 		logger.Info("Feature SpiderSubnet is disabled")
 	}

--- a/pkg/applicationcontroller/applicationinformers/utils.go
+++ b/pkg/applicationcontroller/applicationinformers/utils.go
@@ -33,6 +33,9 @@ import (
 	"github.com/spidernet-io/spiderpool/pkg/types"
 )
 
+// ClusterSubnetDefaultFlexibleIPNumber is a singleton recording cluster default Subnet flexible IP number.
+var ClusterSubnetDefaultFlexibleIPNumber = new(int)
+
 var errInvalidInput = func(str string) error {
 	return fmt.Errorf("invalid input '%s'", str)
 }
@@ -225,8 +228,8 @@ func GetSubnetAnnoConfig(podAnnotations map[string]string, log *zap.Logger) (*ty
 			subnetAnnoConfig.AssignIPNum = ipNum
 		}
 	} else {
-		log.Sugar().Debugf("no specified IPPool IP number, default to set it 0")
-		subnetAnnoConfig.FlexibleIPNum = pointer.Int(0)
+		log.Sugar().Debugf("no specified IPPool IP number, default to use cluster default subnet flexible IP number: %d", *ClusterSubnetDefaultFlexibleIPNumber)
+		subnetAnnoConfig.FlexibleIPNum = pointer.Int(*ClusterSubnetDefaultFlexibleIPNumber)
 	}
 
 	// annotation: "ipam.spidernet.io/reclaim-ippool", reclaim IPPool or not (default true)


### PR DESCRIPTION
Actually, we owned this feature in `v0.4` version, but later we remove it with `ClusterDefaultSubnet`. From then on, if the user do not set `ipam.spidernet.io/ippool-ip-number` annotation for pod in SpiderSubnet feature, we'll default to set `+0` for that application. But, if we met application upgrade, it might failed.

Finally, we add it back. And the user could configure it in `configmap`. The default `clusterSubnetDefaultFlexibleIPNumber` value will be set to `1`.

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)


**What this PR does / why we need it**:
new feature

**Which issue(s) this PR fixes**:
close #1755 


