### PR TITLE
ippool inherits subnet properties 

### DIFF
--- a/pkg/ippoolmanager/ippool_mutate.go
+++ b/pkg/ippoolmanager/ippool_mutate.go
@@ -9,6 +9,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -63,8 +64,14 @@ func (iw *IPPoolWebhook) mutateIPPool(ctx context.Context, ipPool *spiderpoolv2b
 	}
 
 	if iw.EnableSpiderSubnet {
-		if err := iw.setControllerSubnet(ctx, ipPool); err != nil {
+		subnet, err := iw.setControllerSubnet(ctx, ipPool)
+		if err != nil {
 			return apierrors.NewInternalError(fmt.Errorf("failed to set the reference of the controller Subnet: %v", err))
+		}
+
+		// inherit gateway,vlan,routes from corresponding SpiderSubnet if not set
+		if subnet != nil {
+			inheritSubnetProperties(subnet, ipPool)
 		}
 	}
 
@@ -93,18 +100,18 @@ func (iw *IPPoolWebhook) mutateIPPool(ctx context.Context, ipPool *spiderpoolv2b
 	return nil
 }
 
-func (iw *IPPoolWebhook) setControllerSubnet(ctx context.Context, ipPool *spiderpoolv2beta1.SpiderIPPool) error {
+func (iw *IPPoolWebhook) setControllerSubnet(ctx context.Context, ipPool *spiderpoolv2beta1.SpiderIPPool) (*spiderpoolv2beta1.SpiderSubnet, error) {
 	logger := logutils.FromContext(ctx)
 
 	// TODO(iiiceoo): There was an occasional bug.
 	owner := metav1.GetControllerOf(ipPool)
 	if v, ok := ipPool.Labels[constant.LabelIPPoolOwnerSpiderSubnet]; ok && owner != nil && v == owner.Name {
-		return nil
+		return nil, nil
 	}
 
 	cidr, err := spiderpoolip.CIDRToLabelValue(*ipPool.Spec.IPVersion, ipPool.Spec.Subnet)
 	if err != nil {
-		return fmt.Errorf("failed to parse CIDR %s as a valid label value: %v", ipPool.Spec.Subnet, err)
+		return nil, fmt.Errorf("failed to parse CIDR %s as a valid label value: %v", ipPool.Spec.Subnet, err)
 	}
 
 	var subnetList spiderpoolv2beta1.SpiderSubnetList
@@ -113,17 +120,17 @@ func (iw *IPPoolWebhook) setControllerSubnet(ctx context.Context, ipPool *spider
 		&subnetList,
 		client.MatchingLabels{constant.LabelSubnetCIDR: cidr},
 	); err != nil {
-		return fmt.Errorf("failed to list Subnets: %v", err)
+		return nil, fmt.Errorf("failed to list Subnets: %v", err)
 	}
 
 	if len(subnetList.Items) == 0 {
-		return nil
+		return nil, nil
 	}
 
-	subnet := subnetList.Items[0]
-	if !metav1.IsControlledBy(ipPool, &subnet) {
-		if err := ctrl.SetControllerReference(&subnet, ipPool, iw.Client.Scheme()); err != nil {
-			return fmt.Errorf("failed to set owner reference: %v", err)
+	subnet := subnetList.Items[0].DeepCopy()
+	if !metav1.IsControlledBy(ipPool, subnet) {
+		if err := ctrl.SetControllerReference(subnet, ipPool, iw.Client.Scheme()); err != nil {
+			return nil, fmt.Errorf("failed to set owner reference: %v", err)
 		}
 		logger.Sugar().Infof("Set owner reference as Subnet %s", subnet.Name)
 	}
@@ -133,5 +140,22 @@ func (iw *IPPoolWebhook) setControllerSubnet(ctx context.Context, ipPool *spider
 		logger.Sugar().Infof("Set label %s: %s", constant.LabelIPPoolOwnerSpiderSubnet, subnet.Name)
 	}
 
-	return nil
+	return subnet, nil
+}
+
+func inheritSubnetProperties(subnet *spiderpoolv2beta1.SpiderSubnet, ipPool *spiderpoolv2beta1.SpiderIPPool) {
+	if subnet.Spec.Gateway != nil && ipPool.Spec.Gateway == nil {
+		ipPool.Spec.Gateway = pointer.String(*subnet.Spec.Gateway)
+	}
+
+	if subnet.Spec.Vlan != nil && ipPool.Spec.Vlan == nil {
+		ipPool.Spec.Vlan = pointer.Int64(*subnet.Spec.Vlan)
+	}
+
+	// if customer set empty route for this IPPool, it would not inherit the SpiderSubnet.Spec.Routes
+	if len(subnet.Spec.Routes) != 0 && ipPool.Spec.Routes == nil {
+		routes := make([]spiderpoolv2beta1.Route, len(subnet.Spec.Routes))
+		copy(routes, subnet.Spec.Routes)
+		ipPool.Spec.Routes = routes
+	}
 }

--- a/test/e2e/annotation/annotation_test.go
+++ b/test/e2e/annotation/annotation_test.go
@@ -548,6 +548,7 @@ var _ = Describe("test annotation", Label("annotation"), func() {
 				GinkgoWriter.Println("Pod IP is successfully released")
 			})
 	})
+
 	It("succeeded to running pod after added valid route field", Label("A00002"), func() {
 		var v4PoolName, v6PoolName, ipv4Dst, ipv6Dst, ipv4Gw, ipv6Gw string
 		var v4Pool, v6Pool *spiderpool.SpiderIPPool


### PR DESCRIPTION
The IPPool should inherits subnet gateway, routes, vlan if not specified

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)

What this PR does / why we need it:
fix bug

Which issue(s) this PR fixes:
close https://github.com/spidernet-io/spiderpool/issues/1958