### PR TITLE
fix spiderpool-controller startup potential datarace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ lint-openapi:
 lint-code-spell:
 	$(QUIET) if ! which codespell &> /dev/null ; then \
   				echo "try to install codespell" ; \
-  				if ! pip3 install codespell ; then \
+  				if ! pip3 install codespell==2.2.1 ; then \
   					echo "error, miss tool codespell, install it: pip3 install codespell" ; \
   					exit 1 ; \
   				fi \

--- a/cmd/spiderpool-controller/cmd/daemon.go
+++ b/cmd/spiderpool-controller/cmd/daemon.go
@@ -176,6 +176,7 @@ func DaemonMain() {
 	initGCManager(controllerContext.InnerCtx)
 
 	logger.Info("Set spiderpool-controller Startup probe ready")
+	controllerContext.webhookClient = newWebhookHealthCheckClient()
 	controllerContext.IsStartupProbe.Store(true)
 
 	// The CRD webhook of Spiderpool must be started before informer, so that
@@ -505,8 +506,6 @@ func setupInformers() {
 }
 
 func checkWebhookReady() {
-	controllerContext.webhookClient = newWebhookHealthCheckClient()
-
 	for i := 1; i <= 100; i++ {
 		if i == 100 {
 			logger.Fatal("out of the max wait duration for webhook ready in process starting phase")


### PR DESCRIPTION
Just new the singleton http.client at first. This can avoid the singleton http.client `set` and `get` at the same time.

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)


**What this PR does / why we need it**:
fix bug

**Which issue(s) this PR fixes**:
close #1908 
