### PR TITLE
IP-GC improvement with discarding tracing hostnetwork pod

### DIFF
--- a/pkg/gcmanager/pod_cache.go
+++ b/pkg/gcmanager/pod_cache.go
@@ -128,6 +128,11 @@ func (s *SpiderGC) buildPodEntry(oldPod, currentPod *corev1.Pod, deleted bool) (
 		return nil, fmt.Errorf("currentPod must be specified")
 	}
 
+	if currentPod.Spec.HostNetwork {
+		logger.Sugar().Debugf("discard tracing HostNetwork pod %s/%s", currentPod.Namespace, currentPod.Name)
+		return nil, nil
+	}
+
 	// TODO(Icarus9913): Replace with method GetPodTopController.
 	ownerRef := metav1.GetControllerOf(currentPod)
 


### PR DESCRIPTION
In the IP-GC pod-informer architecture, we'll trace all terminating pod. But there are also some HostNetwork Pod and these pods never use Spiderpool IPs. Consequently, there's no need for us to record these pods.

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)