### PR TITLE
fix: spidermultusconfig 

### DIFF
--- a/charts/spiderpool/crds/spiderpool.spidernet.io_spidercoordinators.yaml
+++ b/charts/spiderpool/crds/spiderpool.spidernet.io_spidercoordinators.yaml
@@ -40,39 +40,39 @@ spec:
             description: CoordinationSpec defines the desired state of SpiderCoordinator.
             properties:
               detectGateway:
-                default: false
                 type: boolean
               detectIPConflict:
-                default: false
                 type: boolean
               hijackCIDR:
                 items:
                   type: string
                 type: array
               hostRPFilter:
-                default: 0
                 type: integer
               hostRuleTable:
-                default: 500
                 type: integer
               mode:
-                default: underlay
                 enum:
                 - underlay
                 - overlay
                 - disabled
                 type: string
               podCIDRType:
+                description: CoordinatorSpec is used by SpiderCoordinator and SpiderMultusConfig
+                  in spidermultusconfig CRD , podCIDRType should not be required,
+                  which could be merged from SpiderCoordinator CR but in SpiderCoordinator
+                  CRD, podCIDRType should be required
+                enum:
+                - cluster
+                - calico
+                - cilium
                 type: string
               podDefaultRouteNIC:
                 type: string
               podMACPrefix:
                 type: string
               tunePodRoutes:
-                default: true
                 type: boolean
-            required:
-            - podCIDRType
             type: object
           status:
             description: CoordinationStatus defines the observed state of SpiderCoordinator.

--- a/charts/spiderpool/crds/spiderpool.spidernet.io_spidermultusconfigs.yaml
+++ b/charts/spiderpool/crds/spiderpool.spidernet.io_spidermultusconfigs.yaml
@@ -55,39 +55,39 @@ spec:
                 description: CoordinationSpec defines the desired state of SpiderCoordinator.
                 properties:
                   detectGateway:
-                    default: false
                     type: boolean
                   detectIPConflict:
-                    default: false
                     type: boolean
                   hijackCIDR:
                     items:
                       type: string
                     type: array
                   hostRPFilter:
-                    default: 0
                     type: integer
                   hostRuleTable:
-                    default: 500
                     type: integer
                   mode:
-                    default: underlay
                     enum:
                     - underlay
                     - overlay
                     - disabled
                     type: string
                   podCIDRType:
+                    description: CoordinatorSpec is used by SpiderCoordinator and
+                      SpiderMultusConfig in spidermultusconfig CRD , podCIDRType should
+                      not be required, which could be merged from SpiderCoordinator
+                      CR but in SpiderCoordinator CRD, podCIDRType should be required
+                    enum:
+                    - cluster
+                    - calico
+                    - cilium
                     type: string
                   podDefaultRouteNIC:
                     type: string
                   podMACPrefix:
                     type: string
                   tunePodRoutes:
-                    default: true
                     type: boolean
-                required:
-                - podCIDRType
                 type: object
               customCNI:
                 description: OtherCniTypeConfig only used for CniType custom, valid

--- a/cmd/coordinator/cmd/cni_types.go
+++ b/cmd/coordinator/cmd/cni_types.go
@@ -25,7 +25,7 @@ import (
 var (
 	defaultLogPath          = "/var/log/spidernet/coordinator.log"
 	defaultUnderlayVethName = "veth0"
-	defaultMarkBit          = 0 //ox1
+	defaultMarkBit          = 0 // ox1
 	// by default, k8s pod's first NIC is eth0
 	defaultOverlayVethName = "eth0"
 	defaultPodRuleTable    = 100

--- a/cmd/spiderpool-init/cmd/root.go
+++ b/cmd/spiderpool-init/cmd/root.go
@@ -44,7 +44,7 @@ func Execute() {
 			},
 			Spec: spiderpoolv2beta1.CoordinatorSpec{
 				Mode:               &config.CoordinatorMode,
-				PodCIDRType:        config.CoordinatorPodCIDRType,
+				PodCIDRType:        &config.CoordinatorPodCIDRType,
 				TunePodRoutes:      &config.CoordinatorTunePodRoutes,
 				DetectIPConflict:   &config.CoordinatorDetectIPConflict,
 				DetectGateway:      &config.CoordinatorDetectGateway,

--- a/docs/develop/contributing.md
+++ b/docs/develop/contributing.md
@@ -2,6 +2,12 @@
 
 ***
 
+## unitest
+
+run the following command to check unitest
+
+`make unitest-tests`
+
 ## setup cluster and run test
 
 1. check required developing tools on you local host. If something missing, please run 'test/scripts/install-tools.sh' to install them
@@ -111,10 +117,10 @@
         $ make e2e_test_underlay_subnet 
 
         # Run all e2e tests for enableSpiderSubnet=false cluster
-        $ make e2e_test_overlay_calico
+        $ make e2e_test_calico
 
         # Run all e2e tests for enableSpiderSubnet=false cluster
-        $ make e2e_test_overlay_cilium 
+        $ make e2e_test_cilium 
 
         $ ls e2ereport.json
 

--- a/pkg/coordinatormanager/coordinator_informer.go
+++ b/pkg/coordinatormanager/coordinator_informer.go
@@ -45,6 +45,8 @@ const (
 	cilium  = "cilium"
 )
 
+var SupportedPodCIDRType = []string{cluster, calico, cilium}
+
 const (
 	calicoConfig = "calico-config"
 	ciliumConfig = "cilium-config"
@@ -204,12 +206,12 @@ func (cc *CoordinatorController) enqueueCoordinatorOnUpdate(oldObj, newObj inter
 		zap.String("Operation", "UPDATE"),
 	)
 
-	if newCoord.Spec.PodCIDRType != oldCoord.Spec.PodCIDRType {
+	if newCoord.Spec.PodCIDRType != oldCoord.Spec.PodCIDRType && *newCoord.Spec.PodCIDRType != *oldCoord.Spec.PodCIDRType {
 		event.EventRecorder.Eventf(
 			newCoord,
 			corev1.EventTypeNormal,
 			"PodCIDRTypeChanged",
-			"Pod CIDR type changed from %s to %s", oldCoord.Spec.PodCIDRType, newCoord.Spec.PodCIDRType,
+			"Pod CIDR type changed from %s to %s", *oldCoord.Spec.PodCIDRType, *newCoord.Spec.PodCIDRType,
 		)
 	}
 
@@ -341,7 +343,7 @@ func (cc *CoordinatorController) syncHandler(ctx context.Context, coordinatorNam
 	}
 
 	k8sPodCIDR, k8sServiceCIDR := extractK8sCIDR(&cmPodList.Items[0])
-	switch coord.Spec.PodCIDRType {
+	switch *coord.Spec.PodCIDRType {
 	case cluster:
 		if cc.caliCtrlCanncel != nil {
 			cc.caliCtrlCanncel()

--- a/pkg/coordinatormanager/coordinator_mutate.go
+++ b/pkg/coordinatormanager/coordinator_mutate.go
@@ -5,6 +5,8 @@ package coordinatormanager
 
 import (
 	"context"
+	"fmt"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -17,9 +19,32 @@ func mutateCoordinator(ctx context.Context, coord *spiderpoolv2beta1.SpiderCoord
 	logger := logutils.FromContext(ctx)
 	logger.Info("Start to mutate Coordinator")
 
+	if coord.Spec.Mode == nil {
+		coord.Spec.Mode = pointer.String("underlay")
+	}
+	if coord.Spec.TunePodRoutes == nil {
+		coord.Spec.TunePodRoutes = pointer.Bool(true)
+	}
+	if coord.Spec.HostRuleTable == nil {
+		coord.Spec.HostRuleTable = pointer.Int(500)
+	}
+	if coord.Spec.HostRPFilter == nil {
+		coord.Spec.HostRPFilter = pointer.Int(0)
+	}
+	if coord.Spec.DetectIPConflict == nil {
+		coord.Spec.DetectIPConflict = pointer.Bool(false)
+	}
+	if coord.Spec.DetectGateway == nil {
+		coord.Spec.DetectGateway = pointer.Bool(false)
+	}
+
 	if coord.DeletionTimestamp != nil {
 		logger.Info("Terminating Coordinator, noting to mutate")
 		return nil
+	}
+
+	if coord.Spec.PodCIDRType == nil {
+		return fmt.Errorf("PodCIDRType is not allowed to be empty")
 	}
 
 	if !controllerutil.ContainsFinalizer(coord, constant.SpiderFinalizer) {

--- a/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/spidercoordinator_types.go
+++ b/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/spidercoordinator_types.go
@@ -9,13 +9,16 @@ import (
 
 // CoordinationSpec defines the desired state of SpiderCoordinator.
 type CoordinatorSpec struct {
-	// +kubebuilder:default=underlay
 	// +kubebuilder:validation:Enum=underlay;overlay;disabled
 	// +kubebuilder:validation:Optional
 	Mode *string `json:"mode,omitempty"`
 
-	// +kubebuilder:validation:Required
-	PodCIDRType string `json:"podCIDRType"`
+	// CoordinatorSpec is used by SpiderCoordinator and SpiderMultusConfig
+	// in spidermultusconfig CRD , podCIDRType should not be required, which could be merged from SpiderCoordinator CR
+	// but in SpiderCoordinator CRD, podCIDRType should be required
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum=cluster;calico;cilium
+	PodCIDRType *string `json:"podCIDRType,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	HijackCIDR []string `json:"hijackCIDR,omitempty"`
@@ -23,26 +26,21 @@ type CoordinatorSpec struct {
 	// +kubebuilder:validation:Optional
 	PodMACPrefix *string `json:"podMACPrefix,omitempty"`
 
-	// +kubebuilder:default=true
 	// +kubebuilder:validation:Optional
 	TunePodRoutes *bool `json:"tunePodRoutes,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	PodDefaultRouteNIC *string `json:"podDefaultRouteNIC,omitempty"`
 
-	// +kubebuilder:default=500
 	// +kubebuilder:validation:Optional
 	HostRuleTable *int `json:"hostRuleTable,omitempty"`
 
-	// +kubebuilder:default=0
 	// +kubebuilder:validation:Optional
 	HostRPFilter *int `json:"hostRPFilter,omitempty"`
 
-	// +kubebuilder:default=false
 	// +kubebuilder:validation:Optional
 	DetectIPConflict *bool `json:"detectIPConflict,omitempty"`
 
-	// +kubebuilder:default=false
 	// +kubebuilder:validation:Optional
 	DetectGateway *bool `json:"detectGateway,omitempty"`
 }

--- a/pkg/multuscniconfig/multusconfig_validate.go
+++ b/pkg/multuscniconfig/multusconfig_validate.go
@@ -87,7 +87,7 @@ func validateCNIConfig(multusConfig *spiderpoolv2beta1.SpiderMultusConfig) *fiel
 	}
 
 	if multusConfig.Spec.CoordinatorConfig != nil {
-		err := coordinatormanager.ValidateCoordinatorSpec(multusConfig.Spec.CoordinatorConfig.DeepCopy())
+		err := coordinatormanager.ValidateCoordinatorSpec(multusConfig.Spec.CoordinatorConfig.DeepCopy(), false)
 		if nil != err {
 			return err
 		}

--- a/pkg/networking/networking/ip.go
+++ b/pkg/networking/networking/ip.go
@@ -19,7 +19,7 @@ import (
 var DefaultInterfacesToExclude = []string{
 	"docker.*", "cbr.*", "dummy.*",
 	"virbr.*", "lxcbr.*", "veth.*", "lo",
-	"cali.*", "tunl.*", "flannel.*", "kube-ipvs.*",
+	"^cali.*", "flannel.*", "kube-ipvs.*",
 	"cni.*", "vx-submariner", "cilium*",
 }
 
@@ -106,6 +106,8 @@ func IPAddressOnNode(logger *zap.Logger, ipFamily int) ([]netlink.Addr, error) {
 	var allIPAddress []netlink.Addr
 	for idx := range links {
 		iLink := links[idx]
+
+		// TODO: this may be dangerous, it should not filter the node IP who is calculated by `ip r get POD_IP`
 		if excludeRegexp.MatchString(iLink.Attrs().Name) {
 			continue
 		}

--- a/test/e2e/coordinator/macvlan-overlay-one/macvlan_overlay_one_test.go
+++ b/test/e2e/coordinator/macvlan-overlay-one/macvlan_overlay_one_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"k8s.io/utils/pointer"
 	"math/rand"
 	"net"
 	"strconv"
@@ -222,7 +223,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 						PodMACPrefix:       &macPrefix,
 						PodDefaultRouteNIC: &common.NIC2,
 						Mode:               &mode,
-						PodCIDRType:        podCidrType,
+						PodCIDRType:        &podCidrType,
 					},
 				},
 			}
@@ -325,7 +326,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 					CoordinatorConfig: &spiderpoolv2beta1.CoordinatorSpec{
 						Mode:          &mode,
 						DetectGateway: &detectGateway,
-						PodCIDRType:   podCidrType,
+						PodCIDRType:   &podCidrType,
 					},
 				},
 			}
@@ -420,12 +421,13 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 				Spec: spiderpoolv2beta1.MultusCNIConfigSpec{
 					CniType: "macvlan",
 					MacvlanConfig: &spiderpoolv2beta1.SpiderMacvlanCniConfig{
-						Master: []string{common.NIC4},
+						Master: []string{common.NIC1},
+						VlanID: pointer.Int32(200),
 					},
 					CoordinatorConfig: &spiderpoolv2beta1.CoordinatorSpec{
 						Mode:             &mode,
 						DetectIPConflict: &ipConflict,
-						PodCIDRType:      podCidrType,
+						PodCIDRType:      &podCidrType,
 					},
 				},
 			}

--- a/test/e2e/spidermultus/spidermultus_test.go
+++ b/test/e2e/spidermultus/spidermultus_test.go
@@ -40,7 +40,7 @@ var _ = Describe("test spidermultus", Label("spiderMultus", "overlay"), func() {
 					},
 					CoordinatorConfig: &spiderpoolv2beta1.CoordinatorSpec{
 						Mode:        &mode, //	mode = "disabled"
-						PodCIDRType: podCidrType,
+						PodCIDRType: &podCidrType,
 					},
 				},
 			}

--- a/test/scripts/config-network.sh
+++ b/test/scripts/config-network.sh
@@ -21,39 +21,8 @@ DEFAULT_INTERFACE=eth0
 VLAN_GATEWAY_CONTAINER=${VLAN_GATEWAY_CONTAINER:-"vlan-gateway"}
 VLANID1=100
 VLANID2=200
-VLANID1_IP=172.100.0.100/16
-VLANID2_IP=172.200.0.100/16
-VLANID1_IP6=fd00:172:100::100/64
-VLANID2_IP6=fd00:172:200::100/64
 E2E_VLAN_GATEWAY_IMAGE=${E2E_VLAN_GATEWAY_IMAGE:-"docker.io/centos/tools:latest"}
 
-res=0
-kind_nodes=$(docker ps  | egrep "kindest/node.* ${E2E_CLUSTER_NAME}-(control-plane|worker)"  | awk '{print $1}')
-for node in ${kind_nodes}; do
-  docker exec ${node} ip link add link ${DEFAULT_INTERFACE} name ${DEFAULT_INTERFACE}.${VLANID1} type vlan id ${VLANID1}  || res=$?
-  docker exec ${node} ip link add link ${DEFAULT_INTERFACE} name ${DEFAULT_INTERFACE}.${VLANID2} type vlan id ${VLANID2}  || res=$?
-  if [[ ${res} -ne "0" ]] && [[ ${res} -ne "2" ]]; then echo failed to create vlan interface for kind-node && exit ${res} ; fi
-  if [ ${E2E_IP_FAMILY} = "ipv4" ]; then
-    docker exec ${node} ip addr add ${VLANID1_IP} dev ${DEFAULT_INTERFACE}.${VLANID1}
-    docker exec ${node} ip addr add ${VLANID2_IP} dev ${DEFAULT_INTERFACE}.${VLANID2}
-  elif [ ${E2E_IP_FAMILY} = "ipv6" ]; then
-    docker exec ${node} ip addr add ${VLANID1_IP6} dev ${DEFAULT_INTERFACE}.${VLANID1}
-    docker exec ${node} ip addr add ${VLANID2_IP6} dev ${DEFAULT_INTERFACE}.${VLANID2}
-  elif [ ${E2E_IP_FAMILY} = "dual" ]; then
-    docker exec ${node} ip addr add ${VLANID1_IP} dev ${DEFAULT_INTERFACE}.${VLANID1}
-    docker exec ${node} ip addr add ${VLANID2_IP} dev ${DEFAULT_INTERFACE}.${VLANID2}
-    docker exec ${node} ip addr add ${VLANID1_IP6} dev ${DEFAULT_INTERFACE}.${VLANID1}
-    docker exec ${node} ip addr add ${VLANID2_IP6} dev ${DEFAULT_INTERFACE}.${VLANID2}
-  else
-    echo "error ip family, the value of E2E_IP_FAMILY must be of ipv4,ipv6 or dual." && exit 1
-  fi
-  docker exec ${node} ip link set ${DEFAULT_INTERFACE}.${VLANID1} up
-  docker exec ${node} ip link set ${DEFAULT_INTERFACE}.${VLANID2} up
-  VLANID1_IP=172.100.0.200/16
-  VLANID2_IP=172.200.0.200/16
-  VLANID1_IP6=fd00:172:100::200/64
-  VLANID2_IP6=fd00:172:200::200/64
-done
 
 # run a test container as a vlan gateway and client
 # note: ip address of this container should be consist with spiderpool's gateway

--- a/test/scripts/install-multus.sh
+++ b/test/scripts/install-multus.sh
@@ -49,30 +49,18 @@ if [ ${OS} == "darwin" ]; then SED_COMMAND=gsed ; fi
 Install::MultusCR(){
 
 MACVLAN_CR_TEMPLATE='
-apiVersion: k8s.cni.cncf.io/v1
-kind: NetworkAttachmentDefinition
+apiVersion: spiderpool.spidernet.io/v2beta1
+kind: SpiderMultusConfig
 metadata:
   name: <<CNI_NAME>>
   namespace: <<NAMESPACE>>
 spec:
-  config: |-
-    {
-        "cniVersion": "0.3.1",
-        "name": "<<CNI_NAME>>",
-        "plugins": [
-            {
-                "type": "macvlan",
-                "master": "<<MASTER>>",
-                "mode": "bridge",
-                "ipam": {
-                    "type": "spiderpool"
-                }
-            },{
-                "type": "coordinator",
-                "mode": "<<MODE>>"
-            }
-        ]
-    }
+  cniType: macvlan
+  macvlan:
+    master: ["<<MASTER>>"]
+    vlanID: <<VLAN>>
+  coordinator:
+    mode: "<<MODE>>"
 '
 
   echo "${MACVLAN_CR_TEMPLATE}" \
@@ -80,35 +68,39 @@ spec:
     | sed 's?<<NAMESPACE>>?'"${RELEASE_NAMESPACE}"'?g' \
     | sed 's?<<MODE>>?underlay?g' \
     | sed 's?<<MASTER>>?eth0?g' \
+    | sed 's?<<VLAN>>?0?g' \
     | kubectl apply --kubeconfig ${E2E_KUBECONFIG} -f -
 
   echo "${MACVLAN_CR_TEMPLATE}" \
     | sed 's?<<CNI_NAME>>?'""${MULTUS_DEFAULT_CNI_VLAN100}""'?g' \
     | sed 's?<<NAMESPACE>>?'"${RELEASE_NAMESPACE}"'?g' \
     | sed 's?<<MODE>>?underlay?g' \
-    | sed 's?<<MASTER>>?eth0.100?g' \
+    | sed 's?<<MASTER>>?eth0?g' \
+    | sed 's?<<VLAN>>?100?g' \
     | kubectl apply --kubeconfig ${E2E_KUBECONFIG} -f -
-
 
   echo "${MACVLAN_CR_TEMPLATE}" \
     | sed 's?<<CNI_NAME>>?'""${MULTUS_ADDITIONAL_CNI_VLAN100}""'?g' \
     | sed 's?<<NAMESPACE>>?'"${RELEASE_NAMESPACE}"'?g' \
     | sed 's?<<MODE>>?overlay?g' \
-    | sed 's?<<MASTER>>?eth0.100?g' \
+    | sed 's?<<MASTER>>?eth0?g' \
+    | sed 's?<<VLAN>>?100?g' \
     | kubectl apply --kubeconfig ${E2E_KUBECONFIG} -f -
 
   echo "${MACVLAN_CR_TEMPLATE}" \
     | sed 's?<<CNI_NAME>>?'""${MULTUS_ADDITIONAL_CNI_VLAN200}""'?g' \
     | sed 's?<<NAMESPACE>>?'"${RELEASE_NAMESPACE}"'?g' \
     | sed 's?<<MODE>>?overlay?g' \
-    | sed 's?<<MASTER>>?eth0.200?g' \
+    | sed 's?<<MASTER>>?eth0?g' \
+    | sed 's?<<VLAN>>?200?g' \
     | kubectl apply --kubeconfig ${E2E_KUBECONFIG} -f -
 
   echo "${MACVLAN_CR_TEMPLATE}" \
     | sed 's?<<CNI_NAME>>?'""${MULTUS_DEFAULT_CNI_VLAN200}""'?g' \
     | sed 's?<<NAMESPACE>>?'"${RELEASE_NAMESPACE}"'?g' \
     | sed 's?<<MODE>>?underlay?g' \
-    | sed 's?<<MASTER>>?eth0.200?g' \
+    | sed 's?<<MASTER>>?eth0?g' \
+    | sed 's?<<VLAN>>?200?g' \
     | kubectl apply --kubeconfig ${E2E_KUBECONFIG} -f -
 
 }


### PR DESCRIPTION
(1)
CoordinatorSpec is used by SpiderCoordinator and SpiderMultusConfig
in spidermultusconfig CRD , podCIDRType should not be required, which could be merged from SpiderCoordinator CR
but in SpiderCoordinator CRD, podCIDRType should be required
so just use webhook to check for SpiderCoordinator, but not CRD 

(2) all other fieds in CoordinatorSpec is dangerous
in spidermultusconfig CRD , if leave some fields to be empty, and they will be to default value and ignore the SpiderCoordinator, which make SpiderCoordinator to be meaningless
so just use webhook to set default value for SpiderCoordinator, but not CRD 

(3) coordinator cooperator with ifacer when overlay mode
miss arp for node IP from vxlan interface
 