### PR TITLE
spidermultusconfig: make IPAM field to pointer

### DIFF
--- a/pkg/multuscniconfig/multusconfig_informer.go
+++ b/pkg/multuscniconfig/multusconfig_informer.go
@@ -477,7 +477,7 @@ func generateMacvlanCNIConf(disableIPAM bool, multusConfSpec spiderpoolv2beta1.M
 	}
 
 	if !disableIPAM {
-		netConf.IPAM = spiderpoolcmd.IPAMConfig{
+		netConf.IPAM = &spiderpoolcmd.IPAMConfig{
 			Type: constant.Spiderpool,
 		}
 	}
@@ -513,7 +513,7 @@ func generateIPvlanCNIConf(disableIPAM bool, multusConfSpec spiderpoolv2beta1.Mu
 	}
 
 	if !disableIPAM {
-		netConf.IPAM = spiderpoolcmd.IPAMConfig{
+		netConf.IPAM = &spiderpoolcmd.IPAMConfig{
 			Type: constant.Spiderpool,
 		}
 	}
@@ -533,7 +533,7 @@ func generateSriovCNIConf(disableIPAM bool, multusConfSpec spiderpoolv2beta1.Mul
 	}
 
 	if !disableIPAM {
-		netConf.IPAM = spiderpoolcmd.IPAMConfig{
+		netConf.IPAM = &spiderpoolcmd.IPAMConfig{
 			Type: constant.Spiderpool,
 		}
 	}
@@ -557,7 +557,7 @@ func generateOvsCNIConf(disableIPAM bool, multusConfSpec *spiderpoolv2beta1.Mult
 	}
 
 	if !disableIPAM {
-		netConf.IPAM = spiderpoolcmd.IPAMConfig{
+		netConf.IPAM = &spiderpoolcmd.IPAMConfig{
 			Type: constant.Spiderpool,
 		}
 	}

--- a/pkg/multuscniconfig/utils.go
+++ b/pkg/multuscniconfig/utils.go
@@ -42,23 +42,23 @@ const (
 )
 
 type MacvlanNetConf struct {
-	Type   string                   `json:"type"`
-	Master string                   `json:"master"`
-	Mode   string                   `json:"mode"`
-	IPAM   spiderpoolcmd.IPAMConfig `json:"ipam,omitempty"`
+	Type   string                    `json:"type"`
+	Master string                    `json:"master"`
+	Mode   string                    `json:"mode"`
+	IPAM   *spiderpoolcmd.IPAMConfig `json:"ipam,omitempty"`
 }
 
 type IPvlanNetConf struct {
-	Type   string                   `json:"type"`
-	Master string                   `json:"master"`
-	IPAM   spiderpoolcmd.IPAMConfig `json:"ipam,omitempty"`
+	Type   string                    `json:"type"`
+	Master string                    `json:"master"`
+	IPAM   *spiderpoolcmd.IPAMConfig `json:"ipam,omitempty"`
 }
 
 type SRIOVNetConf struct {
-	Vlan     *int32                   `json:"vlan,omitempty"`
-	Type     string                   `json:"type"`
-	DeviceID string                   `json:"deviceID,omitempty"`
-	IPAM     spiderpoolcmd.IPAMConfig `json:"ipam,omitempty"`
+	Vlan     *int32                    `json:"vlan,omitempty"`
+	Type     string                    `json:"type"`
+	DeviceID string                    `json:"deviceID,omitempty"`
+	IPAM     *spiderpoolcmd.IPAMConfig `json:"ipam,omitempty"`
 }
 
 type OvsNetConf struct {
@@ -66,7 +66,7 @@ type OvsNetConf struct {
 	Type     string                     `json:"type"`
 	BrName   string                     `json:"bridge"`
 	DeviceID string                     `json:"deviceID,omitempty"`
-	IPAM     spiderpoolcmd.IPAMConfig   `json:"ipam,omitempty"`
+	IPAM     *spiderpoolcmd.IPAMConfig  `json:"ipam,omitempty"`
 	Trunk    []*spiderpoolv2beta1.Trunk `json:"trunk,omitempty"`
 }
 


### PR DESCRIPTION
IPAM field need to be a pointer, Or it can't be ignored while json unmarshal

---
name: Pull request
about: Tell us about your contribution
labels: ["pr/release/none-required"]
---

---
## Thanks for contributing !

Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/contributing/development/pullrequest/#need-review>

**What this PR does / why we need it**:

IPAM field need to be a pointer, Or it can't be ignored while json unmarshal

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**make sure your commit is signed off**
