### PR TITLE
update lock detect SelfishThresholdSec duration to 0.5 seconds

### DIFF
--- a/pkg/lock/lock_debug.go
+++ b/pkg/lock/lock_debug.go
@@ -25,7 +25,7 @@ var (
 
 	// SelfishThresholdSec is the number of seconds that should be used when
 	// detecting if a lock was held for more than the specified time.
-	SelfishThresholdSec = 0.2
+	SelfishThresholdSec = 0.5
 
 	// Waiting for a lock for longer than DeadlockTimeout is considered a deadlock.
 	// Ignored is DeadlockTimeout <= 0.


### PR DESCRIPTION
I found lots of e2e failure because of lock detection. 
So, I suggest to change the lock detection duration from 0.2 seconds to 0.5 seconds.

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)