### PR TITLE
annotate the auto-generated spidermMultusConfig by init-pod

### DIFF
--- a/cmd/spiderpool-init/cmd/config.go
+++ b/cmd/spiderpool-init/cmd/config.go
@@ -317,7 +317,7 @@ func parseCNIFromConfig(cniConfigPath string) (string, string, error) {
 }
 
 func getMultusCniConfig(cniName, cniType string) *spiderpoolv2beta1.SpiderMultusConfig {
-	annotations := make(map[string]string)
+	annotations := getDefaultAnnotations()
 	// change calico cni name from k8s-pod-network to calico
 	// more datails see:
 	// https://github.com/projectcalico/calico/issues/7837
@@ -330,10 +330,23 @@ func getMultusCniConfig(cniName, cniType string) *spiderpoolv2beta1.SpiderMultus
 			Name:        cniName,
 			Namespace:   "kube-system",
 			Annotations: annotations,
+			Labels: map[string]string{
+				constant.MultusInstanceShowLabel: "enable",
+			},
 		},
 		Spec: spiderpoolv2beta1.MultusCNIConfigSpec{
 			CniType:           spiderpoolv2beta1.CniType(cniType),
 			EnableCoordinator: pointer.Bool(false),
 		},
 	}
+}
+
+func getDefaultAnnotations() (annotations map[string]string) {
+	annotations = make(map[string]string)
+	annotations[constant.MultusInstanceIsDefaultLabel] = "true"
+	annotations[constant.MultusInstanceIsUnderlayLabel] = "false"
+	annotations[constant.MultusInstanceTypeLabel] = "default"
+	annotations[constant.MultusInstanceCoexistLabel] = "[\"macvlan_overlay\",\"ipvlan_overlay\",\"sriov_overlay\"]"
+	annotations[constant.MultusInstanceVlanIDLabel] = "0"
+	return annotations
 }

--- a/pkg/constant/k8s.go
+++ b/pkg/constant/k8s.go
@@ -91,6 +91,14 @@ const (
 	AnnoNetAttachConfName      = MultusConfAnnoPre + "/cr-name"
 	AnnoMultusConfigCNIVersion = MultusConfAnnoPre + "/cni-version"
 
+	AnnoMultusInstancePrefix      = "v1.multus-underlay-cni.io"
+	MultusInstanceShowLabel       = AnnoMultusInstancePrefix + "/instance-status"
+	MultusInstanceTypeLabel       = AnnoMultusInstancePrefix + "/instance-type"
+	MultusInstanceIsDefaultLabel  = AnnoMultusInstancePrefix + "/default-cni"
+	MultusInstanceIsUnderlayLabel = AnnoMultusInstancePrefix + "/underlay-cni"
+	MultusInstanceVlanIDLabel     = AnnoMultusInstancePrefix + "/vlanId"
+	MultusInstanceCoexistLabel    = AnnoMultusInstancePrefix + "/coexist-types"
+
 	// Coordinator
 	AnnoDefaultRouteInterface = AnnotationPre + "/default-route-nic"
 )


### PR DESCRIPTION
---
name: Pull request
about: Tell us about your contribution
labels: ["pr/release/none-required"]
---

---
## Thanks for contributing !

Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/contributing/development/pullrequest/#need-review>

**What this PR does / why we need it**:

it's for production. We should annotate some known annotations to the auto-generated spidermMultusConfig.

For examples:

```
  annotations:
    v1.multus-underlay-cni.io/coexist-types: '["macvlan_overlay","sriov_overlay"]'
    v1.multus-underlay-cni.io/default-cni: "true"
    v1.multus-underlay-cni.io/instance-type: default
    v1.multus-underlay-cni.io/vlanId: "0"
  labels:
    v1.multus-underlay-cni.io/instance-status: enable
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**make sure your commit is signed off**
