### PR TITLE
feature : SpiderSubnet could take over orphan IPPool

### DIFF
--- a/.github/workflows/e2e-init.yaml
+++ b/.github/workflows/e2e-init.yaml
@@ -37,8 +37,6 @@ jobs:
         include:
           - e2e_init_mode: e2e_init_underlay
             e2e_test_mode: e2e_test_underlay
-          - e2e_init_mode: e2e_init_underlay_subnet
-            e2e_test_mode: e2e_test_underlay_subnet
           - e2e_init_mode: e2e_init_calico
             e2e_test_mode: e2e_test_calico
           - e2e_init_mode: e2e_init_cilium
@@ -186,7 +184,7 @@ jobs:
 
       - name: Get the E2E Performance Result For Dual-stack
         id: get_performance
-        if: ${{ inputs.run_e2e == 'true' && inputs.ip_family == 'dual' && ( matrix.e2e_test_mode == 'e2e_test_underlay' || matrix.e2e_test_mode == 'e2e_test_underlay_subnet' ) }}
+        if: ${{ inputs.run_e2e == 'true' && inputs.ip_family == 'dual' && matrix.e2e_test_mode == 'e2e_test_underlay' }}
         shell: bash
         run: |
           # sudo apt-get install -y jq

--- a/.github/workflows/lint-license.yaml
+++ b/.github/workflows/lint-license.yaml
@@ -50,4 +50,4 @@ jobs:
 
       - name: Check License Header
         id: checklicense
-        uses: apache/skywalking-eyes@v0.5.0
+        uses: apache/skywalking-eyes@v0.4.0

--- a/Makefile
+++ b/Makefile
@@ -308,10 +308,6 @@ e2e_init:
 
 .PHONY: e2e_init_underlay
 e2e_init_underlay:
-	$(QUIET)  make e2e_init -e INSTALL_OVERLAY_CNI=false -e E2E_SPIDERPOOL_ENABLE_SUBNET=false
-
-.PHONY: e2e_init_underlay_subnet
-e2e_init_underlay_subnet:
 	$(QUIET)  make e2e_init -e INSTALL_OVERLAY_CNI=false -e E2E_SPIDERPOOL_ENABLE_SUBNET=true
 
 .PHONY: e2e_init_calico
@@ -329,10 +325,6 @@ e2e_test:
 
 .PHONY: e2e_test_underlay
 e2e_test_underlay:
-	$(QUIET)  make e2e_test -e INSTALL_OVERLAY_CNI=false -e E2E_SPIDERPOOL_ENABLE_SUBNET=false
-
-.PHONY: e2e_test_underlay_subnet
-e2e_test_underlay_subnet:
 	$(QUIET)  make e2e_test -e INSTALL_OVERLAY_CNI=false -e E2E_SPIDERPOOL_ENABLE_SUBNET=true
 
 .PHONY: e2e_test_calico

--- a/docs/develop/contributing.md
+++ b/docs/develop/contributing.md
@@ -39,12 +39,11 @@ run the following command to check unitest
 
     before start the test, you shoud know there are test scenes as following 
 
-    | kind                                     | setup cluster                    | test                          |
-    |------------------------------------------|----------------------------------|-------------------------------|
-    | test underlay CNI without subnet feature | make    e2e_init_underlay        | make e2e_test_underlay        |
-    | test underlay CNI with subnet feature    | make    e2e_init_underlay_subnet | make e2e_test_underlay_subnet |
-    | test overlay CNI for calico              | make    e2e_init_overlay_calico  | make e2e_test_overlay_calico  |
-    | test overlay CNI for cilium              | make    e2e_init_overlay_cilium  | make e2e_test_overlay_cilium  |
+    | kind                                  | setup cluster                    | test                          |
+    |---------------------------------------|----------------------------------|-------------------------------|
+    | test underlay CNI                     | make    e2e_init_underlay        | make e2e_test_underlay        |
+    | test overlay CNI for calico           | make    e2e_init_overlay_calico  | make e2e_test_overlay_calico  |
+    | test overlay CNI for cilium           | make    e2e_init_overlay_cilium  | make e2e_test_overlay_cilium  |
 
     if you are in China, it could add `-e E2E_CHINA_IMAGE_REGISTRY=true` to pull images from china image registry, add `-e HTTP_PROXY=http://${ADDR}` to get chart
 
@@ -83,9 +82,6 @@ run the following command to check unitest
         # it pulls images from another image registry and just use http proxy to pull chart 
         $ make e2e_init_underlay  -e E2E_CHINA_IMAGE_REGISTRY=true -e HTTP_PROXY=http://${ADDR}
 
-        # setup cluster with subnet feature
-        $ make e2e_init_underlay_subnet -e E2E_CHINA_IMAGE_REGISTRY=true -e HTTP_PROXY=http://${ADDR}
-
         # setup cluster with calico cni
         $ make e2e_init_calico -e E2E_CHINA_IMAGE_REGISTRY=true -e HTTP_PROXY=http://${ADDR}
 
@@ -112,9 +108,6 @@ run the following command to check unitest
 
         # example: run a case until fails
         $ make e2e_test_underlay -e GINKGO_OPTION=" --label-filter=CaseLabel --until-it-fails "
-
-        # Run all e2e tests for enableSpiderSubnet=false cluster
-        $ make e2e_test_underlay_subnet 
 
         # Run all e2e tests for enableSpiderSubnet=false cluster
         $ make e2e_test_calico

--- a/docs/usage/install/underlay/get-started-kind-zh_CN.md
+++ b/docs/usage/install/underlay/get-started-kind-zh_CN.md
@@ -26,16 +26,10 @@ Kind 是一个使用 Docker 容器节点运行本地 Kubernetes 集群的工具�
 
 如果您在中国大陆，安装时可以额外指定参数 `-e E2E_CHINA_IMAGE_REGISTRY=true` ，以帮助您更快的拉取镜像。
 
-### 安装不带子网功能的 Spiderpool 在 Underlay CNI（Macvlan） 集群
+### 安装 Spiderpool 在 Underlay CNI（Macvlan） 集群
   
   ```bash
   ~# make e2e_init_underlay -e E2E_SPIDERPOOL_TAG=$SPIDERPOOL_LATEST_IMAGE_TAG
-  ```
-
-### 安装具有子网功能的 Spiderpool 在 Underlay CNI（Macvlan）集群
-
-  ```bash
-  ~# make e2e_init_underlay_subnet -e E2E_SPIDERPOOL_TAG=$SPIDERPOOL_LATEST_IMAGE_TAG
   ```
 
 ### 安装 Spiderpool 在 Calico Overlay CNI 集群

--- a/docs/usage/install/underlay/get-started-kind.md
+++ b/docs/usage/install/underlay/get-started-kind.md
@@ -26,16 +26,10 @@ Kind is a tool for running local Kubernetes clusters using Docker container "nod
 
 If you are mainland user who is not available to access ghcr.io, Additional parameter `-e E2E_CHINA_IMAGE_REGISTRY=true` can be specified during installation to help you pull images faster.
 
-### Install Spiderpool without subnet function in Underlay CNI (Macvlan) cluster
+### Install Spiderpool in Underlay CNI (Macvlan) cluster
 
   ```bash
   ~# make e2e_init_underlay -e E2E_SPIDERPOOL_TAG=$SPIDERPOOL_LATEST_IMAGE_TAG
-  ```
-
-### Install Spiderpool with subnets in Underlay CNI (Macvlan) cluster
-
-  ```bash
-  ~# make e2e_init_underlay_subnet -e E2E_SPIDERPOOL_TAG=$SPIDERPOOL_LATEST_IMAGE_TAG
   ```
 
 ### Install Spiderpool on Calico Overlay CNI cluster

--- a/pkg/ippoolmanager/ippool_subnet_validate.go
+++ b/pkg/ippoolmanager/ippool_subnet_validate.go
@@ -51,10 +51,7 @@ func (iw *IPPoolWebhook) validateUpdateIPPoolWhileEnableSpiderSubnet(ctx context
 func (iw *IPPoolWebhook) validateSubnetTotalIPsContainsIPPoolTotalIPs(ctx context.Context, ipPool *spiderpoolv2beta1.SpiderIPPool) *field.Error {
 	owner := metav1.GetControllerOf(ipPool)
 	if owner == nil {
-		return field.Forbidden(
-			subnetField,
-			fmt.Sprintf("orphan IPPool, must be controlled by Subnet with the same 'spec.subnet' %s", ipPool.Spec.Subnet),
-		)
+		return nil
 	}
 
 	poolTotalIPs, err := spiderpoolip.AssembleTotalIPs(*ipPool.Spec.IPVersion, ipPool.Spec.IPs, ipPool.Spec.ExcludeIPs)

--- a/pkg/ippoolmanager/ippool_validate.go
+++ b/pkg/ippoolmanager/ippool_validate.go
@@ -189,10 +189,6 @@ func (iw *IPPoolWebhook) validateIPPoolCIDR(ctx context.Context, ipPool *spiderp
 		)
 	}
 
-	if iw.EnableSpiderSubnet {
-		return nil
-	}
-
 	// TODO(iiiceoo): Use label selector.
 	var ipPoolList spiderpoolv2beta1.SpiderIPPoolList
 	if err := iw.APIReader.List(ctx, &ipPoolList); err != nil {

--- a/pkg/ippoolmanager/ippool_webhook_test.go
+++ b/pkg/ippoolmanager/ippool_webhook_test.go
@@ -1053,7 +1053,7 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 					ipPoolWebhook.EnableSpiderSubnet = true
 				})
 
-				It("is orphan IPPool", func() {
+				It("succeed to create orphan IPPool", func() {
 					ipPoolT.Spec.IPVersion = pointer.Int64(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
 					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
@@ -1064,7 +1064,7 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 					)
 
 					err := ipPoolWebhook.ValidateCreate(ctx, ipPoolT)
-					Expect(apierrors.IsInvalid(err)).To(BeTrue())
+					Expect(err).NotTo(HaveOccurred())
 				})
 
 				It("sets owner reference to non-existent Subnet", func() {
@@ -1786,7 +1786,7 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 					ipPoolWebhook.EnableSpiderSubnet = true
 				})
 
-				It("updates orphan IPPool", func() {
+				It("succeed to update orphan IPPool", func() {
 					ipPoolT.Spec.IPVersion = pointer.Int64(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
 					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs, "172.18.40.1-172.18.40.2")
@@ -1795,7 +1795,7 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 					newIPPoolT.Spec.IPs = append(newIPPoolT.Spec.IPs, "172.18.40.10")
 
 					err := ipPoolWebhook.ValidateUpdate(ctx, ipPoolT, newIPPoolT)
-					Expect(apierrors.IsInvalid(err)).To(BeTrue())
+					Expect(err).NotTo(HaveOccurred())
 				})
 
 				It("updates the IPPool that sets the owner reference to non-existent Subnet", func() {

--- a/pkg/subnetmanager/subnet_informer.go
+++ b/pkg/subnetmanager/subnet_informer.go
@@ -218,6 +218,7 @@ func (sc *SubnetController) enqueueSubnetOnUpdate(oldObj, newObj interface{}) {
 	logger.Debug(messageEnqueueSubnet)
 }
 
+// enqueueSubnetOnIPPoolChange receives the IPPool resources events
 func (sc *SubnetController) enqueueSubnetOnIPPoolChange(obj interface{}) {
 	ipPool := obj.(*spiderpoolv2beta1.SpiderIPPool)
 	ownerSubnet, ok := ipPool.Labels[constant.LabelIPPoolOwnerSpiderSubnet]
@@ -384,6 +385,7 @@ func (sc *SubnetController) syncHandler(ctx context.Context, subnetName string) 
 	return nil
 }
 
+// syncMetadata add "ipam.spidernet.io/subnet-cidr" label for the SpiderSubnet object
 func (sc *SubnetController) syncMetadata(ctx context.Context, subnet *spiderpoolv2beta1.SpiderSubnet) error {
 	cidr, err := spiderpoolip.CIDRToLabelValue(*subnet.Spec.IPVersion, subnet.Spec.Subnet)
 	if err != nil {
@@ -406,6 +408,7 @@ func (sc *SubnetController) syncMetadata(ctx context.Context, subnet *spiderpool
 	return nil
 }
 
+// syncControllerSubnet would set ownerReference and add "ipam.spidernet.io/owner-spider-subnet" label for the previous orphan IPPool
 func (sc *SubnetController) syncControllerSubnet(ctx context.Context, subnet *spiderpoolv2beta1.SpiderSubnet) error {
 	ipPools, err := sc.IPPoolsLister.List(labels.Everything())
 	if err != nil {

--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -66,7 +66,7 @@ E2E_TIMEOUT ?= 60m
 
 E2E_GINKGO_PROCS ?= 4
 
-E2E_SPIDERPOOL_ENABLE_SUBNET ?= false # consistent with open source, closed by default
+E2E_SPIDERPOOL_ENABLE_SUBNET ?= true # consistent with open source, closed by default
 E2E_SPIDERPOOL_ENABLE_COORDINATOR ?= true
 E2E_SPIDERPOOL_ENABLE_MULTUSCONFIG ?= true
 

--- a/test/doc/subnet.md
+++ b/test/doc/subnet.md
@@ -1,26 +1,28 @@
 # E2E Cases for SpiderSubnet
 
-| Case ID | Title                                                                                                                               | Priority | Smoke | Status | Other |
-| ------- | ----------------------------------------------------------------------------------------------------------------------------------- | -------- | ----- | ------ | ----- |
-| I00001  | Add, delete, modify, and query CIDR subnet                                                                                          |   p1     |       |  done  |       |
-| I00002  | Add and remove IP for CIDR subnet                                                                                                   |   p1     |       |  done  |       |
-| I00003  | Automatically create, scale, restart, and delete of ippools for different types of controllers                                      |   p1     |       |  done  |       |
-| I00004  | The excludeIPs in the subnet will not be used by pools created automatically or manually.                                           |   p2     |       |  done  |       |
-| I00005  | If routes and gateway are modified for CIDR, how the manually created ippools are affected?                                         |   p3     |       |  done  |       |
-| I00006  | Multiple automatic creation and recycling of ippools, eventually the free IPs in the subnet should be restored to its initial state |   p1     | true  |  done  |       |
-| I00007  | Multiple manual creation and recycling of ippools, eventually the free IPs in the subnet should be restored to its initial state    |   p1     | true  |  done  |       |
-| I00008  | Scale up and down the number of deployment several times to see if the state of the ippools is eventually stable                    |   p1     |       |  done  |       |
-| I00009  | Create 100 Subnets with the same `Subnet.spec` and see if only one succeeds in the end                                              |   p1     |       |  done  |       |
-| I00010  | Create 100 IPPools with the same `IPPool.spec` and see if only one succeeds in the end                                              |   p1     |       |  done  |       |
-| I00011  | The subnet automatically creates an ippool and allocates IP, and should consider reservedIP                                         |   p1     |       |  done  |       |
-| I00012  | SpiderSubnet supports multiple interfaces                                                                                           |   p1     |       |  done  |       |
-| I00013  | SpiderSubnet supports automatic IP assignment for Pods                                                                              |   p2     |       |  done  |       |
-| I00014  | The default subnet should support different controller types                                                                        |   p2     |       |  done  |       |
-| I00015  | Applications with the same name and type can use the reserved IPPool.      |   p2     |       |  done  |       |
-| I00016  | Applications with the same name and different types cannot use the reserved IPPool.                       |   p3     |       |  done  |       |
-| I00017  | Ability to create fixed IPPools for applications with very long names                      |   p3     |       |  done  |       |
-| I00018  | automatic IPPool IPs are not modifiable                                                    |   p3     |       |  done  |       |
-| I00019  | Change the annotation ipam.spidernet.io/ippool-reclaim to true and the reserved IPPool will be reclaimed.                   |   p3     |       |  done  |       |
-| I00020  | Redundant IPs for automatic IPPool, which cannot be used by other applications             |   p3     |       |  done  |       |
-| I00021  | Pod works correctly when multiple NICs are specified by annotations for applications of the same name             |   p3     |       |  done  |       |
-| I00022  | Dirty data in the subnet should be recycled.             |   p3     |       |  done  |       |
+| Case ID | Title                                                                                                                               | Priority | Smoke | Status  | Other |
+|---------|-------------------------------------------------------------------------------------------------------------------------------------|----------|-------|---------|-------|
+| I00001  | Add, delete, modify, and query CIDR subnet                                                                                          | p1       |       | done    |       |
+| I00002  | Add and remove IP for CIDR subnet                                                                                                   | p1       |       | done    |       |
+| I00003  | Automatically create, scale, restart, and delete of ippools for different types of controllers                                      | p1       |       | done    |       |
+| I00004  | The excludeIPs in the subnet will not be used by pools created automatically or manually.                                           | p2       |       | done    |       |
+| I00005  | If routes and gateway are modified for CIDR, how the manually created ippools are affected?                                         | p3       |       | done    |       |
+| I00006  | Multiple automatic creation and recycling of ippools, eventually the free IPs in the subnet should be restored to its initial state | p1       | true  | done    |       |
+| I00007  | Multiple manual creation and recycling of ippools, eventually the free IPs in the subnet should be restored to its initial state    | p1       | true  | done    |       |
+| I00008  | Scale up and down the number of deployment several times to see if the state of the ippools is eventually stable                    | p1       |       | done    |       |
+| I00009  | Create 100 Subnets with the same `Subnet.spec` and see if only one succeeds in the end                                              | p1       |       | done    |       |
+| I00010  | Create 100 IPPools with the same `IPPool.spec` and see if only one succeeds in the end                                              | p1       |       | done    |       |
+| I00011  | The subnet automatically creates an ippool and allocates IP, and should consider reservedIP                                         | p1       |       | done    |       |
+| I00012  | SpiderSubnet supports multiple interfaces                                                                                           | p1       |       | done    |       |
+| I00013  | SpiderSubnet supports automatic IP assignment for Pods                                                                              | p2       |       | done    |       |
+| I00014  | The default subnet should support different controller types                                                                        | p2       |       | done    |       |
+| I00015  | Applications with the same name and type can use the reserved IPPool.                                                               | p2       |       | done    |       |
+| I00016  | Applications with the same name and different types cannot use the reserved IPPool.                                                 | p3       |       | done    |       |
+| I00017  | Ability to create fixed IPPools for applications with very long names                                                               | p3       |       | done    |       |
+| I00018  | automatic IPPool IPs are not modifiable                                                                                             | p3       |       | done    |       |
+| I00019  | Change the annotation ipam.spidernet.io/ippool-reclaim to true and the reserved IPPool will be reclaimed.                           | p3       |       | done    |       |
+| I00020  | Redundant IPs for automatic IPPool, which cannot be used by other applications                                                      | p3       |       | done    |       |
+| I00021  | Pod works correctly when multiple NICs are specified by annotations for applications of the same name                               | p3       |       | done    |       |
+| I00022  | Dirty data in the subnet should be recycled.                                                                                        | p3       |       | done    |       |
+| I00023  | Orphan IPPool creation in SpiderSubnet feature.(validate spec.subnet overlaps)                                                      | p3       |       | ongoing |       |
+| I00024  | New SpiderSubnet resource controls orphan IPPool resource.(validate OwnerRef, IPs ranges containing, cascade deletion)              | p3       |       | ongoing |       |

--- a/test/e2e/affinity/affinity_test.go
+++ b/test/e2e/affinity/affinity_test.go
@@ -545,9 +545,6 @@ var _ = Describe("test Affinity", Label("affinity"), func() {
 		nsName1 = "ns1" + tools.RandomName()
 
 		BeforeEach(func() {
-			if frame.Info.SpiderSubnetEnabled {
-				Skip("The subnet function is enabled, the namespace annotation has a lower priority than the default subnet")
-			}
 			// Create another namespace
 			GinkgoWriter.Printf("create another namespace %v \n", nsName1)
 			err := frame.CreateNamespaceUntilDefaultServiceAccountReady(nsName1, common.ServiceAccountReadyTimeout)

--- a/test/e2e/annotation/annotation_test.go
+++ b/test/e2e/annotation/annotation_test.go
@@ -440,9 +440,6 @@ var _ = Describe("test annotation", Label("annotation"), func() {
 
 			It(`the namespace annotation has precedence over global default ippool`, Label("A00006", "smoke"), func() {
 				// Generate a pod yaml with namespace annotations
-				if frame.Info.SpiderSubnetEnabled {
-					Skip("The subnet function is enabled, the namespace annotation has a lower priority than the default subnet")
-				}
 				podYaml := common.GenerateExamplePodYaml(podName, nsName)
 				Expect(podYaml).NotTo(BeNil())
 				// The namespace annotation has precedence over global default ippool

--- a/test/e2e/ippoolcr/ippoolcr_test.go
+++ b/test/e2e/ippoolcr/ippoolcr_test.go
@@ -378,10 +378,6 @@ var _ = Describe("test ippool CR", Label("ippoolCR"), func() {
 	})
 
 	It("create and delete batch of ippool and check time cost", Label("D00006"), func() {
-		if frame.Info.SpiderSubnetEnabled {
-			Skip("Suitable for no subnets")
-		}
-
 		var ipv4PoolNameList, ipv6PoolNameList []string
 		var err error
 		const ippoolNumber = 10


### PR DESCRIPTION
In the past version, it's invalid to create a orphan IPPool in SpiderSubnet feature, which means you have to create a SpiderSubnet resource firstly.

Now, I make it compatible to create orphan SpiderIPPool resource with SpiderSubnet feature

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)

