### PR TITLE
spidermultusconfig: improve parameters validate

### DIFF
--- a/pkg/multuscniconfig/multusconfig_informer.go
+++ b/pkg/multuscniconfig/multusconfig_informer.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/containernetworking/cni/pkg/types"
 	netv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	ifacercmd "github.com/spidernet-io/spiderpool/cmd/ifacer/cmd"
 	"go.uber.org/zap"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -538,8 +539,10 @@ func generateIfacer(master []string, vlanID int32, bond *spiderpoolv2beta1.BondC
 	}
 
 	if bond != nil {
-		netConf.Bond.Name = bond.Name
-		netConf.Bond.Mode = int(bond.Mode)
+		netConf.Bond = &ifacercmd.Bond{
+			Name: bond.Name,
+			Mode: int(bond.Mode),
+		}
 
 		if bond.Options != nil {
 			netConf.Bond.Options = *bond.Options

--- a/pkg/multuscniconfig/multusconfig_validate.go
+++ b/pkg/multuscniconfig/multusconfig_validate.go
@@ -27,6 +27,12 @@ func validateCNIConfig(multusConfig *spiderpoolv2beta1.SpiderMultusConfig) *fiel
 			return field.Required(macvlanConfigField, fmt.Sprintf("no %s specified", macvlanConfigField.String()))
 		}
 
+		if multusConfig.Spec.MacvlanConfig.VlanID != nil {
+			if err := validateVlanId(*multusConfig.Spec.MacvlanConfig.VlanID); err != nil {
+				return field.Invalid(macvlanConfigField, *multusConfig.Spec.MacvlanConfig.VlanID, err.Error())
+			}
+		}
+
 		if err := validateVlanCNIConfig(multusConfig.Spec.MacvlanConfig.Master, multusConfig.Spec.MacvlanConfig.Bond); err != nil {
 			return field.Invalid(macvlanConfigField, *multusConfig.Spec.MacvlanConfig, err.Error())
 		}
@@ -38,6 +44,12 @@ func validateCNIConfig(multusConfig *spiderpoolv2beta1.SpiderMultusConfig) *fiel
 	case IpVlanType:
 		if multusConfig.Spec.IPVlanConfig == nil {
 			return field.Required(ipvlanConfigField, fmt.Sprintf("no %s specified", ipvlanConfigField.String()))
+		}
+
+		if multusConfig.Spec.IPVlanConfig.VlanID != nil {
+			if err := validateVlanId(*multusConfig.Spec.IPVlanConfig.VlanID); err != nil {
+				return field.Invalid(ipvlanConfigField, *multusConfig.Spec.IPVlanConfig.VlanID, err.Error())
+			}
 		}
 
 		if err := validateVlanCNIConfig(multusConfig.Spec.IPVlanConfig.Master, multusConfig.Spec.IPVlanConfig.Bond); err != nil {
@@ -52,13 +64,23 @@ func validateCNIConfig(multusConfig *spiderpoolv2beta1.SpiderMultusConfig) *fiel
 		if multusConfig.Spec.SriovConfig == nil {
 			return field.Required(sriovConfigField, fmt.Sprintf("no %s specified", sriovConfigField.String()))
 		}
+
+		if multusConfig.Spec.SriovConfig.VlanID != nil {
+			if err := validateVlanId(*multusConfig.Spec.SriovConfig.VlanID); err != nil {
+				return field.Invalid(sriovConfigField, *multusConfig.Spec.SriovConfig.VlanID, err.Error())
+			}
+		}
+
+		if multusConfig.Spec.SriovConfig.ResourceName == "" {
+			return field.Required(sriovConfigField, fmt.Sprintf("no %s specified", sriovConfigField.Key("resourceName")))
+		}
+
 		if multusConfig.Spec.MacvlanConfig != nil || multusConfig.Spec.IPVlanConfig != nil || multusConfig.Spec.CustomCNIConfig != nil {
 			return field.Forbidden(cniTypeField, fmt.Sprintf("the cniType %s only supports %s, please remove other CNI configs", SriovType, sriovConfigField.String()))
 		}
 
 	case CustomType:
 		// multusConfig.Spec.CustomCNIConfig can be empty
-
 		if multusConfig.Spec.MacvlanConfig != nil || multusConfig.Spec.IPVlanConfig != nil || multusConfig.Spec.SriovConfig != nil {
 			return field.Forbidden(cniTypeField, fmt.Sprintf("the cniType %s only supports %s, please remove other CNI configs", CustomType, customCniConfigField.String()))
 		}
@@ -75,11 +97,23 @@ func validateCNIConfig(multusConfig *spiderpoolv2beta1.SpiderMultusConfig) *fiel
 }
 
 func validateVlanCNIConfig(master []string, bond *spiderpoolv2beta1.BondConfig) error {
-	if len(master) >= 2 {
+	if len(master) == 0 {
+		return fmt.Errorf("master can't be empty")
+	} else if len(master) >= 2 {
 		if bond == nil {
 			return fmt.Errorf("the bond property is nil with multiple Interfaces")
 		}
+		if bond.Name == "" {
+			return fmt.Errorf("bond name can't be empty")
+		}
 	}
 
+	return nil
+}
+
+func validateVlanId(vlanId int32) error {
+	if vlanId < 0 || vlanId > 4094 {
+		return fmt.Errorf("invalid vlanId %v, please make sure vlanId in range [0,4094]", vlanId)
+	}
 	return nil
 }


### PR DESCRIPTION
---
name: Pull request
about: Tell us about your contribution
labels: ["pr/release/none-required"]
---

---
## Thanks for contributing !

Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/contributing/development/pullrequest/#need-review>

**What this PR does / why we need it**:

spidermultusconfig: improve parameters validate

```
{"level":"INFO","ts":"2023-07-27T08:41:12.249Z","logger":"Coordinator-Informer","caller":"coordinatormanager/coordinator_informer.go:284","msg":"Succeed to SYNC","CoordinatorName":"default","Operation":"PROCESS"}
E0727 08:41:12.337796       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 268 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x1bc05a0?, 0x3001a70})
	/src/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x99
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc0003ed430?})
	/src/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x75
panic({0x1bc05a0, 0x3001a70})
	/usr/local/go/src/runtime/panic.go:884 +0x213
github.com/spidernet-io/spiderpool/pkg/multuscniconfig.generateMacvlanCNIConf({{0xc000850db0, 0x7}, 0xc0006753e0, 0x0, 0x0, 0xc000369e50, 0x0, 0x0})
	/src/pkg/multuscniconfig/multusconfig_informer.go:448 +0x88
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**make sure your commit is signed off**
