### PR TITLE
fix: Update the collection method of cluster CIDR

### DIFF
--- a/cmd/spiderpool-controller/cmd/daemon.go
+++ b/cmd/spiderpool-controller/cmd/daemon.go
@@ -435,6 +435,7 @@ func setupInformers() {
 	if err := (&coordinatormanager.CoordinatorController{
 		Manager:             controllerContext.CRDManager,
 		Client:              controllerContext.CRDManager.GetClient(),
+		APIReader:           controllerContext.CRDManager.GetAPIReader(),
 		LeaderRetryElectGap: time.Duration(controllerContext.Cfg.LeaseRetryGap) * time.Second,
 		ResyncPeriod:        time.Duration(controllerContext.Cfg.CoordinatorInformerResyncPeriod) * time.Second,
 	}).SetupInformer(controllerContext.InnerCtx, crdClient, k8sClient, controllerContext.Leader); err != nil {


### PR DESCRIPTION
The coordinator should collect the CIDR of the cluster from the
cmd parameters of the kube-controller-manager instead of the
CM kubeadm-config.

Signed-off-by: iiiceoo <iiiceoo@foxmail.com>