### PR TITLE
e2e docs: add new e2e case for spiderpool

### DIFF
--- a/test/doc/annotation.md
+++ b/test/doc/annotation.md
@@ -13,3 +13,4 @@
 | A00009  | Modify the annotated IPPool for a specified Deployment pod<br />Modify the annotated IPPool for a specified StatefulSet pod                 | p2       |       |  done   |       |
 | A00010  | Modify the annotated IPPool for a pod running on multiple NICs       | p3       |       | done   |       |
 | A00011  | Use the ippool route with `cleanGateway=false` in the pod annotation as a default route | p3     |     |  done  |         |
+| A00012  | Specify the default NIC through Pod annotations  | p2     |     |    |         |

--- a/test/doc/ippoolcr.md
+++ b/test/doc/ippoolcr.md
@@ -9,3 +9,8 @@
 | D00005  | A "true" value of IPPool/Spec/disabled should forbid IP allocation, but still allow ip de-allocation | p2       |       | done   |       |
 | D00006  | Successfully create and delete IPPools in batch                  | p2      |       | done   |       |
 | D00007  | Add, delete, modify, and query ippools that are created manually | p1      |       | done   |       |
+| D00008  | Manually ippool inherits subnet attributes (including routes, vlanId, etc.) | p3      |       |     |       |
+| D00009  | ippool cr: multusName affinity                                   | p2      |       |     |       |
+| D00010  | ippool cr: nodeName affinity                                     | p2      |       |     |       |
+| D00011  | ippool cr: namespaceName affinity                                | p2      |       |     |       |
+| D00012  | Multiple default IP pools can be set by `default: true`          | p3      |       |     |       |

--- a/test/doc/metric.md
+++ b/test/doc/metric.md
@@ -1,0 +1,5 @@
+# E2E Cases for metric
+
+| Case ID | Title                                                        | Priority | Smoke | Status | Other |
+| ------- | ------------------------------------------------------------ | -------- | ----- | ------ | ----- |
+| T00001  | The metric should work fine.                                 | p1       |  true |        |       |

--- a/test/doc/spidermultus.md
+++ b/test/doc/spidermultus.md
@@ -8,3 +8,4 @@
 | M00004  | Manually delete the net-attach-conf of multus, it will be created automatically | p1      |  smoke  |    |       |
 | M00005  | Customize net-attach-conf name via annotation multus.spidernet.io/cr-name | p2       |       |    |       |
 | M00006  | Change net-attach-conf version via annotation multus.spidernet.io/cni-version | p2     |       |    |       |
+| M00007  | spidermultusconfig webhook verification, including vlan, cnitype and other fields | p3     |       |    |       |


### PR DESCRIPTION
**What this PR does / why we need it**:
Supplement e2e case

**Which issue(s) this PR fixes**:
```
None
```

**make sure your commit is signed off**
Signed-off-by: ty-dc [tao.yang@daocloud.io](mailto:tao.yang@daocloud.io)
