### PR TITLE
fix IP GC scan all running unhealthy

### DIFF
--- a/pkg/gcmanager/scanAll_IPPool.go
+++ b/pkg/gcmanager/scanAll_IPPool.go
@@ -31,8 +31,10 @@ func (s *SpiderGC) monitorGCSignal(ctx context.Context) {
 	timer := time.NewTimer(d)
 	defer timer.Stop()
 
-	logger.Debug("initial scan all for cluster firstly")
-	s.gcSignal <- struct{}{}
+	go func() {
+		logger.Debug("initial scan all for cluster firstly")
+		s.gcSignal <- struct{}{}
+	}()
 
 	for {
 		select {


### PR DESCRIPTION
I make the `monitorGCSignal` initial scan all signal sending runs in goroutine. And it surely not blocks the for loop.

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)


**What this PR does / why we need it**:
fix bug

**Which issue(s) this PR fixes**:
close #1882 

