### PR TITLE
charts default value adjustment

### DIFF
--- a/charts/spiderpool/README.md
+++ b/charts/spiderpool/README.md
@@ -130,16 +130,16 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 
 ### coordinator parameters
 
-| Name                           | Description                                                               | Value     |
-| ------------------------------ | ------------------------------------------------------------------------- | --------- |
-| `coordinator.enabled`          | enable SpiderCoordinator                                                  | `true`    |
-| `coordinator.name`             | the name of the default SpiderCoordinator CR                              | `default` |
-| `coordinator.mode`             | optional network mode, ["auto","underlay", "overlay", "disabled"]         | `auto`    |
-| `coordinator.podCIDRType`      | Pod CIDR type that should be collected, [ "cluster", "calico", "cilium" ] | `cluster` |
-| `coordinator.detectGateway`    | detect the reachability of the gateway                                    | `false`   |
-| `coordinator.detectIPConflict` | detect IP address conflicts                                               | `false`   |
-| `coordinator.tunePodRoutes`    | tune Pod routes                                                           | `true`    |
-| `coordinator.hijackCIDR`       | Additional subnets that need to be hijacked to the host forward           | `[]`      |
+| Name                           | Description                                                                                                                              | Value                |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| `coordinator.enabled`          | enable SpiderCoordinator                                                                                                                 | `true`               |
+| `coordinator.name`             | the name of the default SpiderCoordinator CR                                                                                             | `default`            |
+| `coordinator.mode`             | optional network mode, ["auto","underlay", "overlay", "disabled"]                                                                        | `auto`               |
+| `coordinator.podCIDRType`      | Pod CIDR type that should be collected, [ "cluster", "calico", "cilium" ]                                                                | `cluster`            |
+| `coordinator.detectGateway`    | detect the reachability of the gateway                                                                                                   | `false`              |
+| `coordinator.detectIPConflict` | detect IP address conflicts                                                                                                              | `false`              |
+| `coordinator.tunePodRoutes`    | tune Pod routes                                                                                                                          | `true`               |
+| `coordinator.hijackCIDR`       | Additional subnets that need to be hijacked to the host forward, the default link-local range "169.254.0.0/16" is used for NodeLocal DNS | `["169.254.0.0/16"]` |
 
 ### multus parameters
 

--- a/charts/spiderpool/templates/_helpers.tpl
+++ b/charts/spiderpool/templates/_helpers.tpl
@@ -224,13 +224,6 @@ generate the CA cert
 {{- end }}
 
 {{/*
-insight labels
-*/}}
-{{- define "insight.labels" -}}
-operator.insight.io/managed-by: insight
-{{- end}}
-
-{{/*
 spiderpool multus Common labels
 */}}
 {{- define "spiderpool.multus.labels" -}}

--- a/charts/spiderpool/templates/grafanaDashboard.yaml
+++ b/charts/spiderpool/templates/grafanaDashboard.yaml
@@ -5,7 +5,6 @@ metadata:
   name: {{ default "spiderpool" .Values.global.nameOverride }}
   namespace: {{ default .Release.Namespace .Values.grafanaDashboard.namespace }}
   labels:
-    {{- include "insight.labels" . | nindent 4 }}
     {{- if .Values.global.commonLabels }}
     {{- include "tplvalues.render" ( dict "value" .Values.global.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/charts/spiderpool/templates/prometheusrule.yaml
+++ b/charts/spiderpool/templates/prometheusrule.yaml
@@ -5,7 +5,6 @@ metadata:
   name: {{ .Values.spiderpoolAgent.name | trunc 63 | trimSuffix "-" }}
   namespace: {{ default .Release.Namespace .Values.spiderpoolAgent.prometheus.prometheusRule.namespace }}
   labels:
-    {{- include "insight.labels" . | nindent 4 }}
       {{- if .Values.spiderpoolAgent.prometheus.prometheusRule.labels }}
       {{- include "tplvalues.render" ( dict "value" .Values.spiderpoolAgent.prometheus.prometheusRule.labels "context" $ ) | nindent 4 }}
       {{- end }}
@@ -83,10 +82,9 @@ metadata:
   name: {{ .Values.spiderpoolController.name | trunc 63 | trimSuffix "-" }}
   namespace: {{ default .Release.Namespace .Values.spiderpoolController.prometheus.prometheusRule.namespace }}
   labels:
-    {{- include "insight.labels" . | nindent 4 }}
-      {{- if .Values.spiderpoolController.prometheus.prometheusRule.labels }}
-      {{- include "tplvalues.render" ( dict "value" .Values.spiderpoolAgent.prometheus.prometheusRule.labels "context" $ ) | nindent 4 }}
-      {{- end }}
+    {{- if .Values.spiderpoolController.prometheus.prometheusRule.labels }}
+    {{- include "tplvalues.render" ( dict "value" .Values.spiderpoolAgent.prometheus.prometheusRule.labels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if or .Values.global.commonAnnotations .Values.spiderpoolController.prometheus.prometheusRule.annotations }}
   annotations:
     {{- if .Values.global.commonAnnotations }}

--- a/charts/spiderpool/templates/servicemonitor.yaml
+++ b/charts/spiderpool/templates/servicemonitor.yaml
@@ -5,7 +5,6 @@ metadata:
   name: {{ .Values.spiderpoolAgent.name | trunc 63 | trimSuffix "-" }}
   namespace: {{ default .Release.Namespace .Values.spiderpoolAgent.prometheus.serviceMonitor.namespace }}
   labels:
-    {{- include "insight.labels" . | nindent 4 }}
   {{- if or .Values.global.commonAnnotations .Values.spiderpoolAgent.prometheus.serviceMonitor.annotations }}
   annotations:
     {{- if .Values.global.commonAnnotations }}
@@ -40,8 +39,6 @@ kind: ServiceMonitor
 metadata:
   name: {{ .Values.spiderpoolController.name | trunc 63 | trimSuffix "-" }}
   namespace: {{ default .Release.Namespace .Values.spiderpoolController.prometheus.serviceMonitor.namespace }}
-  labels:
-    {{- include "insight.labels" . | nindent 4 }}
   {{- if or .Values.global.commonAnnotations .Values.spiderpoolController.prometheus.serviceMonitor.annotations }}
   annotations:
     {{- if .Values.global.commonAnnotations }}

--- a/charts/spiderpool/values.yaml
+++ b/charts/spiderpool/values.yaml
@@ -105,8 +105,8 @@ coordinator:
   ## @param coordinator.tunePodRoutes tune Pod routes
   tunePodRoutes: true
 
-  ## @param coordinator.hijackCIDR Additional subnets that need to be hijacked to the host forward
-  hijackCIDR: []
+  ## @param coordinator.hijackCIDR Additional subnets that need to be hijacked to the host forward, the default link-local range "169.254.0.0/16" is used for NodeLocal DNS
+  hijackCIDR: ["169.254.0.0/16"]
 
 ## @section multus parameters
 ##


### PR DESCRIPTION
1. remove grafanaDashboard irrevevant labels
2. add default hijackCIDR "169.254.0.0/16". (The local listen IP address for NodeLocal DNSCache can be any address that can be guaranteed to not collide with any existing IP in your cluster. It's recommended to use an address with a local scope, for example, from the 'link-local' range '169.254.0.0/16' for IPv4 or from the 'Unique Local Address' range in IPv6 'fd00::/8'.)

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)

reference:
close https://github.com/spidernet-io/spiderpool/issues/2300