### PR TITLE
e2e: add use case for changing multus properties via spidermultus annotation

### DIFF
--- a/test/doc/spidermultus.md
+++ b/test/doc/spidermultus.md
@@ -5,7 +5,7 @@
 | M00001  | After creating spiderMultusConfig, a corresponding multus net-attach-conf will be created  | p1       |   smoke    | done   |       |
 | M00002  | After deleting spiderMultusConfig, the corresponding net-attach-conf will also be deleted  | p1      |  smoke  | done   |       |
 | M00003  | Update spidermultusConfig, the corresponding multus net-attach-conf will also be updated   | p1      |  smoke  |    |       |
-| M00004  | Manually delete the net-attach-conf of multus, it will be created automatically | p1      |  smoke  |    |       |
-| M00005  | Customize net-attach-conf name via annotation multus.spidernet.io/cr-name | p2       |       |    |       |
-| M00006  | Change net-attach-conf version via annotation multus.spidernet.io/cni-version | p2     |       |    |       |
+| M00004  | Manually delete the net-attach-conf of multus, it will be created automatically | p1      |  smoke  |  done  |       |
+| M00005  | Customize net-attach-conf name via annotation multus.spidernet.io/cr-name | p2       |       |  done  |       |
+| M00006  | Change net-attach-conf version via annotation multus.spidernet.io/cni-version | p2     |       |  done  |       |
 | M00007  | spidermultusconfig webhook verification, including vlan, cnitype and other fields | p3     |       |    |       |

--- a/test/e2e/spidermultus/spidermultus_test.go
+++ b/test/e2e/spidermultus/spidermultus_test.go
@@ -3,6 +3,8 @@
 package spidermultus_test
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spidernet-io/spiderpool/pkg/constant"
@@ -15,10 +17,10 @@ import (
 var _ = Describe("test spidermultus", Label("spiderMultus", "overlay"), func() {
 
 	Context("Creation, update, deletion of spider multus", func() {
-		var namespace, mode, multusNadName, podCidrType string
+		var namespace, mode, spiderMultusNadName, podCidrType string
 
 		BeforeEach(func() {
-			multusNadName = "test-multus-" + common.GenerateString(10, true)
+			spiderMultusNadName = "test-multus-" + common.GenerateString(10, true)
 			mode = "disabled"
 			podCidrType = "cluster"
 			namespace = "ns-" + common.GenerateString(10, true)
@@ -30,7 +32,7 @@ var _ = Describe("test spidermultus", Label("spiderMultus", "overlay"), func() {
 			// Define multus cni NetworkAttachmentDefinition and create
 			nad := &spiderpoolv2beta1.SpiderMultusConfig{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      multusNadName,
+					Name:      spiderMultusNadName,
 					Namespace: namespace,
 				},
 				Spec: spiderpoolv2beta1.MultusCNIConfigSpec{
@@ -55,13 +57,13 @@ var _ = Describe("test spidermultus", Label("spiderMultus", "overlay"), func() {
 
 		It(`Delete multus nad and spidermultus, the deletion of the former will be automatically restored, 
 		    and the deletion of the latter will clean up all resources synchronously`, Label("M00001", "M00002", "M00004"), func() {
-			spiderMultusConfig, err := frame.GetSpiderMultusInstance(namespace, multusNadName)
+			spiderMultusConfig, err := frame.GetSpiderMultusInstance(namespace, spiderMultusNadName)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(spiderMultusConfig).NotTo(BeNil())
 			GinkgoWriter.Printf("spiderMultusConfig %+v \n", spiderMultusConfig)
 
 			Eventually(func() bool {
-				multusConfig, err := frame.GetMultusInstance(multusNadName, namespace)
+				multusConfig, err := frame.GetMultusInstance(spiderMultusNadName, namespace)
 				GinkgoWriter.Printf("Auto-generated multus configuration %+v \n", multusConfig)
 				if api_errors.IsNotFound(err) {
 					return false
@@ -75,14 +77,14 @@ var _ = Describe("test spidermultus", Label("spiderMultus", "overlay"), func() {
 
 			// Delete the multus configuration created automatically,
 			// and it will be restored automatically after a period of time.
-			err = frame.DeleteMultusInstance(multusNadName, namespace)
+			err = frame.DeleteMultusInstance(spiderMultusNadName, namespace)
 			Expect(err).NotTo(HaveOccurred())
-			multusConfig, err := frame.GetMultusInstance(multusNadName, namespace)
+			multusConfig, err := frame.GetMultusInstance(spiderMultusNadName, namespace)
 			Expect(api_errors.IsNotFound(err)).To(BeTrue())
 			Expect(multusConfig).To(BeNil())
 
 			Eventually(func() bool {
-				multusConfig, err := frame.GetMultusInstance(multusNadName, namespace)
+				multusConfig, err := frame.GetMultusInstance(spiderMultusNadName, namespace)
 				GinkgoWriter.Printf("multus configuration  %+v automatically restored after deletion \n", multusConfig)
 				if api_errors.IsNotFound(err) {
 					return false
@@ -94,13 +96,138 @@ var _ = Describe("test spidermultus", Label("spiderMultus", "overlay"), func() {
 			}, common.SpiderSyncMultusTime, common.ForcedWaitingTime).Should(BeTrue())
 
 			// After spidermultus is deleted, multus will be deleted synchronously.
-			err = frame.DeleteSpiderMultusInstance(namespace, multusNadName)
+			err = frame.DeleteSpiderMultusInstance(namespace, spiderMultusNadName)
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func() bool {
-				_, err := frame.GetMultusInstance(multusNadName, namespace)
+				_, err := frame.GetMultusInstance(spiderMultusNadName, namespace)
 				return api_errors.IsNotFound(err)
 			}, common.SpiderSyncMultusTime, common.ForcedWaitingTime).Should(BeTrue())
+		})
+	})
+
+	Context("Change multus attributes via spidermultus annotation", func() {
+		var namespace, spiderMultusNadName, mode string
+		var nad *spiderpoolv2beta1.SpiderMultusConfig
+
+		BeforeEach(func() {
+			spiderMultusNadName = "test-multus-" + common.GenerateString(10, true)
+			namespace = "ns-" + common.GenerateString(10, true)
+			mode = "disabled"
+
+			// create namespace
+			err := frame.CreateNamespaceUntilDefaultServiceAccountReady(namespace, common.ServiceAccountReadyTimeout)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Define spidermultus cr and create
+			nad = &spiderpoolv2beta1.SpiderMultusConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      spiderMultusNadName,
+					Namespace: namespace,
+				},
+				Spec: spiderpoolv2beta1.MultusCNIConfigSpec{
+					CniType: "macvlan",
+					MacvlanConfig: &spiderpoolv2beta1.SpiderMacvlanCniConfig{
+						Master: []string{common.NIC1},
+					},
+					CoordinatorConfig: &spiderpoolv2beta1.CoordinatorSpec{
+						Mode: &mode,
+					},
+				},
+			}
+			GinkgoWriter.Printf("spidermultus cr: %+v \n", nad)
+
+			// Clean test env
+			// DeferCleanup(func() {
+			// 	err := frame.DeleteNamespace(namespace)
+			// 	Expect(err).NotTo(HaveOccurred(), "Failed to delete namespace %v")
+			// })
+		})
+
+		It("Customize net-attach-conf name via annotation multus.spidernet.io/cr-name", Label("M00005"), func() {
+			multusNadName := "test-custom-multus-" + common.GenerateString(10, true)
+			nad.ObjectMeta.Annotations = map[string]string{constant.AnnoNetAttachConfName: multusNadName}
+			GinkgoWriter.Printf("spidermultus cr with annotations: %+v \n", nad)
+
+			Expect(frame.CreateSpiderMultusInstance(nad)).NotTo(HaveOccurred())
+
+			spiderMultusConfig, err := frame.GetSpiderMultusInstance(namespace, spiderMultusNadName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(spiderMultusConfig).NotTo(BeNil())
+			GinkgoWriter.Printf("spiderMultusConfig %+v \n", spiderMultusConfig)
+
+			Eventually(func() bool {
+				multusConfig, err := frame.GetMultusInstance(multusNadName, namespace)
+				GinkgoWriter.Printf("Auto-generated multus configuration %+v \n", multusConfig)
+				if api_errors.IsNotFound(err) {
+					return false
+				}
+				if multusConfig.ObjectMeta.OwnerReferences[0].Kind != constant.KindSpiderMultusConfig {
+					return false
+				}
+				return true
+			}, common.SpiderSyncMultusTime, common.ForcedWaitingTime).Should(BeTrue())
+		})
+
+		PIt("annotating custom names that are too long or too short should fail", Label("M00009"), func() {
+			// TODO(ty-dc), Is it a bug ？Customize the name by annotation, and its length should conform to 1-63 (k8s resource)
+			longMultusName := common.GenerateString(64, true)
+			nad.ObjectMeta.Annotations = map[string]string{constant.AnnoNetAttachConfName: longMultusName}
+			GinkgoWriter.Printf("spidermultus cr with annotations: %+v \n", nad)
+			Expect(frame.CreateSpiderMultusInstance(nad)).To(HaveOccurred())
+
+			// TODO(ty-dc), Is it a bug ？
+			// The custom name is an empty string, shouldn't it be possible to create?
+			// Instead of creating a spidermultus cr but no corresponding multus cr ?
+			// This doesn't match the function definition of spidermultus?
+			shortMultusName := ""
+			nad.ObjectMeta.Annotations = map[string]string{constant.AnnoNetAttachConfName: shortMultusName}
+			GinkgoWriter.Printf("spidermultus cr with annotations: %+v \n", nad)
+			Expect(frame.CreateSpiderMultusInstance(nad)).To(HaveOccurred())
+		})
+
+		It("Change net-attach-conf version via annotation multus.spidernet.io/cni-version", Label("M00006"), func() {
+			cniVersion := "0.4.0"
+			nad.ObjectMeta.Annotations = map[string]string{constant.AnnoMultusConfigCNIVersion: cniVersion}
+			GinkgoWriter.Printf("spidermultus cr with annotations: %+v \n", nad)
+			Expect(frame.CreateSpiderMultusInstance(nad)).NotTo(HaveOccurred())
+
+			spiderMultusConfig, err := frame.GetSpiderMultusInstance(namespace, spiderMultusNadName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(spiderMultusConfig).NotTo(BeNil())
+			GinkgoWriter.Printf("spiderMultusConfig %+v \n", spiderMultusConfig)
+
+			Eventually(func() bool {
+				multusConfig, err := frame.GetMultusInstance(spiderMultusNadName, namespace)
+				GinkgoWriter.Printf("Auto-generated multus configuration %+v \n", multusConfig)
+				if api_errors.IsNotFound(err) {
+					return false
+				}
+				// The cni version should match.
+				if multusConfig.ObjectMeta.Annotations[constant.AnnoMultusConfigCNIVersion] != cniVersion {
+					return false
+				}
+				return true
+			}, common.SpiderSyncMultusTime, common.ForcedWaitingTime).Should(BeTrue())
+		})
+
+		It("Should build fail for unsupported cni versions? ", Label("M00006"), func() {
+			mismatchCNIVersion := "x.y.z"
+			nad.ObjectMeta.Annotations = map[string]string{constant.AnnoMultusConfigCNIVersion: mismatchCNIVersion}
+			GinkgoWriter.Printf("spidermultus cr with annotations: %+v \n", nad)
+			// Mismatched versions, when doing a build, the error should occur here?
+			Expect(frame.CreateSpiderMultusInstance(nad)).NotTo(HaveOccurred())
+
+			spiderMultusConfig, err := frame.GetSpiderMultusInstance(namespace, spiderMultusNadName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(spiderMultusConfig).NotTo(BeNil())
+			GinkgoWriter.Printf("spiderMultusConfig %+v \n", spiderMultusConfig)
+
+			// Mismatched versions, can't automatically create multus cr?
+			time.Sleep(time.Second * 20)
+			multusConfig, err := frame.GetMultusInstance(spiderMultusNadName, namespace)
+			GinkgoWriter.Printf("Auto-generated multus configuration %+v \n", multusConfig)
+			Expect(api_errors.IsNotFound(err)).To(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
e2e: add use case for changing multus properties via spidermultus annotation

**Which issue(s) this PR fixes**:
```
None
```

**Special notes for your reviewer**:

**make sure your commit is signed off**
