### PR TITLE
fix multus-config no pointer address panic

### DIFF
--- a/pkg/multuscniconfig/multusconfig_informer.go
+++ b/pkg/multuscniconfig/multusconfig_informer.go
@@ -418,7 +418,9 @@ func generateNetAttachDef(netAttachName string, multusConf *spiderpoolv2beta1.Sp
 		}
 		confStr = string(bytes)
 	} else {
-		confStr = *multusConfSpec.CustomCNIConfig
+		if multusConfSpec.CustomCNIConfig != nil {
+			confStr = *multusConfSpec.CustomCNIConfig
+		}
 	}
 
 	netAttachDef := &netv1.NetworkAttachmentDefinition{


### PR DESCRIPTION
I did not check the pointer variable and just use it and it caused panic.

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)

**What this PR does / why we need it**:
fix bug

**Which issue(s) this PR fixes**:
close #1990 

