### PR TITLE
coordinator: bump netlink version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/spidernet-io/e2eframework v0.0.0-20230724150324-2eee77078275
 	github.com/spidernet-io/spiderdoctor v0.3.0
 	github.com/tigera/operator v1.30.5
-	github.com/vishvananda/netlink v1.2.1-beta.2
+	github.com/vishvananda/netlink v1.2.1-beta.2.0.20230621221334-77712cff8739
 	go.opentelemetry.io/otel v1.16.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.39.0
 	go.opentelemetry.io/otel/metric v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -536,8 +536,8 @@ github.com/tigera/operator v1.30.5 h1:uKWVbr5wDt5PZjcpjKqYSq/KudIiqR73qOFv4LRqkv
 github.com/tigera/operator v1.30.5/go.mod h1:VB9YGUZymXwhZzgcoAa+B4IxV0D4eUPc0AKIV1l5RNU=
 github.com/toqueteos/webbrowser v1.2.0 h1:tVP/gpK69Fx+qMJKsLE7TD8LuGWPnEV71wBN9rrstGQ=
 github.com/toqueteos/webbrowser v1.2.0/go.mod h1:XWoZq4cyp9WeUeak7w7LXRUQf1F1ATJMir8RTqb4ayM=
-github.com/vishvananda/netlink v1.2.1-beta.2 h1:Llsql0lnQEbHj0I1OuKyp8otXp0r3q0mPkuhwHfStVs=
-github.com/vishvananda/netlink v1.2.1-beta.2/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
+github.com/vishvananda/netlink v1.2.1-beta.2.0.20230621221334-77712cff8739 h1:mi+RH1U/MmAQvz2Ys7r1/8OWlGJoBvF8iCXRKk2uym4=
+github.com/vishvananda/netlink v1.2.1-beta.2.0.20230621221334-77712cff8739/go.mod h1:0BeLktV/jHb2/Hmw1yLD7+yaIB8PDy11RCty0tCPWZg=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8=
 github.com/vishvananda/netns v0.0.4/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
@@ -745,7 +745,6 @@ golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -771,6 +770,7 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.9.1-0.20230616193735-e0c3b6e6ae3b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/pkg/networking/networking/route.go
+++ b/pkg/networking/networking/route.go
@@ -45,7 +45,7 @@ func GetDefaultGatewayByName(iface string, ipfamily int) ([]string, error) {
 	gws := make([]string, 0)
 	for _, route := range routes {
 		if route.LinkIndex == link.Attrs().Index {
-			if route.Dst == nil {
+			if route.Dst == nil || route.Dst.IP.Equal(net.IPv4zero) {
 				gws = append(gws, route.Gw.String())
 			}
 		} else {
@@ -261,14 +261,16 @@ func GetDefaultRouteInterface(ipfamily int, filterInterface string, netns ns.Net
 		}
 
 		for idx := range routes {
-			if routes[idx].Dst == nil {
-				// found default route
-				defaultInterface, err = getDefaultRouteIface(routes[idx].LinkIndex, filterInterface)
-				if err != nil {
-					return err
-				}
-				if defaultInterface != "" {
-					return nil
+			if routes[idx].Family == netlink.FAMILY_V4 {
+				if routes[idx].Dst == nil || routes[idx].Dst.IP.Equal(net.IPv4zero) {
+					// found default route
+					defaultInterface, err = getDefaultRouteIface(routes[idx].LinkIndex, filterInterface)
+					if err != nil {
+						return err
+					}
+					if defaultInterface != "" {
+						return nil
+					}
 				}
 			}
 		}

--- a/vendor/github.com/vishvananda/netlink/chain.go
+++ b/vendor/github.com/vishvananda/netlink/chain.go
@@ -1,0 +1,22 @@
+package netlink
+
+import (
+	"fmt"
+)
+
+// Chain contains the attributes of a Chain
+type Chain struct {
+	Parent uint32
+	Chain  uint32
+}
+
+func (c Chain) String() string {
+	return fmt.Sprintf("{Parent: %d, Chain: %d}", c.Parent, c.Chain)
+}
+
+func NewChain(parent uint32, chain uint32) Chain {
+	return Chain{
+		Parent: parent,
+		Chain:  chain,
+	}
+}

--- a/vendor/github.com/vishvananda/netlink/chain_linux.go
+++ b/vendor/github.com/vishvananda/netlink/chain_linux.go
@@ -1,0 +1,112 @@
+package netlink
+
+import (
+	"github.com/vishvananda/netlink/nl"
+	"golang.org/x/sys/unix"
+)
+
+// ChainDel will delete a chain from the system.
+func ChainDel(link Link, chain Chain) error {
+	// Equivalent to: `tc chain del $chain`
+	return pkgHandle.ChainDel(link, chain)
+}
+
+// ChainDel will delete a chain from the system.
+// Equivalent to: `tc chain del $chain`
+func (h *Handle) ChainDel(link Link, chain Chain) error {
+	return h.chainModify(unix.RTM_DELCHAIN, 0, link, chain)
+}
+
+// ChainAdd will add a chain to the system.
+// Equivalent to: `tc chain add`
+func ChainAdd(link Link, chain Chain) error {
+	return pkgHandle.ChainAdd(link, chain)
+}
+
+// ChainAdd will add a chain to the system.
+// Equivalent to: `tc chain add`
+func (h *Handle) ChainAdd(link Link, chain Chain) error {
+	return h.chainModify(
+		unix.RTM_NEWCHAIN,
+		unix.NLM_F_CREATE|unix.NLM_F_EXCL,
+		link,
+		chain)
+}
+
+func (h *Handle) chainModify(cmd, flags int, link Link, chain Chain) error {
+	req := h.newNetlinkRequest(cmd, flags|unix.NLM_F_ACK)
+	index := int32(0)
+	if link != nil {
+		base := link.Attrs()
+		h.ensureIndex(base)
+		index = int32(base.Index)
+	}
+	msg := &nl.TcMsg{
+		Family:  nl.FAMILY_ALL,
+		Ifindex: index,
+		Parent:  chain.Parent,
+	}
+	req.AddData(msg)
+	req.AddData(nl.NewRtAttr(nl.TCA_CHAIN, nl.Uint32Attr(chain.Chain)))
+
+	_, err := req.Execute(unix.NETLINK_ROUTE, 0)
+	return err
+}
+
+// ChainList gets a list of chains in the system.
+// Equivalent to: `tc chain list`.
+// The list can be filtered by link.
+func ChainList(link Link, parent uint32) ([]Chain, error) {
+	return pkgHandle.ChainList(link, parent)
+}
+
+// ChainList gets a list of chains in the system.
+// Equivalent to: `tc chain list`.
+// The list can be filtered by link.
+func (h *Handle) ChainList(link Link, parent uint32) ([]Chain, error) {
+	req := h.newNetlinkRequest(unix.RTM_GETCHAIN, unix.NLM_F_DUMP)
+	index := int32(0)
+	if link != nil {
+		base := link.Attrs()
+		h.ensureIndex(base)
+		index = int32(base.Index)
+	}
+	msg := &nl.TcMsg{
+		Family:  nl.FAMILY_ALL,
+		Ifindex: index,
+		Parent:  parent,
+	}
+	req.AddData(msg)
+
+	msgs, err := req.Execute(unix.NETLINK_ROUTE, unix.RTM_NEWCHAIN)
+	if err != nil {
+		return nil, err
+	}
+
+	var res []Chain
+	for _, m := range msgs {
+		msg := nl.DeserializeTcMsg(m)
+
+		attrs, err := nl.ParseRouteAttr(m[msg.Len():])
+		if err != nil {
+			return nil, err
+		}
+
+		// skip chains from other interfaces
+		if link != nil && msg.Ifindex != index {
+			continue
+		}
+
+		var chain Chain
+		for _, attr := range attrs {
+			switch attr.Attr.Type {
+			case nl.TCA_CHAIN:
+				chain.Chain = native.Uint32(attr.Value)
+				chain.Parent = parent
+			}
+		}
+		res = append(res, chain)
+	}
+
+	return res, nil
+}

--- a/vendor/github.com/vishvananda/netlink/filter.go
+++ b/vendor/github.com/vishvananda/netlink/filter.go
@@ -19,6 +19,7 @@ type FilterAttrs struct {
 	Parent    uint32
 	Priority  uint16 // lower is higher priority
 	Protocol  uint16 // unix.ETH_P_*
+	Chain     *uint32
 }
 
 func (q FilterAttrs) String() string {
@@ -26,6 +27,11 @@ func (q FilterAttrs) String() string {
 }
 
 type TcAct int32
+
+const (
+	TC_ACT_EXT_SHIFT    = 28
+	TC_ACT_EXT_VAL_MASK = (1 << TC_ACT_EXT_SHIFT) - 1
+)
 
 const (
 	TC_ACT_UNSPEC     TcAct = -1
@@ -39,6 +45,22 @@ const (
 	TC_ACT_REDIRECT   TcAct = 7
 	TC_ACT_JUMP       TcAct = 0x10000000
 )
+
+func getTcActExt(local int32) int32 {
+	return local << TC_ACT_EXT_SHIFT
+}
+
+func getTcActGotoChain() TcAct {
+	return TcAct(getTcActExt(2))
+}
+
+func getTcActExtOpcode(combined int32) int32 {
+	return combined & (^TC_ACT_EXT_VAL_MASK)
+}
+
+func TcActExtCmp(combined int32, opcode int32) bool {
+	return getTcActExtOpcode(combined) == opcode
+}
 
 func (a TcAct) String() string {
 	switch a {
@@ -62,6 +84,9 @@ func (a TcAct) String() string {
 		return "redirect"
 	case TC_ACT_JUMP:
 		return "jump"
+	}
+	if TcActExtCmp(int32(a), int32(getTcActGotoChain())) {
+		return "goto"
 	}
 	return fmt.Sprintf("0x%x", int32(a))
 }
@@ -112,6 +137,7 @@ type Action interface {
 
 type GenericAction struct {
 	ActionAttrs
+	Chain int32
 }
 
 func (action *GenericAction) Type() string {
@@ -275,6 +301,7 @@ type SkbEditAction struct {
 	PType        *uint16
 	Priority     *uint32
 	Mark         *uint32
+	Mask         *uint32
 }
 
 func (action *SkbEditAction) Type() string {
@@ -348,6 +375,7 @@ type FwFilter struct {
 	InDev   string
 	Mask    uint32
 	Police  *PoliceAction
+	Actions []Action
 }
 
 func (filter *FwFilter) Attrs() *FilterAttrs {

--- a/vendor/github.com/vishvananda/netlink/handle_unspecified.go
+++ b/vendor/github.com/vishvananda/netlink/handle_unspecified.go
@@ -163,6 +163,22 @@ func (h *Handle) LinkSetGroup(link Link, group int) error {
 	return ErrNotImplemented
 }
 
+func (h *Handle) LinkSetGSOMaxSize(link Link, maxSize int) error {
+	return ErrNotImplemented
+}
+
+func (h *Handle) LinkSetGROMaxSize(link Link, maxSize int) error {
+	return ErrNotImplemented
+}
+
+func (h *Handle) LinkSetGSOIPv4MaxSize(link Link, maxSize int) error {
+	return ErrNotImplemented
+}
+
+func (h *Handle) LinkSetGROIPv4MaxSize(link Link, maxSize int) error {
+	return ErrNotImplemented
+}
+
 func (h *Handle) setProtinfoAttr(link Link, mode bool, attr int) error {
 	return ErrNotImplemented
 }

--- a/vendor/github.com/vishvananda/netlink/ipset_linux.go
+++ b/vendor/github.com/vishvananda/netlink/ipset_linux.go
@@ -67,11 +67,13 @@ type IpsetCreateOptions struct {
 	Comments bool
 	Skbinfo  bool
 
-	Revision uint8
-	IPFrom   net.IP
-	IPTo     net.IP
-	PortFrom uint16
-	PortTo   uint16
+	Family      uint8
+	Revision    uint8
+	IPFrom      net.IP
+	IPTo        net.IP
+	PortFrom    uint16
+	PortTo      uint16
+	MaxElements uint32
 }
 
 // IpsetProtocol returns the ipset protocol version from the kernel
@@ -94,6 +96,11 @@ func IpsetFlush(setname string) error {
 	return pkgHandle.IpsetFlush(setname)
 }
 
+// IpsetSwap swaps two ipsets.
+func IpsetSwap(setname, othersetname string) error {
+	return pkgHandle.IpsetSwap(setname, othersetname)
+}
+
 // IpsetList dumps an specific ipset.
 func IpsetList(setname string) (*IPSetResult, error) {
 	return pkgHandle.IpsetList(setname)
@@ -112,6 +119,11 @@ func IpsetAdd(setname string, entry *IPSetEntry) error {
 // IpsetDel deletes an entry from an existing ipset.
 func IpsetDel(setname string, entry *IPSetEntry) error {
 	return pkgHandle.IpsetDel(setname, entry)
+}
+
+// IpsetTest tests whether an entry is in a set or not.
+func IpsetTest(setname string, entry *IPSetEntry) (bool, error) {
+	return pkgHandle.IpsetTest(setname, entry)
 }
 
 func (h *Handle) IpsetProtocol() (protocol uint8, minVersion uint8, err error) {
@@ -153,10 +165,17 @@ func (h *Handle) IpsetCreate(setname, typename string, options IpsetCreateOption
 		data.AddChild(nl.NewRtAttr(nl.IPSET_ATTR_PORT_FROM|int(nl.NLA_F_NET_BYTEORDER), buf[:2]))
 		data.AddChild(nl.NewRtAttr(nl.IPSET_ATTR_PORT_TO|int(nl.NLA_F_NET_BYTEORDER), buf[2:]))
 	default:
-		family = unix.AF_INET
+		family = options.Family
+		if family == 0 {
+			family = unix.AF_INET
+		}
 	}
 
 	req.AddData(nl.NewRtAttr(nl.IPSET_ATTR_FAMILY, nl.Uint8Attr(family)))
+
+	if options.MaxElements != 0 {
+		data.AddChild(&nl.Uint32Attribute{Type: nl.IPSET_ATTR_MAXELEM | nl.NLA_F_NET_BYTEORDER, Value: options.MaxElements})
+	}
 
 	if timeout := options.Timeout; timeout != nil {
 		data.AddChild(&nl.Uint32Attribute{Type: nl.IPSET_ATTR_TIMEOUT | nl.NLA_F_NET_BYTEORDER, Value: *timeout})
@@ -193,6 +212,14 @@ func (h *Handle) IpsetDestroy(setname string) error {
 func (h *Handle) IpsetFlush(setname string) error {
 	req := h.newIpsetRequest(nl.IPSET_CMD_FLUSH)
 	req.AddData(nl.NewRtAttr(nl.IPSET_ATTR_SETNAME, nl.ZeroTerminated(setname)))
+	_, err := ipsetExecute(req)
+	return err
+}
+
+func (h *Handle) IpsetSwap(setname, othersetname string) error {
+	req := h.newIpsetRequest(nl.IPSET_CMD_SWAP)
+	req.AddData(nl.NewRtAttr(nl.IPSET_ATTR_SETNAME, nl.ZeroTerminated(setname)))
+	req.AddData(nl.NewRtAttr(nl.IPSET_ATTR_TYPENAME, nl.ZeroTerminated(othersetname)))
 	_, err := ipsetExecute(req)
 	return err
 }
@@ -236,18 +263,23 @@ func (h *Handle) IpsetDel(setname string, entry *IPSetEntry) error {
 	return h.ipsetAddDel(nl.IPSET_CMD_DEL, setname, entry)
 }
 
-func (h *Handle) ipsetAddDel(nlCmd int, setname string, entry *IPSetEntry) error {
-	req := h.newIpsetRequest(nlCmd)
-	req.AddData(nl.NewRtAttr(nl.IPSET_ATTR_SETNAME, nl.ZeroTerminated(setname)))
-
-	if entry.Comment != "" {
-		req.AddData(nl.NewRtAttr(nl.IPSET_ATTR_COMMENT, nl.ZeroTerminated(entry.Comment)))
+func encodeIP(ip net.IP) (*nl.RtAttr, error) {
+	typ := int(nl.NLA_F_NET_BYTEORDER)
+	if ip4 := ip.To4(); ip4 != nil {
+		typ |= nl.IPSET_ATTR_IPADDR_IPV4
+		ip = ip4
+	} else {
+		typ |= nl.IPSET_ATTR_IPADDR_IPV6
 	}
 
+	return nl.NewRtAttr(typ, ip), nil
+}
+
+func buildEntryData(entry *IPSetEntry) (*nl.RtAttr, error) {
 	data := nl.NewRtAttr(nl.IPSET_ATTR_DATA|int(nl.NLA_F_NESTED), nil)
 
-	if !entry.Replace {
-		req.Flags |= unix.NLM_F_EXCL
+	if entry.Comment != "" {
+		data.AddChild(nl.NewRtAttr(nl.IPSET_ATTR_COMMENT, nl.ZeroTerminated(entry.Comment)))
 	}
 
 	if entry.Timeout != nil {
@@ -255,7 +287,10 @@ func (h *Handle) ipsetAddDel(nlCmd int, setname string, entry *IPSetEntry) error
 	}
 
 	if entry.IP != nil {
-		nestedData := nl.NewRtAttr(nl.IPSET_ATTR_IP|int(nl.NLA_F_NET_BYTEORDER), entry.IP)
+		nestedData, err := encodeIP(entry.IP)
+		if err != nil {
+			return nil, err
+		}
 		data.AddChild(nl.NewRtAttr(nl.IPSET_ATTR_IP|int(nl.NLA_F_NESTED), nestedData.Serialize()))
 	}
 
@@ -268,7 +303,10 @@ func (h *Handle) ipsetAddDel(nlCmd int, setname string, entry *IPSetEntry) error
 	}
 
 	if entry.IP2 != nil {
-		nestedData := nl.NewRtAttr(nl.IPSET_ATTR_IP|int(nl.NLA_F_NET_BYTEORDER), entry.IP2)
+		nestedData, err := encodeIP(entry.IP2)
+		if err != nil {
+			return nil, err
+		}
 		data.AddChild(nl.NewRtAttr(nl.IPSET_ATTR_IP2|int(nl.NLA_F_NESTED), nestedData.Serialize()))
 	}
 
@@ -295,12 +333,51 @@ func (h *Handle) ipsetAddDel(nlCmd int, setname string, entry *IPSetEntry) error
 	if entry.Mark != nil {
 		data.AddChild(&nl.Uint32Attribute{Type: nl.IPSET_ATTR_MARK | nl.NLA_F_NET_BYTEORDER, Value: *entry.Mark})
 	}
+	return data, nil
+}
 
+func (h *Handle) ipsetAddDel(nlCmd int, setname string, entry *IPSetEntry) error {
+	req := h.newIpsetRequest(nlCmd)
+	req.AddData(nl.NewRtAttr(nl.IPSET_ATTR_SETNAME, nl.ZeroTerminated(setname)))
+
+	if !entry.Replace {
+		req.Flags |= unix.NLM_F_EXCL
+	}
+
+	data, err := buildEntryData(entry)
+	if err != nil {
+		return err
+	}
 	data.AddChild(&nl.Uint32Attribute{Type: nl.IPSET_ATTR_LINENO | nl.NLA_F_NET_BYTEORDER, Value: 0})
 	req.AddData(data)
 
-	_, err := ipsetExecute(req)
+	_, err = ipsetExecute(req)
 	return err
+}
+
+func (h *Handle) IpsetTest(setname string, entry *IPSetEntry) (bool, error) {
+	req := h.newIpsetRequest(nl.IPSET_CMD_TEST)
+	req.AddData(nl.NewRtAttr(nl.IPSET_ATTR_SETNAME, nl.ZeroTerminated(setname)))
+
+	if !entry.Replace {
+		req.Flags |= unix.NLM_F_EXCL
+	}
+
+	data, err := buildEntryData(entry)
+	if err != nil {
+		return false, err
+	}
+	req.AddData(data)
+
+	_, err = ipsetExecute(req)
+	if err != nil {
+		if err == nl.IPSetError(nl.IPSET_ERR_EXIST) {
+			// not exist
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func (h *Handle) newIpsetRequest(cmd int) *nl.NetlinkRequest {
@@ -466,7 +543,7 @@ func parseIPSetEntry(data []byte) (entry IPSetEntry) {
 		case nl.IPSET_ATTR_IP | nl.NLA_F_NESTED:
 			for attr := range nl.ParseAttributes(attr.Value) {
 				switch attr.Type {
-				case nl.IPSET_ATTR_IP:
+				case nl.IPSET_ATTR_IPADDR_IPV4, nl.IPSET_ATTR_IPADDR_IPV6:
 					entry.IP = net.IP(attr.Value)
 				default:
 					log.Printf("unknown nested ADT attribute from kernel: %+v", attr)
@@ -475,7 +552,7 @@ func parseIPSetEntry(data []byte) (entry IPSetEntry) {
 		case nl.IPSET_ATTR_IP2 | nl.NLA_F_NESTED:
 			for attr := range nl.ParseAttributes(attr.Value) {
 				switch attr.Type {
-				case nl.IPSET_ATTR_IP:
+				case nl.IPSET_ATTR_IPADDR_IPV4, nl.IPSET_ATTR_IPADDR_IPV6:
 					entry.IP2 = net.IP(attr.Value)
 				default:
 					log.Printf("unknown nested ADT attribute from kernel: %+v", attr)

--- a/vendor/github.com/vishvananda/netlink/link.go
+++ b/vendor/github.com/vishvananda/netlink/link.go
@@ -22,34 +22,39 @@ type (
 
 // LinkAttrs represents data shared by most link types
 type LinkAttrs struct {
-	Index        int
-	MTU          int
-	TxQLen       int // Transmit Queue Length
-	Name         string
-	HardwareAddr net.HardwareAddr
-	Flags        net.Flags
-	RawFlags     uint32
-	ParentIndex  int         // index of the parent link device
-	MasterIndex  int         // must be the index of a bridge
-	Namespace    interface{} // nil | NsPid | NsFd
-	Alias        string
-	Statistics   *LinkStatistics
-	Promisc      int
-	Allmulti     int
-	Multi        int
-	Xdp          *LinkXdp
-	EncapType    string
-	Protinfo     *Protinfo
-	OperState    LinkOperState
-	PhysSwitchID int
-	NetNsID      int
-	NumTxQueues  int
-	NumRxQueues  int
-	GSOMaxSize   uint32
-	GSOMaxSegs   uint32
-	Vfs          []VfInfo // virtual functions available on link
-	Group        uint32
-	Slave        LinkSlave
+	Index          int
+	MTU            int
+	TxQLen         int // Transmit Queue Length
+	Name           string
+	HardwareAddr   net.HardwareAddr
+	Flags          net.Flags
+	RawFlags       uint32
+	ParentIndex    int         // index of the parent link device
+	MasterIndex    int         // must be the index of a bridge
+	Namespace      interface{} // nil | NsPid | NsFd
+	Alias          string
+	Statistics     *LinkStatistics
+	Promisc        int
+	Allmulti       int
+	Multi          int
+	Xdp            *LinkXdp
+	EncapType      string
+	Protinfo       *Protinfo
+	OperState      LinkOperState
+	PhysSwitchID   int
+	NetNsID        int
+	NumTxQueues    int
+	NumRxQueues    int
+	TSOMaxSegs     uint32
+	TSOMaxSize     uint32
+	GSOMaxSegs     uint32
+	GSOMaxSize     uint32
+	GROMaxSize     uint32
+	GSOIPv4MaxSize uint32
+	GROIPv4MaxSize uint32
+	Vfs            []VfInfo // virtual functions available on link
+	Group          uint32
+	Slave          LinkSlave
 }
 
 // LinkSlave represents a slave device.
@@ -265,6 +270,7 @@ type Bridge struct {
 	AgeingTime        *uint32
 	HelloTime         *uint32
 	VlanFiltering     *bool
+	VlanDefaultPVID   *uint16
 }
 
 func (bridge *Bridge) Attrs() *LinkAttrs {
@@ -1165,6 +1171,7 @@ type Gretun struct {
 	EncapFlags uint16
 	EncapSport uint16
 	EncapDport uint16
+	FlowBased  bool
 }
 
 func (gretun *Gretun) Attrs() *LinkAttrs {
@@ -1208,6 +1215,7 @@ func (gtp *GTP) Type() string {
 }
 
 // Virtual XFRM Interfaces
+//
 //	Named "xfrmi" to prevent confusion with XFRM objects
 type Xfrmi struct {
 	LinkAttrs

--- a/vendor/github.com/vishvananda/netlink/link_linux.go
+++ b/vendor/github.com/vishvananda/netlink/link_linux.go
@@ -345,6 +345,16 @@ func (h *Handle) BridgeSetVlanFiltering(link Link, on bool) error {
 	return h.linkModify(bridge, unix.NLM_F_ACK)
 }
 
+func BridgeSetVlanDefaultPVID(link Link, pvid uint16) error {
+	return pkgHandle.BridgeSetVlanDefaultPVID(link, pvid)
+}
+
+func (h *Handle) BridgeSetVlanDefaultPVID(link Link, pvid uint16) error {
+	bridge := link.(*Bridge)
+	bridge.VlanDefaultPVID = &pvid
+	return h.linkModify(bridge, unix.NLM_F_ACK)
+}
+
 func SetPromiscOn(link Link) error {
 	return pkgHandle.SetPromiscOn(link)
 }
@@ -946,6 +956,114 @@ func LinkSetXdpFdWithFlags(link Link, fd, flags int) error {
 	return err
 }
 
+// LinkSetGSOMaxSize sets the IPv6 GSO maximum size of the link device.
+// Equivalent to: `ip link set $link gso_max_size $maxSize`
+func LinkSetGSOMaxSize(link Link, maxSize int) error {
+	return pkgHandle.LinkSetGSOMaxSize(link, maxSize)
+}
+
+// LinkSetGSOMaxSize sets the IPv6 GSO maximum size of the link device.
+// Equivalent to: `ip link set $link gso_max_size $maxSize`
+func (h *Handle) LinkSetGSOMaxSize(link Link, maxSize int) error {
+	base := link.Attrs()
+	h.ensureIndex(base)
+	req := h.newNetlinkRequest(unix.RTM_SETLINK, unix.NLM_F_ACK)
+
+	msg := nl.NewIfInfomsg(unix.AF_UNSPEC)
+	msg.Index = int32(base.Index)
+	req.AddData(msg)
+
+	b := make([]byte, 4)
+	native.PutUint32(b, uint32(maxSize))
+
+	data := nl.NewRtAttr(unix.IFLA_GSO_MAX_SIZE, b)
+	req.AddData(data)
+
+	_, err := req.Execute(unix.NETLINK_ROUTE, 0)
+	return err
+}
+
+// LinkSetGROMaxSize sets the IPv6 GRO maximum size of the link device.
+// Equivalent to: `ip link set $link gro_max_size $maxSize`
+func LinkSetGROMaxSize(link Link, maxSize int) error {
+	return pkgHandle.LinkSetGROMaxSize(link, maxSize)
+}
+
+// LinkSetGROMaxSize sets the IPv6 GRO maximum size of the link device.
+// Equivalent to: `ip link set $link gro_max_size $maxSize`
+func (h *Handle) LinkSetGROMaxSize(link Link, maxSize int) error {
+	base := link.Attrs()
+	h.ensureIndex(base)
+	req := h.newNetlinkRequest(unix.RTM_SETLINK, unix.NLM_F_ACK)
+
+	msg := nl.NewIfInfomsg(unix.AF_UNSPEC)
+	msg.Index = int32(base.Index)
+	req.AddData(msg)
+
+	b := make([]byte, 4)
+	native.PutUint32(b, uint32(maxSize))
+
+	data := nl.NewRtAttr(unix.IFLA_GRO_MAX_SIZE, b)
+	req.AddData(data)
+
+	_, err := req.Execute(unix.NETLINK_ROUTE, 0)
+	return err
+}
+
+// LinkSetGSOIPv4MaxSize sets the IPv4 GSO maximum size of the link device.
+// Equivalent to: `ip link set $link gso_ipv4_max_size $maxSize`
+func LinkSetGSOIPv4MaxSize(link Link, maxSize int) error {
+	return pkgHandle.LinkSetGSOIPv4MaxSize(link, maxSize)
+}
+
+// LinkSetGSOIPv4MaxSize sets the IPv4 GSO maximum size of the link device.
+// Equivalent to: `ip link set $link gso_ipv4_max_size $maxSize`
+func (h *Handle) LinkSetGSOIPv4MaxSize(link Link, maxSize int) error {
+	base := link.Attrs()
+	h.ensureIndex(base)
+	req := h.newNetlinkRequest(unix.RTM_SETLINK, unix.NLM_F_ACK)
+
+	msg := nl.NewIfInfomsg(unix.AF_UNSPEC)
+	msg.Index = int32(base.Index)
+	req.AddData(msg)
+
+	b := make([]byte, 4)
+	native.PutUint32(b, uint32(maxSize))
+
+	data := nl.NewRtAttr(unix.IFLA_GSO_IPV4_MAX_SIZE, b)
+	req.AddData(data)
+
+	_, err := req.Execute(unix.NETLINK_ROUTE, 0)
+	return err
+}
+
+// LinkSetGROIPv4MaxSize sets the IPv4 GRO maximum size of the link device.
+// Equivalent to: `ip link set $link gro_ipv4_max_size $maxSize`
+func LinkSetGROIPv4MaxSize(link Link, maxSize int) error {
+	return pkgHandle.LinkSetGROIPv4MaxSize(link, maxSize)
+}
+
+// LinkSetGROIPv4MaxSize sets the IPv4 GRO maximum size of the link device.
+// Equivalent to: `ip link set $link gro_ipv4_max_size $maxSize`
+func (h *Handle) LinkSetGROIPv4MaxSize(link Link, maxSize int) error {
+	base := link.Attrs()
+	h.ensureIndex(base)
+	req := h.newNetlinkRequest(unix.RTM_SETLINK, unix.NLM_F_ACK)
+
+	msg := nl.NewIfInfomsg(unix.AF_UNSPEC)
+	msg.Index = int32(base.Index)
+	req.AddData(msg)
+
+	b := make([]byte, 4)
+	native.PutUint32(b, uint32(maxSize))
+
+	data := nl.NewRtAttr(unix.IFLA_GRO_IPV4_MAX_SIZE, b)
+	req.AddData(data)
+
+	_, err := req.Execute(unix.NETLINK_ROUTE, 0)
+	return err
+}
+
 func boolAttr(val bool) []byte {
 	var v uint8
 	if val {
@@ -1399,6 +1517,21 @@ func (h *Handle) linkModify(link Link, flags int) error {
 	if base.GSOMaxSize > 0 {
 		gsoAttr := nl.NewRtAttr(unix.IFLA_GSO_MAX_SIZE, nl.Uint32Attr(base.GSOMaxSize))
 		req.AddData(gsoAttr)
+	}
+
+	if base.GROMaxSize > 0 {
+		groAttr := nl.NewRtAttr(unix.IFLA_GRO_MAX_SIZE, nl.Uint32Attr(base.GROMaxSize))
+		req.AddData(groAttr)
+	}
+
+	if base.GSOIPv4MaxSize > 0 {
+		gsoAttr := nl.NewRtAttr(unix.IFLA_GSO_IPV4_MAX_SIZE, nl.Uint32Attr(base.GSOIPv4MaxSize))
+		req.AddData(gsoAttr)
+	}
+
+	if base.GROIPv4MaxSize > 0 {
+		groAttr := nl.NewRtAttr(unix.IFLA_GRO_IPV4_MAX_SIZE, nl.Uint32Attr(base.GROIPv4MaxSize))
+		req.AddData(groAttr)
 	}
 
 	if base.Group > 0 {
@@ -1937,10 +2070,20 @@ func LinkDeserialize(hdr *unix.NlMsghdr, m []byte) (Link, error) {
 			base.PhysSwitchID = int(native.Uint32(attr.Value[0:4]))
 		case unix.IFLA_LINK_NETNSID:
 			base.NetNsID = int(native.Uint32(attr.Value[0:4]))
-		case unix.IFLA_GSO_MAX_SIZE:
-			base.GSOMaxSize = native.Uint32(attr.Value[0:4])
+		case unix.IFLA_TSO_MAX_SEGS:
+			base.TSOMaxSegs = native.Uint32(attr.Value[0:4])
+		case unix.IFLA_TSO_MAX_SIZE:
+			base.TSOMaxSize = native.Uint32(attr.Value[0:4])
 		case unix.IFLA_GSO_MAX_SEGS:
 			base.GSOMaxSegs = native.Uint32(attr.Value[0:4])
+		case unix.IFLA_GSO_MAX_SIZE:
+			base.GSOMaxSize = native.Uint32(attr.Value[0:4])
+		case unix.IFLA_GRO_MAX_SIZE:
+			base.GROMaxSize = native.Uint32(attr.Value[0:4])
+		case unix.IFLA_GSO_IPV4_MAX_SIZE:
+			base.GSOIPv4MaxSize = native.Uint32(attr.Value[0:4])
+		case unix.IFLA_GRO_IPV4_MAX_SIZE:
+			base.GROIPv4MaxSize = native.Uint32(attr.Value[0:4])
 		case unix.IFLA_VFINFO_LIST:
 			data, err := nl.ParseRouteAttr(attr.Value)
 			if err != nil {
@@ -2653,7 +2796,7 @@ func addGretapAttrs(gretap *Gretap, linkInfo *nl.RtAttr) {
 
 	if gretap.FlowBased {
 		// In flow based mode, no other attributes need to be configured
-		data.AddRtAttr(nl.IFLA_GRE_COLLECT_METADATA, boolAttr(gretap.FlowBased))
+		data.AddRtAttr(nl.IFLA_GRE_COLLECT_METADATA, []byte{})
 		return
 	}
 
@@ -2736,6 +2879,12 @@ func parseGretapData(link Link, data []syscall.NetlinkRouteAttr) {
 func addGretunAttrs(gre *Gretun, linkInfo *nl.RtAttr) {
 	data := linkInfo.AddRtAttr(nl.IFLA_INFO_DATA, nil)
 
+	if gre.FlowBased {
+		// In flow based mode, no other attributes need to be configured
+		data.AddRtAttr(nl.IFLA_GRE_COLLECT_METADATA, []byte{})
+		return
+	}
+
 	if ip := gre.Local; ip != nil {
 		if ip.To4() != nil {
 			ip = ip.To4()
@@ -2806,6 +2955,8 @@ func parseGretunData(link Link, data []syscall.NetlinkRouteAttr) {
 			gre.EncapSport = ntohs(datum.Value[0:2])
 		case nl.IFLA_GRE_ENCAP_DPORT:
 			gre.EncapDport = ntohs(datum.Value[0:2])
+		case nl.IFLA_GRE_COLLECT_METADATA:
+			gre.FlowBased = true
 		}
 	}
 }
@@ -3115,6 +3266,9 @@ func addBridgeAttrs(bridge *Bridge, linkInfo *nl.RtAttr) {
 	if bridge.VlanFiltering != nil {
 		data.AddRtAttr(nl.IFLA_BR_VLAN_FILTERING, boolToByte(*bridge.VlanFiltering))
 	}
+	if bridge.VlanDefaultPVID != nil {
+		data.AddRtAttr(nl.IFLA_BR_VLAN_DEFAULT_PVID, nl.Uint16Attr(*bridge.VlanDefaultPVID))
+	}
 }
 
 func parseBridgeData(bridge Link, data []syscall.NetlinkRouteAttr) {
@@ -3133,6 +3287,9 @@ func parseBridgeData(bridge Link, data []syscall.NetlinkRouteAttr) {
 		case nl.IFLA_BR_VLAN_FILTERING:
 			vlanFiltering := datum.Value[0] == 1
 			br.VlanFiltering = &vlanFiltering
+		case nl.IFLA_BR_VLAN_DEFAULT_PVID:
+			vlanDefaultPVID := native.Uint16(datum.Value[0:2])
+			br.VlanDefaultPVID = &vlanDefaultPVID
 		}
 	}
 }

--- a/vendor/github.com/vishvananda/netlink/netlink_unspecified.go
+++ b/vendor/github.com/vishvananda/netlink/netlink_unspecified.go
@@ -124,6 +124,22 @@ func LinkSetTxQLen(link Link, qlen int) error {
 	return ErrNotImplemented
 }
 
+func LinkSetGSOMaxSize(link Link, maxSize int) error {
+	return ErrNotImplemented
+}
+
+func LinkSetGROMaxSize(link Link, maxSize int) error {
+	return ErrNotImplemented
+}
+
+func LinkSetGSOIPv4MaxSize(link Link, maxSize int) error {
+	return ErrNotImplemented
+}
+
+func LinkSetGROIPv4MaxSize(link Link, maxSize int) error {
+	return ErrNotImplemented
+}
+
 func LinkAdd(link Link) error {
 	return ErrNotImplemented
 }
@@ -213,6 +229,10 @@ func XfrmPolicyDel(policy *XfrmPolicy) error {
 }
 
 func XfrmPolicyList(family int) ([]XfrmPolicy, error) {
+	return nil, ErrNotImplemented
+}
+
+func XfrmPolicyGet(policy *XfrmPolicy) (*XfrmPolicy, error) {
 	return nil, ErrNotImplemented
 }
 

--- a/vendor/github.com/vishvananda/netlink/nl/conntrack_linux.go
+++ b/vendor/github.com/vishvananda/netlink/nl/conntrack_linux.go
@@ -89,6 +89,7 @@ const (
 	CTA_USE            = 11
 	CTA_ID             = 12
 	CTA_TIMESTAMP      = 20
+	CTA_LABELS         = 22
 )
 
 // enum ctattr_tuple {

--- a/vendor/github.com/vishvananda/netlink/nl/ipset_linux.go
+++ b/vendor/github.com/vishvananda/netlink/nl/ipset_linux.go
@@ -88,6 +88,11 @@ const (
 	SET_ATTR_CREATE_MAX
 )
 
+const (
+	IPSET_ATTR_IPADDR_IPV4 = 1
+	IPSET_ATTR_IPADDR_IPV6 = 2
+)
+
 /* ADT specific attributes */
 const (
 	IPSET_ATTR_ETHER = IPSET_ATTR_CADT_MAX + iota + 1

--- a/vendor/github.com/vishvananda/netlink/nl/nl_linux.go
+++ b/vendor/github.com/vishvananda/netlink/nl/nl_linux.go
@@ -330,6 +330,19 @@ func NewIfInfomsgChild(parent *RtAttr, family int) *IfInfomsg {
 	return msg
 }
 
+type Uint32Bitfield struct {
+	Value    uint32
+	Selector uint32
+}
+
+func (a *Uint32Bitfield) Serialize() []byte {
+	return (*(*[SizeofUint32Bitfield]byte)(unsafe.Pointer(a)))[:]
+}
+
+func DeserializeUint32Bitfield(data []byte) *Uint32Bitfield {
+	return (*Uint32Bitfield)(unsafe.Pointer(&data[0:SizeofUint32Bitfield][0]))
+}
+
 type Uint32Attribute struct {
 	Type  uint16
 	Value uint32

--- a/vendor/github.com/vishvananda/netlink/nl/route_linux.go
+++ b/vendor/github.com/vishvananda/netlink/nl/route_linux.go
@@ -48,7 +48,9 @@ type RtNexthop struct {
 }
 
 func DeserializeRtNexthop(b []byte) *RtNexthop {
-	return (*RtNexthop)(unsafe.Pointer(&b[0:unix.SizeofRtNexthop][0]))
+	return &RtNexthop{
+		RtNexthop: *((*unix.RtNexthop)(unsafe.Pointer(&b[0:unix.SizeofRtNexthop][0]))),
+	}
 }
 
 func (msg *RtNexthop) Len() int {

--- a/vendor/github.com/vishvananda/netlink/nl/xfrm_linux.go
+++ b/vendor/github.com/vishvananda/netlink/nl/xfrm_linux.go
@@ -131,7 +131,15 @@ func (x *XfrmAddress) ToIP() net.IP {
 	return ip
 }
 
-func (x *XfrmAddress) ToIPNet(prefixlen uint8) *net.IPNet {
+// family is only used when x and prefixlen are both 0
+func (x *XfrmAddress) ToIPNet(prefixlen uint8, family uint16) *net.IPNet {
+	empty := [SizeofXfrmAddress]byte{}
+	if bytes.Equal(x[:], empty[:]) && prefixlen == 0 {
+		if family == FAMILY_V6 {
+			return &net.IPNet{IP: net.ParseIP("::"), Mask: net.CIDRMask(int(prefixlen), 128)}
+		}
+		return &net.IPNet{IP: net.ParseIP("0.0.0.0"), Mask: net.CIDRMask(int(prefixlen), 32)}
+	}
 	ip := x.ToIP()
 	if GetIPFamily(ip) == FAMILY_V4 {
 		return &net.IPNet{IP: ip, Mask: net.CIDRMask(int(prefixlen), 32)}

--- a/vendor/github.com/vishvananda/netlink/nl/xfrm_state_linux.go
+++ b/vendor/github.com/vishvananda/netlink/nl/xfrm_state_linux.go
@@ -15,6 +15,7 @@ const (
 	SizeofXfrmEncapTmpl      = 0x18
 	SizeofXfrmUsersaFlush    = 0x1
 	SizeofXfrmReplayStateEsn = 0x18
+	SizeofXfrmReplayState    = 0x0c
 )
 
 const (
@@ -26,6 +27,11 @@ const (
 	XFRM_STATE_AF_UNSPEC  = 32
 	XFRM_STATE_ALIGN4     = 64
 	XFRM_STATE_ESN        = 128
+)
+
+const (
+	XFRM_SA_XFLAG_DONT_ENCAP_DSCP = 1
+	XFRM_SA_XFLAG_OSEQ_MAY_WRAP   = 2
 )
 
 // struct xfrm_usersa_id {
@@ -103,6 +109,7 @@ func (msg *XfrmStats) Serialize() []byte {
 // };
 //
 // #define XFRM_SA_XFLAG_DONT_ENCAP_DSCP 1
+// #define XFRM_SA_XFLAG_OSEQ_MAY_WRAP   2
 //
 
 type XfrmUsersaInfo struct {
@@ -331,4 +338,24 @@ type XfrmReplayStateEsn struct {
 func (msg *XfrmReplayStateEsn) Serialize() []byte {
 	// We deliberately do not pass Bmp, as it gets set by the kernel.
 	return (*(*[SizeofXfrmReplayStateEsn]byte)(unsafe.Pointer(msg)))[:]
+}
+
+// struct xfrm_replay_state {
+//     __u32   oseq;
+//     __u32   seq;
+//     __u32   bitmap;
+// };
+
+type XfrmReplayState struct {
+	OSeq   uint32
+	Seq    uint32
+	BitMap uint32
+}
+
+func DeserializeXfrmReplayState(b []byte) *XfrmReplayState {
+	return (*XfrmReplayState)(unsafe.Pointer(&b[0:SizeofXfrmReplayState][0]))
+}
+
+func (msg *XfrmReplayState) Serialize() []byte {
+	return (*(*[SizeofXfrmReplayState]byte)(unsafe.Pointer(msg)))[:]
 }

--- a/vendor/github.com/vishvananda/netlink/qdisc.go
+++ b/vendor/github.com/vishvananda/netlink/qdisc.go
@@ -17,6 +17,12 @@ const (
 	HANDLE_MIN_EGRESS  = 0xFFFFFFF3
 )
 
+const (
+	HORIZON_DROP_POLICY_CAP     = 0
+	HORIZON_DROP_POLICY_DROP    = 1
+	HORIZON_DROP_POLICY_DEFAULT = 255
+)
+
 type Qdisc interface {
 	Attrs() *QdiscAttrs
 	Type() string
@@ -26,10 +32,11 @@ type Qdisc interface {
 // has a handle, a parent and a refcnt. The root qdisc of a device should
 // have parent == HANDLE_ROOT.
 type QdiscAttrs struct {
-	LinkIndex int
-	Handle    uint32
-	Parent    uint32
-	Refcnt    uint32 // read only
+	LinkIndex    int
+	Handle       uint32
+	Parent       uint32
+	Refcnt       uint32 // read only
+	IngressBlock *uint32
 }
 
 func (q QdiscAttrs) String() string {
@@ -278,22 +285,25 @@ type Fq struct {
 	FlowDefaultRate uint32
 	FlowMaxRate     uint32
 	// called BucketsLog under the hood
-	Buckets          uint32
-	FlowRefillDelay  uint32
-	LowRateThreshold uint32
+	Buckets           uint32
+	FlowRefillDelay   uint32
+	LowRateThreshold  uint32
+	Horizon           uint32
+	HorizonDropPolicy uint8
 }
 
 func (fq *Fq) String() string {
 	return fmt.Sprintf(
-		"{PacketLimit: %v, FlowPacketLimit: %v, Quantum: %v, InitialQuantum: %v, Pacing: %v, FlowDefaultRate: %v, FlowMaxRate: %v, Buckets: %v, FlowRefillDelay: %v,  LowRateThreshold: %v}",
-		fq.PacketLimit, fq.FlowPacketLimit, fq.Quantum, fq.InitialQuantum, fq.Pacing, fq.FlowDefaultRate, fq.FlowMaxRate, fq.Buckets, fq.FlowRefillDelay, fq.LowRateThreshold,
+		"{PacketLimit: %v, FlowPacketLimit: %v, Quantum: %v, InitialQuantum: %v, Pacing: %v, FlowDefaultRate: %v, FlowMaxRate: %v, Buckets: %v, FlowRefillDelay: %v,  LowRateThreshold: %v, Horizon: %v, HorizonDropPolicy: %v}",
+		fq.PacketLimit, fq.FlowPacketLimit, fq.Quantum, fq.InitialQuantum, fq.Pacing, fq.FlowDefaultRate, fq.FlowMaxRate, fq.Buckets, fq.FlowRefillDelay, fq.LowRateThreshold, fq.Horizon, fq.HorizonDropPolicy,
 	)
 }
 
 func NewFq(attrs QdiscAttrs) *Fq {
 	return &Fq{
-		QdiscAttrs: attrs,
-		Pacing:     1,
+		QdiscAttrs:        attrs,
+		Pacing:            1,
+		HorizonDropPolicy: HORIZON_DROP_POLICY_DEFAULT,
 	}
 }
 

--- a/vendor/github.com/vishvananda/netlink/route_linux.go
+++ b/vendor/github.com/vishvananda/netlink/route_linux.go
@@ -41,7 +41,6 @@ func (s Scope) String() string {
 	}
 }
 
-
 const (
 	FLAG_ONLINK    NextHopFlag = unix.RTNH_F_ONLINK
 	FLAG_PERVASIVE NextHopFlag = unix.RTNH_F_PERVASIVE
@@ -656,7 +655,8 @@ func RouteAdd(route *Route) error {
 func (h *Handle) RouteAdd(route *Route) error {
 	flags := unix.NLM_F_CREATE | unix.NLM_F_EXCL | unix.NLM_F_ACK
 	req := h.newNetlinkRequest(unix.RTM_NEWROUTE, flags)
-	return h.routeHandle(route, req, nl.NewRtMsg())
+	_, err := h.routeHandle(route, req, nl.NewRtMsg())
+	return err
 }
 
 // RouteAppend will append a route to the system.
@@ -670,7 +670,8 @@ func RouteAppend(route *Route) error {
 func (h *Handle) RouteAppend(route *Route) error {
 	flags := unix.NLM_F_CREATE | unix.NLM_F_APPEND | unix.NLM_F_ACK
 	req := h.newNetlinkRequest(unix.RTM_NEWROUTE, flags)
-	return h.routeHandle(route, req, nl.NewRtMsg())
+	_, err := h.routeHandle(route, req, nl.NewRtMsg())
+	return err
 }
 
 // RouteAddEcmp will add a route to the system.
@@ -682,7 +683,8 @@ func RouteAddEcmp(route *Route) error {
 func (h *Handle) RouteAddEcmp(route *Route) error {
 	flags := unix.NLM_F_CREATE | unix.NLM_F_ACK
 	req := h.newNetlinkRequest(unix.RTM_NEWROUTE, flags)
-	return h.routeHandle(route, req, nl.NewRtMsg())
+	_, err := h.routeHandle(route, req, nl.NewRtMsg())
+	return err
 }
 
 // RouteReplace will add a route to the system.
@@ -696,7 +698,8 @@ func RouteReplace(route *Route) error {
 func (h *Handle) RouteReplace(route *Route) error {
 	flags := unix.NLM_F_CREATE | unix.NLM_F_REPLACE | unix.NLM_F_ACK
 	req := h.newNetlinkRequest(unix.RTM_NEWROUTE, flags)
-	return h.routeHandle(route, req, nl.NewRtMsg())
+	_, err := h.routeHandle(route, req, nl.NewRtMsg())
+	return err
 }
 
 // RouteDel will delete a route from the system.
@@ -709,12 +712,13 @@ func RouteDel(route *Route) error {
 // Equivalent to: `ip route del $route`
 func (h *Handle) RouteDel(route *Route) error {
 	req := h.newNetlinkRequest(unix.RTM_DELROUTE, unix.NLM_F_ACK)
-	return h.routeHandle(route, req, nl.NewRtDelMsg())
+	_, err := h.routeHandle(route, req, nl.NewRtDelMsg())
+	return err
 }
 
-func (h *Handle) routeHandle(route *Route, req *nl.NetlinkRequest, msg *nl.RtMsg) error {
-	if (route.Dst == nil || route.Dst.IP == nil) && route.Src == nil && route.Gw == nil && route.MPLSDst == nil {
-		return fmt.Errorf("one of Dst.IP, Src, or Gw must not be nil")
+func (h *Handle) routeHandle(route *Route, req *nl.NetlinkRequest, msg *nl.RtMsg) ([][]byte, error) {
+	if req.NlMsghdr.Type != unix.RTM_GETROUTE && (route.Dst == nil || route.Dst.IP == nil) && route.Src == nil && route.Gw == nil && route.MPLSDst == nil {
+		return nil, fmt.Errorf("Either Dst.IP, Src.IP or Gw must be set")
 	}
 
 	family := -1
@@ -741,11 +745,11 @@ func (h *Handle) routeHandle(route *Route, req *nl.NetlinkRequest, msg *nl.RtMsg
 
 	if route.NewDst != nil {
 		if family != -1 && family != route.NewDst.Family() {
-			return fmt.Errorf("new destination and destination are not the same address family")
+			return nil, fmt.Errorf("new destination and destination are not the same address family")
 		}
 		buf, err := route.NewDst.Encode()
 		if err != nil {
-			return err
+			return nil, err
 		}
 		rtAttrs = append(rtAttrs, nl.NewRtAttr(unix.RTA_NEWDST, buf))
 	}
@@ -756,7 +760,7 @@ func (h *Handle) routeHandle(route *Route, req *nl.NetlinkRequest, msg *nl.RtMsg
 		rtAttrs = append(rtAttrs, nl.NewRtAttr(unix.RTA_ENCAP_TYPE, buf))
 		buf, err := route.Encap.Encode()
 		if err != nil {
-			return err
+			return nil, err
 		}
 		switch route.Encap.Type() {
 		case nl.LWTUNNEL_ENCAP_BPF:
@@ -770,7 +774,7 @@ func (h *Handle) routeHandle(route *Route, req *nl.NetlinkRequest, msg *nl.RtMsg
 	if route.Src != nil {
 		srcFamily := nl.GetIPFamily(route.Src)
 		if family != -1 && family != srcFamily {
-			return fmt.Errorf("source and destination ip are not the same IP family")
+			return nil, fmt.Errorf("source and destination ip are not the same IP family")
 		}
 		family = srcFamily
 		var srcData []byte
@@ -786,7 +790,7 @@ func (h *Handle) routeHandle(route *Route, req *nl.NetlinkRequest, msg *nl.RtMsg
 	if route.Gw != nil {
 		gwFamily := nl.GetIPFamily(route.Gw)
 		if family != -1 && family != gwFamily {
-			return fmt.Errorf("gateway, source, and destination ip are not the same IP family")
+			return nil, fmt.Errorf("gateway, source, and destination ip are not the same IP family")
 		}
 		family = gwFamily
 		var gwData []byte
@@ -801,7 +805,7 @@ func (h *Handle) routeHandle(route *Route, req *nl.NetlinkRequest, msg *nl.RtMsg
 	if route.Via != nil {
 		buf, err := route.Via.Encode()
 		if err != nil {
-			return fmt.Errorf("failed to encode RTA_VIA: %v", err)
+			return nil, fmt.Errorf("failed to encode RTA_VIA: %v", err)
 		}
 		rtAttrs = append(rtAttrs, nl.NewRtAttr(unix.RTA_VIA, buf))
 	}
@@ -820,7 +824,7 @@ func (h *Handle) routeHandle(route *Route, req *nl.NetlinkRequest, msg *nl.RtMsg
 			if nh.Gw != nil {
 				gwFamily := nl.GetIPFamily(nh.Gw)
 				if family != -1 && family != gwFamily {
-					return fmt.Errorf("gateway, source, and destination ip are not the same IP family")
+					return nil, fmt.Errorf("gateway, source, and destination ip are not the same IP family")
 				}
 				if gwFamily == FAMILY_V4 {
 					children = append(children, nl.NewRtAttr(unix.RTA_GATEWAY, []byte(nh.Gw.To4())))
@@ -830,11 +834,11 @@ func (h *Handle) routeHandle(route *Route, req *nl.NetlinkRequest, msg *nl.RtMsg
 			}
 			if nh.NewDst != nil {
 				if family != -1 && family != nh.NewDst.Family() {
-					return fmt.Errorf("new destination and destination are not the same address family")
+					return nil, fmt.Errorf("new destination and destination are not the same address family")
 				}
 				buf, err := nh.NewDst.Encode()
 				if err != nil {
-					return err
+					return nil, err
 				}
 				children = append(children, nl.NewRtAttr(unix.RTA_NEWDST, buf))
 			}
@@ -844,14 +848,14 @@ func (h *Handle) routeHandle(route *Route, req *nl.NetlinkRequest, msg *nl.RtMsg
 				children = append(children, nl.NewRtAttr(unix.RTA_ENCAP_TYPE, buf))
 				buf, err := nh.Encap.Encode()
 				if err != nil {
-					return err
+					return nil, err
 				}
 				children = append(children, nl.NewRtAttr(unix.RTA_ENCAP, buf))
 			}
 			if nh.Via != nil {
 				buf, err := nh.Via.Encode()
 				if err != nil {
-					return err
+					return nil, err
 				}
 				children = append(children, nl.NewRtAttr(unix.RTA_VIA, buf))
 			}
@@ -968,19 +972,22 @@ func (h *Handle) routeHandle(route *Route, req *nl.NetlinkRequest, msg *nl.RtMsg
 
 	msg.Flags = uint32(route.Flags)
 	msg.Scope = uint8(route.Scope)
-	msg.Family = uint8(family)
+	// only overwrite family if it was not set in msg
+	if msg.Family == 0 {
+		msg.Family = uint8(family)
+	}
 	req.AddData(msg)
 	for _, attr := range rtAttrs {
 		req.AddData(attr)
 	}
 
-	b := make([]byte, 4)
-	native.PutUint32(b, uint32(route.LinkIndex))
+	if (req.NlMsghdr.Type != unix.RTM_GETROUTE) || (req.NlMsghdr.Type == unix.RTM_GETROUTE && route.LinkIndex > 0) {
+		b := make([]byte, 4)
+		native.PutUint32(b, uint32(route.LinkIndex))
+		req.AddData(nl.NewRtAttr(unix.RTA_OIF, b))
+	}
 
-	req.AddData(nl.NewRtAttr(unix.RTA_OIF, b))
-
-	_, err := req.Execute(unix.NETLINK_ROUTE, 0)
-	return err
+	return req.Execute(unix.NETLINK_ROUTE, 0)
 }
 
 // RouteList gets a list of routes in the system.
@@ -994,13 +1001,13 @@ func RouteList(link Link, family int) ([]Route, error) {
 // Equivalent to: `ip route show`.
 // The list can be filtered by link and ip family.
 func (h *Handle) RouteList(link Link, family int) ([]Route, error) {
-	var routeFilter *Route
+	routeFilter := &Route{}
 	if link != nil {
-		routeFilter = &Route{
-			LinkIndex: link.Attrs().Index,
-		}
+		routeFilter.LinkIndex = link.Attrs().Index
+
+		return h.RouteListFiltered(family, routeFilter, RT_FILTER_OIF)
 	}
-	return h.RouteListFiltered(family, routeFilter, RT_FILTER_OIF)
+	return h.RouteListFiltered(family, routeFilter, 0)
 }
 
 // RouteListFiltered gets a list of routes in the system filtered with specified rules.
@@ -1013,11 +1020,9 @@ func RouteListFiltered(family int, filter *Route, filterMask uint64) ([]Route, e
 // All rules must be defined in RouteFilter struct
 func (h *Handle) RouteListFiltered(family int, filter *Route, filterMask uint64) ([]Route, error) {
 	req := h.newNetlinkRequest(unix.RTM_GETROUTE, unix.NLM_F_DUMP)
-	rtmsg := nl.NewRtMsg()
+	rtmsg := &nl.RtMsg{}
 	rtmsg.Family = uint8(family)
-	req.AddData(rtmsg)
-
-	msgs, err := req.Execute(unix.NETLINK_ROUTE, unix.RTM_NEWROUTE)
+	msgs, err := h.routeHandle(filter, req, rtmsg)
 	if err != nil {
 		return nil, err
 	}
@@ -1063,6 +1068,9 @@ func (h *Handle) RouteListFiltered(family int, filter *Route, filterMask uint64)
 				continue
 			case filterMask&RT_FILTER_DST != 0:
 				if filter.MPLSDst == nil || route.MPLSDst == nil || (*filter.MPLSDst) != (*route.MPLSDst) {
+					if filter.Dst == nil {
+						filter.Dst = genZeroIPNet(family)
+					}
 					if !ipNetEqual(route.Dst, filter.Dst) {
 						continue
 					}
@@ -1257,6 +1265,27 @@ func deserializeRoute(m []byte) (Route, error) {
 		}
 	}
 
+	// Same logic to generate "default" dst with iproute2 implementation
+	if route.Dst == nil {
+		var addLen int
+		var ip net.IP
+		switch msg.Family {
+		case FAMILY_V4:
+			addLen = net.IPv4len
+			ip = net.IPv4zero
+		case FAMILY_V6:
+			addLen = net.IPv6len
+			ip = net.IPv6zero
+		}
+
+		if addLen != 0 {
+			route.Dst = &net.IPNet{
+				IP:   ip,
+				Mask: net.CIDRMask(int(msg.Dst_len), 8*addLen),
+			}
+		}
+	}
+
 	if len(encap.Value) != 0 && len(encapType.Value) != 0 {
 		typ := int(native.Uint16(encapType.Value[0:2]))
 		var e Encap
@@ -1295,6 +1324,8 @@ type RouteGetOptions struct {
 	Oif     string
 	VrfName string
 	SrcAddr net.IP
+	UID     *uint32
+	Mark    int
 }
 
 // RouteGetWithOptions gets a route to a specific destination from the host system.
@@ -1380,6 +1411,21 @@ func (h *Handle) RouteGetWithOptions(destination net.IP, options *RouteGetOption
 			}
 
 			req.AddData(nl.NewRtAttr(unix.RTA_SRC, srcAddr))
+		}
+
+		if options.UID != nil {
+			uid := *options.UID
+			b := make([]byte, 4)
+			native.PutUint32(b, uid)
+
+			req.AddData(nl.NewRtAttr(unix.RTA_UID, b))
+		}
+
+		if options.Mark > 0 {
+			b := make([]byte, 4)
+			native.PutUint32(b, uint32(options.Mark))
+
+			req.AddData(nl.NewRtAttr(unix.RTA_MARK, b))
 		}
 	}
 
@@ -1552,4 +1598,25 @@ func (p RouteProtocol) String() string {
 	default:
 		return strconv.Itoa(int(p))
 	}
+}
+
+// genZeroIPNet returns 0.0.0.0/0 or ::/0 for IPv4 or IPv6, otherwise nil
+func genZeroIPNet(family int) *net.IPNet {
+	var addLen int
+	var ip net.IP
+	switch family {
+	case FAMILY_V4:
+		addLen = net.IPv4len
+		ip = net.IPv4zero
+	case FAMILY_V6:
+		addLen = net.IPv6len
+		ip = net.IPv6zero
+	}
+	if addLen != 0 {
+		return &net.IPNet{
+			IP:   ip,
+			Mask: net.CIDRMask(0, 8*addLen),
+		}
+	}
+	return nil
 }

--- a/vendor/github.com/vishvananda/netlink/rule.go
+++ b/vendor/github.com/vishvananda/netlink/rule.go
@@ -26,6 +26,8 @@ type Rule struct {
 	Dport             *RulePortRange
 	Sport             *RulePortRange
 	IPProto           int
+	UIDRange          *RuleUIDRange
+	Protocol          uint8
 }
 
 func (r Rule) String() string {
@@ -65,4 +67,15 @@ func NewRulePortRange(start, end uint16) *RulePortRange {
 type RulePortRange struct {
 	Start uint16
 	End   uint16
+}
+
+// NewRuleUIDRange creates rule uid range.
+func NewRuleUIDRange(start, end uint32) *RuleUIDRange {
+	return &RuleUIDRange{Start: start, End: end}
+}
+
+// RuleUIDRange represents rule uid range.
+type RuleUIDRange struct {
+	Start uint32
+	End   uint32
 }

--- a/vendor/github.com/vishvananda/netlink/rule_linux.go
+++ b/vendor/github.com/vishvananda/netlink/rule_linux.go
@@ -168,6 +168,15 @@ func ruleHandle(rule *Rule, req *nl.NetlinkRequest) error {
 		req.AddData(nl.NewRtAttr(nl.FRA_SPORT_RANGE, b))
 	}
 
+	if rule.UIDRange != nil {
+		b := rule.UIDRange.toRtAttrData()
+		req.AddData(nl.NewRtAttr(nl.FRA_UID_RANGE, b))
+	}
+
+	if rule.Protocol > 0 {
+		req.AddData(nl.NewRtAttr(nl.FRA_PROTOCOL, nl.Uint8Attr(rule.Protocol)))
+	}
+
 	_, err := req.Execute(unix.NETLINK_ROUTE, 0)
 	return err
 }
@@ -262,6 +271,10 @@ func (h *Handle) RuleListFiltered(family int, filter *Rule, filterMask uint64) (
 				rule.Dport = NewRulePortRange(native.Uint16(attrs[j].Value[0:2]), native.Uint16(attrs[j].Value[2:4]))
 			case nl.FRA_SPORT_RANGE:
 				rule.Sport = NewRulePortRange(native.Uint16(attrs[j].Value[0:2]), native.Uint16(attrs[j].Value[2:4]))
+			case nl.FRA_UID_RANGE:
+				rule.UIDRange = NewRuleUIDRange(native.Uint32(attrs[j].Value[0:4]), native.Uint32(attrs[j].Value[4:8]))
+			case nl.FRA_PROTOCOL:
+				rule.Protocol = uint8(attrs[j].Value[0])
 			}
 		}
 
@@ -297,5 +310,12 @@ func (pr *RulePortRange) toRtAttrData() []byte {
 	b := [][]byte{make([]byte, 2), make([]byte, 2)}
 	native.PutUint16(b[0], pr.Start)
 	native.PutUint16(b[1], pr.End)
+	return bytes.Join(b, []byte{})
+}
+
+func (pr *RuleUIDRange) toRtAttrData() []byte {
+	b := [][]byte{make([]byte, 4), make([]byte, 4)}
+	native.PutUint32(b[0], pr.Start)
+	native.PutUint32(b[1], pr.End)
 	return bytes.Join(b, []byte{})
 }

--- a/vendor/github.com/vishvananda/netlink/xfrm_policy_linux.go
+++ b/vendor/github.com/vishvananda/netlink/xfrm_policy_linux.go
@@ -75,6 +75,7 @@ func (h *Handle) xfrmPolicyAddOrUpdate(policy *XfrmPolicy, nlProto int) error {
 		userTmpl := nl.DeserializeXfrmUserTmpl(tmplData[start : start+nl.SizeofXfrmUserTmpl])
 		userTmpl.XfrmId.Daddr.FromIP(tmpl.Dst)
 		userTmpl.Saddr.FromIP(tmpl.Src)
+		userTmpl.Family = uint16(nl.GetIPFamily(tmpl.Dst))
 		userTmpl.XfrmId.Proto = uint8(tmpl.Proto)
 		userTmpl.XfrmId.Spi = nl.Swap32(uint32(tmpl.Spi))
 		userTmpl.Mode = uint8(tmpl.Mode)
@@ -223,8 +224,8 @@ func parseXfrmPolicy(m []byte, family int) (*XfrmPolicy, error) {
 
 	var policy XfrmPolicy
 
-	policy.Dst = msg.Sel.Daddr.ToIPNet(msg.Sel.PrefixlenD)
-	policy.Src = msg.Sel.Saddr.ToIPNet(msg.Sel.PrefixlenS)
+	policy.Dst = msg.Sel.Daddr.ToIPNet(msg.Sel.PrefixlenD, uint16(family))
+	policy.Src = msg.Sel.Saddr.ToIPNet(msg.Sel.PrefixlenS, uint16(family))
 	policy.Proto = Proto(msg.Sel.Proto)
 	policy.DstPort = int(nl.Swap16(msg.Sel.Dport))
 	policy.SrcPort = int(nl.Swap16(msg.Sel.Sport))

--- a/vendor/github.com/vishvananda/netlink/xfrm_state.go
+++ b/vendor/github.com/vishvananda/netlink/xfrm_state.go
@@ -81,31 +81,48 @@ type XfrmStateStats struct {
 	UseTime      uint64
 }
 
+// XfrmReplayState represents the sequence number states for
+// "legacy" anti-replay mode.
+type XfrmReplayState struct {
+	OSeq   uint32
+	Seq    uint32
+	BitMap uint32
+}
+
+func (r XfrmReplayState) String() string {
+	return fmt.Sprintf("{OSeq: 0x%x, Seq: 0x%x, BitMap: 0x%x}",
+		r.OSeq, r.Seq, r.BitMap)
+}
+
 // XfrmState represents the state of an ipsec policy. It optionally
 // contains an XfrmStateAlgo for encryption and one for authentication.
 type XfrmState struct {
-	Dst          net.IP
-	Src          net.IP
-	Proto        Proto
-	Mode         Mode
-	Spi          int
-	Reqid        int
-	ReplayWindow int
-	Limits       XfrmStateLimits
-	Statistics   XfrmStateStats
-	Mark         *XfrmMark
-	OutputMark   *XfrmMark
-	Ifid         int
-	Auth         *XfrmStateAlgo
-	Crypt        *XfrmStateAlgo
-	Aead         *XfrmStateAlgo
-	Encap        *XfrmStateEncap
-	ESN          bool
+	Dst           net.IP
+	Src           net.IP
+	Proto         Proto
+	Mode          Mode
+	Spi           int
+	Reqid         int
+	ReplayWindow  int
+	Limits        XfrmStateLimits
+	Statistics    XfrmStateStats
+	Mark          *XfrmMark
+	OutputMark    *XfrmMark
+	Ifid          int
+	Auth          *XfrmStateAlgo
+	Crypt         *XfrmStateAlgo
+	Aead          *XfrmStateAlgo
+	Encap         *XfrmStateEncap
+	ESN           bool
+	DontEncapDSCP bool
+	OSeqMayWrap   bool
+	Replay        *XfrmReplayState
+	Selector      *XfrmPolicy
 }
 
 func (sa XfrmState) String() string {
-	return fmt.Sprintf("Dst: %v, Src: %v, Proto: %s, Mode: %s, SPI: 0x%x, ReqID: 0x%x, ReplayWindow: %d, Mark: %v, OutputMark: %v, Ifid: %d, Auth: %v, Crypt: %v, Aead: %v, Encap: %v, ESN: %t",
-		sa.Dst, sa.Src, sa.Proto, sa.Mode, sa.Spi, sa.Reqid, sa.ReplayWindow, sa.Mark, sa.OutputMark, sa.Ifid, sa.Auth, sa.Crypt, sa.Aead, sa.Encap, sa.ESN)
+	return fmt.Sprintf("Dst: %v, Src: %v, Proto: %s, Mode: %s, SPI: 0x%x, ReqID: 0x%x, ReplayWindow: %d, Mark: %v, OutputMark: %v, Ifid: %d, Auth: %v, Crypt: %v, Aead: %v, Encap: %v, ESN: %t, DontEncapDSCP: %t, OSeqMayWrap: %t, Replay: %v",
+		sa.Dst, sa.Src, sa.Proto, sa.Mode, sa.Spi, sa.Reqid, sa.ReplayWindow, sa.Mark, sa.OutputMark, sa.Ifid, sa.Auth, sa.Crypt, sa.Aead, sa.Encap, sa.ESN, sa.DontEncapDSCP, sa.OSeqMayWrap, sa.Replay)
 }
 func (sa XfrmState) Print(stats bool) string {
 	if !stats {

--- a/vendor/github.com/vishvananda/netlink/xfrm_state_linux.go
+++ b/vendor/github.com/vishvananda/netlink/xfrm_state_linux.go
@@ -77,6 +77,14 @@ func writeReplayEsn(replayWindow int) []byte {
 	return replayEsn.Serialize()
 }
 
+func writeReplay(r *XfrmReplayState) []byte {
+	return (&nl.XfrmReplayState{
+		OSeq:   r.OSeq,
+		Seq:    r.Seq,
+		BitMap: r.BitMap,
+	}).Serialize()
+}
+
 // XfrmStateAdd will add an xfrm state to the system.
 // Equivalent to: `ip xfrm state add $state`
 func XfrmStateAdd(state *XfrmState) error {
@@ -166,6 +174,21 @@ func (h *Handle) xfrmStateAddOrUpdate(state *XfrmState, nlProto int) error {
 			req.AddData(out)
 		}
 	}
+	if state.OSeqMayWrap || state.DontEncapDSCP {
+		var flags uint32
+		if state.DontEncapDSCP {
+			flags |= nl.XFRM_SA_XFLAG_DONT_ENCAP_DSCP
+		}
+		if state.OSeqMayWrap {
+			flags |= nl.XFRM_SA_XFLAG_OSEQ_MAY_WRAP
+		}
+		out := nl.NewRtAttr(nl.XFRMA_SA_EXTRA_FLAGS, nl.Uint32Attr(flags))
+		req.AddData(out)
+	}
+	if state.Replay != nil {
+		out := nl.NewRtAttr(nl.XFRMA_REPLAY_VAL, writeReplay(state.Replay))
+		req.AddData(out)
+	}
 
 	if state.Ifid != 0 {
 		ifId := nl.NewRtAttr(nl.XFRMA_IF_ID, nl.Uint32Attr(uint32(state.Ifid)))
@@ -186,7 +209,6 @@ func (h *Handle) xfrmStateAllocSpi(state *XfrmState) (*XfrmState, error) {
 	msg.Min = 0x100
 	msg.Max = 0xffffffff
 	req.AddData(msg)
-
 	if state.Mark != nil {
 		out := nl.NewRtAttr(nl.XFRMA_MARK, writeMark(state.Mark))
 		req.AddData(out)
@@ -314,7 +336,6 @@ var familyError = fmt.Errorf("family error")
 
 func xfrmStateFromXfrmUsersaInfo(msg *nl.XfrmUsersaInfo) *XfrmState {
 	var state XfrmState
-
 	state.Dst = msg.Id.Daddr.ToIP()
 	state.Src = msg.Saddr.ToIP()
 	state.Proto = Proto(msg.Id.Proto)
@@ -324,20 +345,25 @@ func xfrmStateFromXfrmUsersaInfo(msg *nl.XfrmUsersaInfo) *XfrmState {
 	state.ReplayWindow = int(msg.ReplayWindow)
 	lftToLimits(&msg.Lft, &state.Limits)
 	curToStats(&msg.Curlft, &msg.Stats, &state.Statistics)
+	state.Selector = &XfrmPolicy{
+		Dst:     msg.Sel.Daddr.ToIPNet(msg.Sel.PrefixlenD, msg.Sel.Family),
+		Src:     msg.Sel.Saddr.ToIPNet(msg.Sel.PrefixlenS, msg.Sel.Family),
+		Proto:   Proto(msg.Sel.Proto),
+		DstPort: int(nl.Swap16(msg.Sel.Dport)),
+		SrcPort: int(nl.Swap16(msg.Sel.Sport)),
+		Ifindex: int(msg.Sel.Ifindex),
+	}
 
 	return &state
 }
 
 func parseXfrmState(m []byte, family int) (*XfrmState, error) {
 	msg := nl.DeserializeXfrmUsersaInfo(m)
-
 	// This is mainly for the state dump
 	if family != FAMILY_ALL && family != int(msg.Family) {
 		return nil, familyError
 	}
-
 	state := xfrmStateFromXfrmUsersaInfo(msg)
-
 	attrs, err := nl.ParseRouteAttr(m[nl.SizeofXfrmUsersaInfo:])
 	if err != nil {
 		return nil, err
@@ -385,6 +411,14 @@ func parseXfrmState(m []byte, family int) (*XfrmState, error) {
 			state.Mark = new(XfrmMark)
 			state.Mark.Value = mark.Value
 			state.Mark.Mask = mark.Mask
+		case nl.XFRMA_SA_EXTRA_FLAGS:
+			flags := native.Uint32(attr.Value)
+			if (flags & nl.XFRM_SA_XFLAG_DONT_ENCAP_DSCP) != 0 {
+				state.DontEncapDSCP = true
+			}
+			if (flags & nl.XFRM_SA_XFLAG_OSEQ_MAY_WRAP) != 0 {
+				state.OSeqMayWrap = true
+			}
 		case nl.XFRMA_SET_MARK:
 			if state.OutputMark == nil {
 				state.OutputMark = new(XfrmMark)
@@ -400,6 +434,14 @@ func parseXfrmState(m []byte, family int) (*XfrmState, error) {
 			}
 		case nl.XFRMA_IF_ID:
 			state.Ifid = int(native.Uint32(attr.Value))
+		case nl.XFRMA_REPLAY_VAL:
+			if state.Replay == nil {
+				state.Replay = new(XfrmReplayState)
+			}
+			replay := nl.DeserializeXfrmReplayState(attr.Value[:])
+			state.Replay.OSeq = replay.OSeq
+			state.Replay.Seq = replay.Seq
+			state.Replay.BitMap = replay.BitMap
 		}
 	}
 
@@ -476,6 +518,9 @@ func xfrmUsersaInfoFromXfrmState(state *XfrmState) *nl.XfrmUsersaInfo {
 	msg.Id.Spi = nl.Swap32(uint32(state.Spi))
 	msg.Reqid = uint32(state.Reqid)
 	msg.ReplayWindow = uint8(state.ReplayWindow)
-
+	msg.Sel = nl.XfrmSelector{}
+	if state.Selector != nil {
+		selFromPolicy(&msg.Sel, state.Selector)
+	}
 	return msg
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -459,7 +459,7 @@ github.com/tigera/operator/pkg/apis/crd.projectcalico.org/v1
 # github.com/toqueteos/webbrowser v1.2.0
 ## explicit; go 1.12
 github.com/toqueteos/webbrowser
-# github.com/vishvananda/netlink v1.2.1-beta.2
+# github.com/vishvananda/netlink v1.2.1-beta.2.0.20230621221334-77712cff8739
 ## explicit; go 1.12
 github.com/vishvananda/netlink
 github.com/vishvananda/netlink/nl


### PR DESCRIPTION
In latest netlink, For netlink.RouteList function, we can't check the route.dst == nil to determine if it is the default route or not. Now if it is the default route, its route.Dst is no longer nil, but an empty address.

---
name: Pull request
about: Tell us about your contribution
labels: ["pr/release/none-required"]
---

---
## Thanks for contributing !

Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/contributing/development/pullrequest/#need-review>

**What this PR does / why we need it**:

Due to https://github.com/spidernet-io/spiderpool/actions/runs/6167611725/job/16738949668?pr=2326, After we import the cilium public library, the version of netlink needs to be upgraded.

https://github.com/vishvananda/netlink/commit/acdc658b8613655ddb69f978e9fb4cf413e2b830

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**make sure your commit is signed off**
