### PR TITLE
optimize the autopool name length to 253

### DIFF
--- a/pkg/applicationcontroller/applicationinformers/utils.go
+++ b/pkg/applicationcontroller/applicationinformers/utils.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	apitypes "k8s.io/apimachinery/pkg/types"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/utils/pointer"
 	"k8s.io/utils/strings/slices"
@@ -41,7 +42,7 @@ var errInvalidInput = func(str string) error {
 }
 
 const (
-	maxNameLength = 63
+	maxNameLength = k8svalidation.DNS1123SubdomainMaxLength
 	randomLength  = 5
 )
 


### PR DESCRIPTION
Refer to DNS (RFC 1123), the subdomain's max length is 253. But we made mistake and regard it as length 63.
Actually the `finalizer name`, `annotation key` and `label key` max length is 63

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)