### PR TITLE
fix: results report exited unexpectedly before the parallel process e…

### DIFF
--- a/pkg/lock/lock_debug_test.go
+++ b/pkg/lock/lock_debug_test.go
@@ -40,6 +40,8 @@ var _ = Describe("Debug lock", Label("unitest", "lock_test"), func() {
 
 		It("holds the lock timeout", func() {
 			go func() {
+				defer GinkgoRecover()
+
 				mutex.Lock()
 				time.Sleep(selfishTimeout)
 				mutex.Unlock()
@@ -50,6 +52,8 @@ var _ = Describe("Debug lock", Label("unitest", "lock_test"), func() {
 
 		It("ignores the timeout when unlocking", func() {
 			go func() {
+				defer GinkgoRecover()
+
 				mutex.Lock()
 				time.Sleep(selfishTimeout)
 				mutex.UnlockIgnoreTime()
@@ -76,6 +80,8 @@ var _ = Describe("Debug lock", Label("unitest", "lock_test"), func() {
 
 		It("holds the lock timeout", func() {
 			go func() {
+				defer GinkgoRecover()
+
 				rwMutex.Lock()
 				time.Sleep(selfishTimeout)
 				rwMutex.Unlock()
@@ -86,6 +92,8 @@ var _ = Describe("Debug lock", Label("unitest", "lock_test"), func() {
 
 		It("ignores the timeout when unlocking", func() {
 			go func() {
+				defer GinkgoRecover()
+
 				rwMutex.Lock()
 				time.Sleep(selfishTimeout)
 				rwMutex.UnlockIgnoreTime()


### PR DESCRIPTION
#2005

```
This occurs if a parallel process exits before it reports its results to the
Ginkgo CLI.  The CLI will now print out all the stdout/stderr output it's
collected from the running processes.  However you may not see anything useful
in these logs because the individual test processes usually intercept output to
stdout/stderr in order to capture it in the spec reports.
```
