### PR TITLE
e2e fix: use api to abbreviate ipv6 addresses and fix subnet creation  failure due to duplicate names

### DIFF
--- a/test/e2e/common/spiderpool.go
+++ b/test/e2e/common/spiderpool.go
@@ -435,7 +435,7 @@ func GenerateExampleIpv4poolObject(ipNum int) (string, *v1.SpiderIPPool) {
 	}
 	var v4Ipversion = new(types.IPVersion)
 	*v4Ipversion = constant.IPv4
-	var v4PoolName string = "v4pool-" + tools.RandomName()
+	var v4PoolName string = "v4pool-" + GenerateString(15, true)
 	var randomNumber1 string = GenerateRandomNumber(255)
 	var randomNumber2 string = GenerateRandomNumber(255)
 
@@ -473,7 +473,7 @@ func GenerateExampleIpv6poolObject(ipNum int) (string, *v1.SpiderIPPool) {
 
 	var v6Ipversion = new(types.IPVersion)
 	*v6Ipversion = constant.IPv6
-	var v6PoolName string = "v6pool-" + tools.RandomName()
+	var v6PoolName string = "v6pool-" + GenerateString(15, true)
 	var randomNumber string = GenerateString(4, true)
 
 	iPv6PoolObj := &v1.SpiderIPPool{

--- a/test/e2e/common/spidersubnet.go
+++ b/test/e2e/common/spidersubnet.go
@@ -37,7 +37,7 @@ func GenerateExampleV4SubnetObject(ipNum int) (string, *spiderpool.SpiderSubnet)
 		GinkgoWriter.Println("the IP range should be between 1 and 65533")
 		Fail("the IP range should be between 1 and 65533")
 	}
-	subnetName := "v4-ss-" + tools.RandomName()
+	subnetName := "v4-ss-" + GenerateString(15, true)
 	randNum1 := GenerateRandomNumber(255)
 	randNum2 := GenerateRandomNumber(255)
 
@@ -76,7 +76,7 @@ func GenerateExampleV6SubnetObject(ipNum int) (string, *spiderpool.SpiderSubnet)
 		Fail("the IP range should be between 1 and 65533")
 	}
 
-	subnetName := "v6-ss-" + tools.RandomName()
+	subnetName := "v6-ss-" + GenerateString(15, true)
 	randNum := GenerateString(4, true)
 	subnetObj := &spiderpool.SpiderSubnet{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:
1. We use ginkgo. When using timestamp as a random variable, because it runs multiple it (4 in ci) concurrently, there is a very small probability that the same name will appear, resulting in the creation failure.
2. Improve ipv6 address abbreviation using api

**Which issue(s) this PR fixes**:

#2034 
#1820 

**make sure your commit is signed off**
Signed-off-by: ty-dc [tao.yang@daocloud.io](mailto:tao.yang@daocloud.io)