### PR TITLE
spidermultusconfig: IPAM can be disabled

### DIFF
--- a/charts/spiderpool/crds/spiderpool.spidernet.io_spidermultusconfigs.yaml
+++ b/charts/spiderpool/crds/spiderpool.spidernet.io_spidermultusconfigs.yaml
@@ -90,6 +90,9 @@ spec:
                 description: OtherCniTypeConfig only used for CniType custom, valid
                   json format, can be empty
                 type: string
+              disableIPAM:
+                default: false
+                type: boolean
               enableCoordinator:
                 default: true
                 type: boolean

--- a/docs/reference/crd-spidermultusconfig.md
+++ b/docs/reference/crd-spidermultusconfig.md
@@ -57,6 +57,7 @@ This is the SpiderReservedIP spec for users to configure.
 | sriov             | sriov CNI configuration                           | [SpiderSRIOVCniConfig](./crd-spidermultusconfig.md#SpiderSRIOVCniConfig)     | optional   |                                 |         |
 | ovs               | ovs CNI configuration                             | [SpiderOvsCniConfig](./crd-spidermultusconfig.md#SpiderOvsCniConfig)         | optional   |                                 |         |
 | enableCoordinator | enable coordinator or not                         | boolean                                                                      | optional   | true,false                      | true    |
+| disableIPAM       | disable IPAM or not                               | boolean                                                                      | optional   | true,false                      | false    |
 | coordinator       | coordinator CNI configuration                     | [CoordinatorSpec](./crd-spidercoordinator.md#Spec)                           | optional   |                                 |         |
 | customCNI         | a string that represents custom CNI configuration | string                                                                       | optional   |                                 |         |
 

--- a/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/spidermultus_types.go
+++ b/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/spidermultus_types.go
@@ -47,6 +47,10 @@ type MultusCNIConfigSpec struct {
 	// +kubebuilder:validation:Optional
 	EnableCoordinator *bool `json:"enableCoordinator"`
 
+	// +kubebuilder:default=false
+	// +kubebuilder:validation:Optional
+	DisableIPAM *bool `json:"disableIPAM"`
+
 	// +kubebuilder:validation:Optional
 	CoordinatorConfig *CoordinatorSpec `json:"coordinator,omitempty"`
 

--- a/pkg/multuscniconfig/utils.go
+++ b/pkg/multuscniconfig/utils.go
@@ -45,20 +45,20 @@ type MacvlanNetConf struct {
 	Type   string                   `json:"type"`
 	Master string                   `json:"master"`
 	Mode   string                   `json:"mode"`
-	IPAM   spiderpoolcmd.IPAMConfig `json:"ipam"`
+	IPAM   spiderpoolcmd.IPAMConfig `json:"ipam,omitempty"`
 }
 
 type IPvlanNetConf struct {
 	Type   string                   `json:"type"`
 	Master string                   `json:"master"`
-	IPAM   spiderpoolcmd.IPAMConfig `json:"ipam"`
+	IPAM   spiderpoolcmd.IPAMConfig `json:"ipam,omitempty"`
 }
 
 type SRIOVNetConf struct {
 	Vlan     *int32                   `json:"vlan,omitempty"`
 	Type     string                   `json:"type"`
 	DeviceID string                   `json:"deviceID,omitempty"`
-	IPAM     spiderpoolcmd.IPAMConfig `json:"ipam"`
+	IPAM     spiderpoolcmd.IPAMConfig `json:"ipam,omitempty"`
 }
 
 type OvsNetConf struct {
@@ -66,7 +66,7 @@ type OvsNetConf struct {
 	Type     string                     `json:"type"`
 	BrName   string                     `json:"bridge"`
 	DeviceID string                     `json:"deviceID,omitempty"`
-	IPAM     spiderpoolcmd.IPAMConfig   `json:"ipam"`
+	IPAM     spiderpoolcmd.IPAMConfig   `json:"ipam,omitempty"`
 	Trunk    []*spiderpoolv2beta1.Trunk `json:"trunk,omitempty"`
 }
 

--- a/test/doc/spidermultus.md
+++ b/test/doc/spidermultus.md
@@ -18,3 +18,4 @@
 | M00020  | Already have multus cr, spidermultus should take care of it                     | p3     |       |  done  |       |
 | M00022  | The value of webhook verification cniType is inconsistent with cniConf          | p3     |       | done |       |
 | M00023  | vlan is not in the range of 0-4094 and will not be created                    | p3     |       |  done  |       |
+| M00024  | set disableIPAM to true and see if multus's nad has ipam config                    | p3     |       |  done  |       |


### PR DESCRIPTION
You can set spidermultusconfig.spec.disableIPAM to true, and multus NAD does not include the IPAM configuration.

---
name: Pull request
about: Tell us about your contribution
labels: ["pr/release/none-required"]
---

---
## Thanks for contributing !

Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/contributing/development/pullrequest/#need-review>

**What this PR does / why we need it**:

In some special cases, CNI does not require ipam, Now you can set spidermultusconfig.spec.disableIPAM to true, and multus NAD does not include the IPAM configuration.

**Which issue(s) this PR fixes**:

https://github.com/spidernet-io/spiderpool/issues/2133

**Special notes for your reviewer**:

**make sure your commit is signed off**
