### PR TITLE
fix multus-config CNI configuration master name faults and ifacer incorresponding configuration

### DIFF
--- a/charts/spiderpool/crds/spiderpool.spidernet.io_spidermultusconfigs.yaml
+++ b/charts/spiderpool/crds/spiderpool.spidernet.io_spidermultusconfigs.yaml
@@ -103,9 +103,7 @@ spec:
                       name:
                         type: string
                       options:
-                        additionalProperties:
-                          type: string
-                        type: object
+                        type: string
                     required:
                     - mode
                     - name
@@ -147,9 +145,7 @@ spec:
                       name:
                         type: string
                       options:
-                        additionalProperties:
-                          type: string
-                        type: object
+                        type: string
                     required:
                     - mode
                     - name

--- a/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/spidermultus_types.go
+++ b/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/spidermultus_types.go
@@ -110,7 +110,7 @@ type BondConfig struct {
 	Mode int32 `json:"mode"`
 
 	// +kubebuilder:validation:Optional
-	Options map[string]string `json:"options,omitempty"`
+	Options *string `json:"options,omitempty"`
 }
 
 // SpiderpoolPools could specify the IPAM spiderpool CNI configuration default IPv4&IPv6 pools.

--- a/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/zz_generated.deepcopy.go
+++ b/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/zz_generated.deepcopy.go
@@ -18,10 +18,8 @@ func (in *BondConfig) DeepCopyInto(out *BondConfig) {
 	*out = *in
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
+		*out = new(string)
+		**out = **in
 	}
 }
 

--- a/pkg/multuscniconfig/multusconfig_informer.go
+++ b/pkg/multuscniconfig/multusconfig_informer.go
@@ -448,7 +448,7 @@ func generateMacvlanCNIConf(multusConfSpec spiderpoolv2beta1.MultusCNIConfigSpec
 	// set vlanID for interface basement name
 	if multusConfSpec.MacvlanConfig.VlanID != nil {
 		if *multusConfSpec.MacvlanConfig.VlanID != 0 {
-			masterName = fmt.Sprintf("%s.%d", multusConfSpec.MacvlanConfig.Master, *multusConfSpec.MacvlanConfig.VlanID)
+			masterName = fmt.Sprintf("%s.%d", masterName, *multusConfSpec.MacvlanConfig.VlanID)
 		}
 	}
 
@@ -483,7 +483,7 @@ func generateIPvlanCNIConf(multusConfSpec spiderpoolv2beta1.MultusCNIConfigSpec)
 
 	if multusConfSpec.IPVlanConfig.VlanID != nil {
 		if *multusConfSpec.IPVlanConfig.VlanID != 0 {
-			masterName = fmt.Sprintf("%s.%d", multusConfSpec.IPVlanConfig.Master, *multusConfSpec.IPVlanConfig.VlanID)
+			masterName = fmt.Sprintf("%s.%d", masterName, *multusConfSpec.IPVlanConfig.VlanID)
 		}
 	}
 
@@ -527,15 +527,20 @@ func generateSriovCNIConf(multusConfSpec spiderpoolv2beta1.MultusCNIConfigSpec) 
 
 func generateIfacer(master []string, vlanID int32, bond *spiderpoolv2beta1.BondConfig) interface{} {
 	netConf := IfacerNetConf{
-		Type:      ifacerBinName,
-		Interface: master,
-		VlanID:    vlanID,
+		NetConf: types.NetConf{
+			Type: ifacerBinName,
+		},
+		Interfaces: master,
+		VlanID:     int(vlanID),
 	}
 
 	if bond != nil {
 		netConf.Bond.Name = bond.Name
-		netConf.Bond.Mode = bond.Mode
-		netConf.Bond.Options = bond.Options
+		netConf.Bond.Mode = int(bond.Mode)
+
+		if bond.Options != nil {
+			netConf.Bond.Options = *bond.Options
+		}
 	}
 
 	return netConf

--- a/pkg/multuscniconfig/utils.go
+++ b/pkg/multuscniconfig/utils.go
@@ -4,8 +4,8 @@
 package multuscniconfig
 
 import (
+	ifacercmd "github.com/spidernet-io/spiderpool/cmd/ifacer/cmd"
 	spiderpoolcmd "github.com/spidernet-io/spiderpool/cmd/spiderpool/cmd"
-
 	spiderpoolv2beta1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1"
 )
 
@@ -42,13 +42,4 @@ type SRIOVNetConf struct {
 	DeviceID     string                   `json:"deviceID,omitempty"`
 }
 
-type IfacerNetConf struct {
-	Type      string   `json:"type"` // Ifacer
-	Interface []string `json:"interface"`
-	VlanID    int32    `json:"vlanID,omitempty"`
-	Bond      *struct {
-		Name    string            `json:"name"`
-		Mode    int32             `json:"mode"`
-		Options map[string]string `json:"options,omitempty"`
-	} `json:"bond,omitempty"`
-}
+type IfacerNetConf = ifacercmd.Ifacer


### PR DESCRIPTION
There's a bug about the multus-config CNI configuration master name faults.
And I reuse the ifacer cmd struct rather than a custom one

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)


**What this PR does / why we need it**:
fix bug

**Which issue(s) this PR fixes**:
close #1969 


