### PR TITLE
fix failed to init arp client

### DIFF
--- a/cmd/coordinator/cmd/command_add.go
+++ b/cmd/coordinator/cmd/command_add.go
@@ -178,11 +178,11 @@ func CmdAdd(args *skel.CmdArgs) (err error) {
 	}
 
 	if conf.IPConflict != nil && *conf.IPConflict {
-		ipc, err := ipchecking.NewIPChecker(c.ipFamily, conf.DetectOptions.Retry, c.currentInterface, conf.DetectOptions.Interval, conf.DetectOptions.TimeOut, c.netns, logger)
+		ipc, err := ipchecking.NewIPChecker(conf.DetectOptions.Retry, conf.DetectOptions.Interval, conf.DetectOptions.TimeOut, c.netns, logger)
 		if err != nil {
 			return fmt.Errorf("failed to run NewIPChecker: %w", err)
 		}
-		ipc.DoIPConflictChecking(prevResult.IPs, errg)
+		ipc.DoIPConflictChecking(prevResult.IPs, c.currentInterface, errg)
 	}
 
 	if err = errg.Wait(); err != nil {


### PR DESCRIPTION
---
name: Pull request
about: Tell us about your contribution
labels: ["pr/release/none-required"]
---

---
## Thanks for contributing !

Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/contributing/development/pullrequest/#need-review>

**What this PR does / why we need it**:

If  the feature: `IP Conflict detection` is enabled, we must make sure that the `ARP/NDP` client is initialized in the main goroutine and in the pod's netns, not a new goroutine.

```
test-multus-8950a5d744]: error adding container to network "test-multus-8950a5d744": failed to ip checking: failed to init arp client: listen packet 0a:d7:2d:a6:81:62: bind: no such device
```

```
error adding container to network "test-multus-0e130ba0ac": failed to ip checking: failed to init ndp client: ndp: address "linklocal" not found on interface "net1"

```


**Which issue(s) this PR fixes**:

https://github.com/spidernet-io/spiderpool/issues/2056

**Special notes for your reviewer**:

**make sure your commit is signed off**
