### PR TITLE
docs fix: update busybox to nginx

### DIFF
--- a/docs/usage/install/cloud/get-started-alibaba-zh_CN.md
+++ b/docs/usage/install/cloud/get-started-alibaba-zh_CN.md
@@ -242,7 +242,7 @@ spec:
         v1.multus-cni.io/default-network: kube-system/ipvlan-eth1
     spec:
       containers:
-      - image: busybox
+      - image: nginx
         imagePullPolicy: IfNotPresent
         name: test-app-2
         ports:
@@ -255,7 +255,7 @@ kind: Service
 metadata:
   name: test-svc
   labels:
-    app: test-app-1
+    app: test-app-2
 spec:
   type: ClusterIP
   ports:
@@ -263,7 +263,7 @@ spec:
       protocol: TCP
       targetPort: 80
   selector:
-    app: test-app-1
+    app: test-app-2
 EOF
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Both sets of applications in this article use the busybus mirror, but need to use the curl command to access the clusterIP. busybus does not have this command. In addition, when the application is accessed through a public network load balancer, it is expected that the page can display content. It is more convenient to use nginx.

The application test-app-1 uses the busybox image for ping.
The application test-app-2 uses the nginx mirror for curl.

**Which issue(s) this PR fixes**:

update busybox to nginx

**make sure your commit is signed off**
Signed-off-by: ty-dc [tao.yang@daocloud.io](mailto:tao.yang@daocloud.io)