### PR TITLE
add SpiderMultusConfig annotation validation in webhook

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
       - Certificates: usage/install/certificate.md
   - Usage:
       - SpiderSubnet: usage/spider-subnet.md
+      - SpiderMultusConfig: usage/spider-multus-config.md
       - Default IPPool at namespace: usage/ippool-namespace.md
       - Multiple interfaces: usage/multi-interfaces-annotation.md
       - Backup IPPool: usage/ippool-multi.md

--- a/docs/reference/crd-spidermultusconfig.md
+++ b/docs/reference/crd-spidermultusconfig.md
@@ -2,14 +2,19 @@
 
 A SpiderMultusConfig resource represents a best practice to generate a multus net-attach-def CR object for spiderpool to use.
 
+For details on using this CRD, please read the [SpiderMultusConfig guide](./../usage/spider-multus-config.md).
+
 ## Sample YAML
 
 ```yaml
 apiVersion: spiderpool.spidernet.io/v2beta1
 kind: SpiderMultusConfig
 metadata:
-  name: macvlan-100
+  name: demo
   namespace: default
+  annotations:
+    multus.spidernet.io/cr-name: "macvlan-100"
+    multus.spidernet.io/cni-version: 0.4.0
 spec:
   cniType: macvlan
   macvlan:
@@ -20,15 +25,25 @@ spec:
       ipv6: ["default-pool-v6"]
 ```
 
-## SpiderReservedIP definition
+## SpiderMultusConfig definition
 
 ### Metadata
 
-| Field     | Description                                       | Schema | Validation |
-|-----------|---------------------------------------------------|--------|------------|
-| name      | The name of this SpiderMultusConfig resource      | string | required   |
-| namespace | The namespace of this SpiderMultusConfig resource | string | required   |
+| Field       | Description                                         | Schema | Validation |
+|-------------|-----------------------------------------------------|--------|------------|
+| name        | The name of this SpiderMultusConfig resource        | string | required   |
+| namespace   | The namespace of this SpiderMultusConfig resource   | string | required   |
+| annotations | The annotations of this SpiderMultusConfig resource | map    | optional   |
 
+### Metadata.annotations
+
+You can also set annotations for this SpiderMultusConfig resource, then the corresponding Multus net-attach-def resource will inherit these annotations too.  
+And you can also use special annotation `multus.spidernet.io/cr-name` and `multus.spidernet.io/cni-version` to customize the corresponding Multus net-attach-def resource name and CNI version.
+
+| Field                           | Description                                               | Schema | Validation | Default |
+|---------------------------------|-----------------------------------------------------------|--------|------------|---------|
+| multus.spidernet.io/cr-name     | The customized Multus net-attach-def resource name        | string | optional   |         |
+| multus.spidernet.io/cni-version | The customized Multus net-attach-def resource CNI version | string | optional   | 0.3.1   |
 
 ### Spec
 
@@ -41,7 +56,7 @@ This is the SpiderReservedIP spec for users to configure.
 | ipvlan            | ipvlan CNI configuration                          | [SpiderIPvlanCniConfig](./crd-spidermultusconfig.md#SpiderIPvlanCniConfig)   | optional   |                             |         |
 | sriov             | sriov CNI configuration                           | [SpiderSRIOVCniConfig](./crd-spidermultusconfig.md#SpiderSRIOVCniConfig)     | optional   |                             |         |
 | enableCoordinator | enable coordinator or not                         | boolean                                                                      | optional   | true,false                  | true    |
-| coordinator       | coordinator CNI configuration                     | CoordinatorSpec                                                              | optional   |                             |         |
+| coordinator       | coordinator CNI configuration                     | [CoordinatorSpec](./crd-spidercoordinator.md#Spec)                           | optional   |                             |         |
 | customCNI         | a string that represents custom CNI configuration | string                                                                       | optional   |                             |         |
 
 #### SpiderMacvlanCniConfig

--- a/docs/usage/spider-multus-config.md
+++ b/docs/usage/spider-multus-config.md
@@ -1,0 +1,3 @@
+# SpiderMultusConfig
+
+TODO

--- a/pkg/multuscniconfig/multusconfig_webhook.go
+++ b/pkg/multuscniconfig/multusconfig_webhook.go
@@ -45,7 +45,7 @@ func (mcw *MultusConfigWebhook) ValidateCreate(ctx context.Context, obj runtime.
 	)
 	log.Sugar().Debugf("Request MultusConfig: %+v", *multusConfig)
 
-	err := validateCNIConfig(multusConfig)
+	err := validate(nil, multusConfig)
 	if nil != err {
 		return apierrors.NewInvalid(
 			spiderpoolv2beta1.SchemeGroupVersion.WithKind(constant.KindSpiderMultusConfig).GroupKind(),
@@ -68,9 +68,7 @@ func (mcw *MultusConfigWebhook) ValidateUpdate(ctx context.Context, oldObj, newO
 	log.Sugar().Debugf("Request old MultusConfig: %+v", *oldMultusConfig)
 	log.Sugar().Debugf("Request new MultusConfig: %+v", *newMultusConfig)
 
-	// no need to validate the old object
-	// because the already exist object must have been validated before.
-	err := validateCNIConfig(newMultusConfig)
+	err := validate(oldMultusConfig, newMultusConfig)
 	if nil != err {
 		return apierrors.NewInvalid(
 			spiderpoolv2beta1.SchemeGroupVersion.WithKind(constant.KindSpiderMultusConfig).GroupKind(),


### PR DESCRIPTION
1. add customized net-attach-def name with empty string or over max length string validation in webhook
2. add customized CNI version validation in webhook
3. now it's invalid to change the Multus net-attach-def name. 
      - change the SpiderMultusConfig annotation to customize net-attach-def name is invalid
      - update a SpiderMultusConfig resource to add annotation to customize net-attach-def name is invalid

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)

**What this PR does / why we need it**:
enhancement

**Which issue(s) this PR fixes**:
close #2169 
