### PR TITLE
get wrong top pod controller for non-native controller

### DIFF
--- a/cmd/spiderpool-agent/cmd/config.go
+++ b/cmd/spiderpool-agent/cmd/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/pflag"
 	"go.uber.org/atomic"
 	"gopkg.in/yaml.v3"
+	"k8s.io/client-go/dynamic"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/spidernet-io/spiderpool/api/v1/agent/client"
@@ -109,6 +110,8 @@ type AgentContext struct {
 	// It will be cancelled after receiving an interrupt or termination signal.
 	InnerCtx    context.Context
 	InnerCancel context.CancelFunc
+
+	DynamicClient *dynamic.DynamicClient
 
 	// manager
 	IPAM              ipam.IPAM

--- a/cmd/spiderpool-controller/cmd/daemon.go
+++ b/cmd/spiderpool-controller/cmd/daemon.go
@@ -245,6 +245,7 @@ func initControllerServiceManagers(ctx context.Context) {
 	podManager, err := podmanager.NewPodManager(
 		controllerContext.CRDManager.GetClient(),
 		controllerContext.CRDManager.GetAPIReader(),
+		controllerContext.DynamicClient,
 	)
 	if err != nil {
 		logger.Fatal(err.Error())

--- a/pkg/applicationcontroller/app_controller.go
+++ b/pkg/applicationcontroller/app_controller.go
@@ -729,8 +729,8 @@ func (sac *SubnetAppController) syncHandler(appKey appWorkQueueKey, log *zap.Log
 				Namespace:  app.GetNamespace(),
 				Name:       app.GetName(),
 			},
-			UID: app.GetUID(),
-			APP: app,
+			UID:      app.GetUID(),
+			Replicas: &appReplicas,
 		},
 		appReplicas)
 	if nil != err {

--- a/pkg/applicationcontroller/applicationinformers/utils.go
+++ b/pkg/applicationcontroller/applicationinformers/utils.go
@@ -452,7 +452,7 @@ func IsAppExist(ctx context.Context, cacheClient client.Client, dynamicClient dy
 
 	var unstructuredObject *unstructured.Unstructured
 	if isThird {
-		gvr, e := GenerateGVR(appNamespacedName)
+		gvr, e := GenerateGVR(appNamespacedName.APIVersion, appNamespacedName.Kind)
 		if nil != e {
 			return false, "", e
 		}
@@ -479,13 +479,13 @@ func IsAppExist(ctx context.Context, cacheClient client.Client, dynamicClient dy
 	return true, appUID, nil
 }
 
-func GenerateGVR(appNamespacedName types.AppNamespacedName) (schema.GroupVersionResource, error) {
-	gv, err := schema.ParseGroupVersion(appNamespacedName.APIVersion)
+func GenerateGVR(apiVersion, kind string) (schema.GroupVersionResource, error) {
+	gv, err := schema.ParseGroupVersion(apiVersion)
 	if nil != err {
 		return schema.GroupVersionResource{}, err
 	}
 
-	gvk := gv.WithKind(appNamespacedName.Kind)
+	gvk := gv.WithKind(kind)
 	gvrPlural, _ := meta.UnsafeGuessKindToResource(gvk)
 
 	return gvrPlural, nil

--- a/pkg/applicationcontroller/applicationinformers/utils_test.go
+++ b/pkg/applicationcontroller/applicationinformers/utils_test.go
@@ -546,7 +546,7 @@ var _ = Describe("Utils", func() {
 				Namespace:  "test-ns",
 				Name:       "test-name",
 			}
-			gvr, err := GenerateGVR(appNamespacedName)
+			gvr, err := GenerateGVR(appNamespacedName.APIVersion, appNamespacedName.Kind)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(gvr.Group).To(Equal(appsv1.SchemeGroupVersion.Group))
 			Expect(gvr.Version).To(Equal(appsv1.SchemeGroupVersion.Version))
@@ -560,7 +560,7 @@ var _ = Describe("Utils", func() {
 				Namespace:  "test-ns",
 				Name:       "test-name",
 			}
-			gvr, err := GenerateGVR(appNamespacedName)
+			gvr, err := GenerateGVR(appNamespacedName.APIVersion, appNamespacedName.Kind)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(gvr.Group).To(BeEmpty())
 			Expect(gvr.Version).To(Equal(corev1.SchemeGroupVersion.Version))
@@ -574,7 +574,7 @@ var _ = Describe("Utils", func() {
 				Namespace:  "test-ns",
 				Name:       "test-name",
 			}
-			_, err := GenerateGVR(appNamespacedName)
+			_, err := GenerateGVR(appNamespacedName.APIVersion, appNamespacedName.Kind)
 			Expect(err).To(HaveOccurred())
 		})
 	})

--- a/pkg/ipam/pool_selections.go
+++ b/pkg/ipam/pool_selections.go
@@ -27,8 +27,6 @@ import (
 )
 
 func (i *ipam) getPoolCandidates(ctx context.Context, addArgs *models.IpamAddArgs, pod *corev1.Pod, podController types.PodTopController) (ToBeAllocateds, error) {
-	log := logutils.FromContext(ctx)
-
 	// If feature SpiderSubnet is enabled, select IPPool candidates through the
 	// Pod annotations "ipam.spidernet.io/subnet" or "ipam.spidernet.io/subnets". (expect orphan Pod controller)
 	if i.config.EnableSpiderSubnet {
@@ -37,13 +35,7 @@ func (i *ipam) getPoolCandidates(ctx context.Context, addArgs *models.IpamAddArg
 			return nil, fmt.Errorf("failed to get IPPool candidates from Subnet: %v", err)
 		}
 		if fromSubnet != nil {
-			// The SpiderSubnet feature doesn't support orphan Pod.
-			// So the orphan pod would get the IPPool candidates from the other traditional IPPool rules.
-			if podController.APIVersion == corev1.SchemeGroupVersion.String() && podController.Kind == constant.KindPod {
-				log.Sugar().Warnf("SpiderSubnet feature doesn't support no-controller pod, try to allocate IPs in traditional IPPool way")
-			} else {
-				return ToBeAllocateds{fromSubnet}, nil
-			}
+			return ToBeAllocateds{fromSubnet}, nil
 		}
 	}
 
@@ -94,9 +86,18 @@ func (i *ipam) getPoolFromSubnetAnno(ctx context.Context, pod *corev1.Pod, nic s
 		return nil, err
 	}
 
-	// default IPPool mode
-	if applicationinformers.IsDefaultIPPoolMode(subnetAnnoConfig) {
-		return nil, nil
+	{
+		// default IPPool mode
+		if applicationinformers.IsDefaultIPPoolMode(subnetAnnoConfig) {
+			return nil, nil
+		}
+
+		// The SpiderSubnet feature doesn't support orphan Pod.
+		// So the orphan pod would get the IPPool candidates from the other traditional IPPool rules.
+		if podController.APIVersion == corev1.SchemeGroupVersion.String() && podController.Kind == constant.KindPod {
+			logger.Sugar().Warnf("SpiderSubnet feature doesn't support no-controller pod, try to allocate IPs in traditional IPPool way")
+			return nil, nil
+		}
 	}
 
 	var subnetItem types.AnnoSubnetItem

--- a/pkg/podmanager/pod_manager.go
+++ b/pkg/podmanager/pod_manager.go
@@ -11,12 +11,16 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/utils/pointer"
 	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/spidernet-io/spiderpool/pkg/applicationcontroller/applicationinformers"
 	"github.com/spidernet-io/spiderpool/pkg/constant"
-	"github.com/spidernet-io/spiderpool/pkg/logutils"
 	"github.com/spidernet-io/spiderpool/pkg/types"
 )
 
@@ -27,21 +31,26 @@ type PodManager interface {
 }
 
 type podManager struct {
-	client    client.Client
-	apiReader client.Reader
+	client        client.Client
+	apiReader     client.Reader
+	dynamicClient dynamic.Interface
 }
 
-func NewPodManager(client client.Client, apiReader client.Reader) (PodManager, error) {
+func NewPodManager(client client.Client, apiReader client.Reader, dynamicClient dynamic.Interface) (PodManager, error) {
 	if client == nil {
 		return nil, fmt.Errorf("k8s client %w", constant.ErrMissingRequiredParam)
 	}
 	if apiReader == nil {
 		return nil, fmt.Errorf("api reader %w", constant.ErrMissingRequiredParam)
 	}
+	if dynamicClient == nil {
+		return nil, fmt.Errorf("dynamic client %w", constant.ErrMissingRequiredParam)
+	}
 
 	return &podManager{
-		client:    client,
-		apiReader: apiReader,
+		client:        client,
+		apiReader:     apiReader,
+		dynamicClient: dynamicClient,
 	}, nil
 }
 
@@ -76,12 +85,8 @@ func (pm *podManager) ListPods(ctx context.Context, cached bool, opts ...client.
 // GetPodTopController will find the pod top owner controller with the given pod.
 // For example, once we create a deployment then it will create replicaset and the replicaset will create pods.
 // So, the pods' top owner is deployment. That's what the method implements.
-// Notice: if the application is a third party controller, the types.PodTopController property App would be nil!
+// Notice: if the application is a third party controller, the types.PodTopController property Replicas would be nil!
 func (pm *podManager) GetPodTopController(ctx context.Context, pod *corev1.Pod) (types.PodTopController, error) {
-	logger := logutils.FromContext(ctx)
-
-	var ownerErr = fmt.Errorf("failed to get pod '%s/%s' owner", pod.Namespace, pod.Name)
-
 	podOwner := metav1.GetControllerOf(pod)
 	if podOwner == nil {
 		return types.PodTopController{
@@ -92,173 +97,105 @@ func (pm *podManager) GetPodTopController(ctx context.Context, pod *corev1.Pod) 
 				Namespace:  pod.Namespace,
 				Name:       pod.Name,
 			},
-			UID: pod.UID,
-			APP: pod,
+			UID:      pod.UID,
+			Replicas: pointer.Int(1),
 		}, nil
 	}
 
-	// third party controller
-	if !slices.Contains(constant.K8sAPIVersions, podOwner.APIVersion) {
-		return types.PodTopController{
-			AppNamespacedName: types.AppNamespacedName{
-				APIVersion: podOwner.APIVersion,
-				Kind:       podOwner.Kind,
-				Namespace:  pod.Namespace,
-				Name:       podOwner.Name,
-			},
-			UID: podOwner.UID,
-		}, nil
+	unstructuredObj, ownerReference, err := pm.controller(ctx, podOwner, pod.Namespace)
+	if nil != err {
+		return types.PodTopController{}, fmt.Errorf("failed to get pod top controller, error: %w", err)
 	}
 
-	namespacedName := apitypes.NamespacedName{
-		Namespace: pod.Namespace,
-		Name:      podOwner.Name,
+	replicas, err := getK8sKindControllerReplicas(unstructuredObj, ownerReference.APIVersion, ownerReference.Kind)
+	if nil != err {
+		return types.PodTopController{}, fmt.Errorf("failed to get controller '%s/%s' replicas, error: %w", ownerReference.APIVersion, ownerReference.Kind, err)
 	}
 
-	switch podOwner.Kind {
-	case constant.KindReplicaSet:
-		var replicaset appsv1.ReplicaSet
-		err := pm.client.Get(ctx, namespacedName, &replicaset)
-		if nil != err {
-			return types.PodTopController{}, fmt.Errorf("%w: %v", ownerErr, err)
-		}
-
-		replicasetOwner := metav1.GetControllerOf(&replicaset)
-		if replicasetOwner != nil {
-			if replicasetOwner.APIVersion == appsv1.SchemeGroupVersion.String() && replicasetOwner.Kind == constant.KindDeployment {
-				var deployment appsv1.Deployment
-				err = pm.client.Get(ctx, apitypes.NamespacedName{Namespace: replicaset.Namespace, Name: replicasetOwner.Name}, &deployment)
-				if nil != err {
-					return types.PodTopController{}, fmt.Errorf("%w: %v", ownerErr, err)
-				}
-				return types.PodTopController{
-					AppNamespacedName: types.AppNamespacedName{
-						// deployment.APIVersion is empty string
-						APIVersion: appsv1.SchemeGroupVersion.String(),
-						Kind:       constant.KindDeployment,
-						Namespace:  deployment.Namespace,
-						Name:       deployment.Name,
-					},
-					UID: deployment.UID,
-					APP: &deployment,
-				}, nil
-			}
-
-			logger.Sugar().Warnf("the controller type '%s' of pod '%s/%s' is unknown", replicasetOwner.Kind, pod.Namespace, pod.Name)
-			return types.PodTopController{
-				AppNamespacedName: types.AppNamespacedName{
-					APIVersion: replicasetOwner.APIVersion,
-					Kind:       replicasetOwner.Kind,
-					Namespace:  pod.Namespace,
-					Name:       replicasetOwner.Name,
-				},
-				UID: replicasetOwner.UID,
-			}, nil
-		}
-		return types.PodTopController{
-			AppNamespacedName: types.AppNamespacedName{
-				APIVersion: appsv1.SchemeGroupVersion.String(),
-				Kind:       constant.KindReplicaSet,
-				Namespace:  replicaset.Namespace,
-				Name:       replicaset.Name,
-			},
-			UID: replicaset.UID,
-			APP: &replicaset,
-		}, nil
-
-	case constant.KindJob:
-		var job batchv1.Job
-		err := pm.client.Get(ctx, namespacedName, &job)
-		if nil != err {
-			return types.PodTopController{}, fmt.Errorf("%w: %v", ownerErr, err)
-		}
-		jobOwner := metav1.GetControllerOf(&job)
-		if jobOwner != nil {
-			if jobOwner.APIVersion == batchv1.SchemeGroupVersion.String() && jobOwner.Kind == constant.KindCronJob {
-				var cronJob batchv1.CronJob
-				err = pm.client.Get(ctx, apitypes.NamespacedName{Namespace: job.Namespace, Name: jobOwner.Name}, &cronJob)
-				if nil != err {
-					return types.PodTopController{}, fmt.Errorf("%w: %v", ownerErr, err)
-				}
-				return types.PodTopController{
-					AppNamespacedName: types.AppNamespacedName{
-						APIVersion: batchv1.SchemeGroupVersion.String(),
-						Kind:       constant.KindCronJob,
-						Namespace:  cronJob.Namespace,
-						Name:       cronJob.Name,
-					},
-					UID: cronJob.UID,
-					APP: &cronJob,
-				}, nil
-			}
-
-			logger.Sugar().Warnf("the controller type '%s' of pod '%s/%s' is unknown", jobOwner.Kind, pod.Namespace, pod.Name)
-			return types.PodTopController{
-				AppNamespacedName: types.AppNamespacedName{
-					APIVersion: jobOwner.APIVersion,
-					Kind:       jobOwner.Kind,
-					Namespace:  job.Namespace,
-					Name:       jobOwner.Name,
-				},
-				UID: jobOwner.UID,
-			}, nil
-		}
-		return types.PodTopController{
-			AppNamespacedName: types.AppNamespacedName{
-				APIVersion: batchv1.SchemeGroupVersion.String(),
-				Kind:       constant.KindJob,
-				Namespace:  job.Namespace,
-				Name:       job.Name,
-			},
-			UID: job.UID,
-			APP: &job,
-		}, nil
-
-	case constant.KindDaemonSet:
-		var daemonSet appsv1.DaemonSet
-		err := pm.client.Get(ctx, namespacedName, &daemonSet)
-		if nil != err {
-			return types.PodTopController{}, fmt.Errorf("%w: %v", ownerErr, err)
-		}
-		return types.PodTopController{
-			AppNamespacedName: types.AppNamespacedName{
-				// daemonSet.APIVersion is empty string
-				APIVersion: appsv1.SchemeGroupVersion.String(),
-				Kind:       constant.KindDaemonSet,
-				Namespace:  daemonSet.Namespace,
-				Name:       daemonSet.Name,
-			},
-			UID: daemonSet.UID,
-			APP: &daemonSet,
-		}, nil
-
-	case constant.KindStatefulSet:
-		var statefulSet appsv1.StatefulSet
-		err := pm.client.Get(ctx, namespacedName, &statefulSet)
-		if nil != err {
-			return types.PodTopController{}, fmt.Errorf("%w: %v", ownerErr, err)
-		}
-		return types.PodTopController{
-			AppNamespacedName: types.AppNamespacedName{
-				// statefulSet.APIVersion is empty string
-				APIVersion: appsv1.SchemeGroupVersion.String(),
-				Kind:       constant.KindStatefulSet,
-				Namespace:  statefulSet.Namespace,
-				Name:       statefulSet.Name,
-			},
-			UID: statefulSet.UID,
-			APP: &statefulSet,
-		}, nil
-	}
-
-	logger.Sugar().Warnf("the controller type '%s' of pod '%s/%s' is unknown", podOwner.Kind, pod.Namespace, pod.Name)
-	return types.PodTopController{
+	result := types.PodTopController{
 		AppNamespacedName: types.AppNamespacedName{
-			APIVersion: podOwner.APIVersion,
-			Kind:       podOwner.Kind,
+			APIVersion: ownerReference.APIVersion,
+			Kind:       ownerReference.Kind,
 			Namespace:  pod.Namespace,
-			Name:       podOwner.Name,
+			Name:       ownerReference.Name,
 		},
-		UID: podOwner.UID,
-	}, nil
+		UID:      ownerReference.UID,
+		Replicas: replicas,
+	}
+
+	return result, nil
+}
+
+func (pm *podManager) controller(ctx context.Context, controllerOwnerRef *metav1.OwnerReference, namespace string) (*unstructured.Unstructured, *metav1.OwnerReference, error) {
+	gvr, err := applicationinformers.GenerateGVR(controllerOwnerRef.APIVersion, controllerOwnerRef.Kind)
+	if nil != err {
+		return nil, nil, err
+	}
+	unstructuredObj, err := pm.dynamicClient.Resource(gvr).Namespace(namespace).Get(ctx, controllerOwnerRef.Name, metav1.GetOptions{})
+	if nil != err {
+		return nil, nil, err
+	}
+	owner := metav1.GetControllerOf(unstructuredObj)
+	if owner == nil {
+		return unstructuredObj, controllerOwnerRef, nil
+	}
+
+	return pm.controller(ctx, owner, namespace)
+}
+
+func getK8sKindControllerReplicas(unstructuredObj *unstructured.Unstructured, apiVersion, kind string) (*int, error) {
+	if slices.Contains(constant.K8sAPIVersions, apiVersion) {
+		switch kind {
+		case constant.KindDeployment:
+			var deployment appsv1.Deployment
+			err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.UnstructuredContent(), &deployment)
+			if nil != err {
+				return nil, err
+			}
+			return pointer.Int(applicationinformers.GetAppReplicas(deployment.Spec.Replicas)), nil
+
+		case constant.KindReplicaSet:
+			var replicaSet appsv1.ReplicaSet
+			err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.UnstructuredContent(), &replicaSet)
+			if nil != err {
+				return nil, err
+			}
+			return pointer.Int(applicationinformers.GetAppReplicas(replicaSet.Spec.Replicas)), nil
+
+		case constant.KindStatefulSet:
+			var statefulSet appsv1.ReplicaSet
+			err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.UnstructuredContent(), &statefulSet)
+			if nil != err {
+				return nil, err
+			}
+			return pointer.Int(applicationinformers.GetAppReplicas(statefulSet.Spec.Replicas)), nil
+
+		case constant.KindDaemonSet:
+			var daemonSet appsv1.DaemonSet
+			err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.UnstructuredContent(), &daemonSet)
+			if nil != err {
+				return nil, err
+			}
+			return pointer.Int(int(daemonSet.Status.DesiredNumberScheduled)), nil
+
+		case constant.KindJob:
+			var job batchv1.Job
+			err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.UnstructuredContent(), &job)
+			if nil != err {
+				return nil, err
+			}
+			return pointer.Int(applicationinformers.CalculateJobPodNum(job.Spec.Parallelism, job.Spec.Completions)), nil
+
+		case constant.KindCronJob:
+			var cronJob batchv1.CronJob
+			err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.UnstructuredContent(), &cronJob)
+			if nil != err {
+				return nil, err
+			}
+			return pointer.Int(applicationinformers.CalculateJobPodNum(cronJob.Spec.JobTemplate.Spec.Parallelism, cronJob.Spec.JobTemplate.Spec.Completions)), nil
+
+		}
+	}
+
+	return nil, nil
 }

--- a/pkg/podmanager/pod_manager_suite_test.go
+++ b/pkg/podmanager/pod_manager_suite_test.go
@@ -4,18 +4,27 @@
 package podmanager_test
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	kruiseapi "github.com/openkruise/kruise-api"
+	kruisev1 "github.com/openkruise/kruise-api/apps/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/spidernet-io/spiderpool/pkg/constant"
 	"github.com/spidernet-io/spiderpool/pkg/podmanager"
 )
 
@@ -23,7 +32,112 @@ var scheme *runtime.Scheme
 var fakeClient client.Client
 var tracker k8stesting.ObjectTracker
 var fakeAPIReader client.Reader
+var fakeDynamicClient *dynamicfake.FakeDynamicClient
 var podManager podmanager.PodManager
+
+const (
+	testNamespace = "testns"
+	testName      = "testname"
+)
+
+var (
+	cloneSet = &kruisev1.CloneSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "CloneSet",
+			APIVersion: kruisev1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: testNamespace,
+		},
+	}
+
+	orphanReplicaSet = &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: testNamespace,
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Replicas: pointer.Int32(2),
+		},
+	}
+
+	replicaSet, deployment = func() (*appsv1.ReplicaSet, *appsv1.Deployment) {
+		tmpReplicaSet := &appsv1.ReplicaSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-1", testName),
+				Namespace: testNamespace,
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion:         appsv1.SchemeGroupVersion.String(),
+					Kind:               constant.KindDeployment,
+					Name:               testName,
+					BlockOwnerDeletion: pointer.Bool(true),
+					Controller:         pointer.Bool(true),
+				}},
+			},
+			Spec: appsv1.ReplicaSetSpec{
+				Replicas: pointer.Int32(2),
+			},
+		}
+		tmpDeployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testName,
+				Namespace: testNamespace,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: pointer.Int32(2),
+			},
+		}
+		return tmpReplicaSet, tmpDeployment
+	}()
+
+	statefulSet = &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: testNamespace,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: pointer.Int32(2),
+		},
+	}
+
+	daemonSet = &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: testNamespace,
+		},
+	}
+
+	orphanJob = &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: testNamespace,
+		},
+	}
+
+	job, cronJob = func() (*batchv1.Job, *batchv1.CronJob) {
+		tmpJob := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-1", testName),
+				Namespace: testNamespace,
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion:         batchv1.SchemeGroupVersion.String(),
+					Kind:               constant.KindCronJob,
+					Name:               testName,
+					BlockOwnerDeletion: pointer.Bool(true),
+					Controller:         pointer.Bool(true),
+				}},
+			},
+		}
+		tmpCronJob := &batchv1.CronJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testName,
+				Namespace: testNamespace,
+			},
+		}
+		return tmpJob, tmpCronJob
+	}()
+)
 
 func TestPodManager(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -32,7 +146,9 @@ func TestPodManager(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	scheme = runtime.NewScheme()
-	err := corev1.AddToScheme(scheme)
+	err := clientgoscheme.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = kruiseapi.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	fakeClient = fake.NewClientBuilder().
@@ -53,9 +169,15 @@ var _ = BeforeSuite(func() {
 		}).
 		Build()
 
+	fakeDynamicClient = dynamicfake.NewSimpleDynamicClient(scheme,
+		cloneSet, orphanReplicaSet, replicaSet, deployment, statefulSet, daemonSet,
+		orphanJob, job, cronJob,
+	)
+
 	podManager, err = podmanager.NewPodManager(
 		fakeClient,
 		fakeAPIReader,
+		fakeDynamicClient,
 	)
 	Expect(err).NotTo(HaveOccurred())
 })

--- a/pkg/podmanager/pod_manager_test.go
+++ b/pkg/podmanager/pod_manager_test.go
@@ -11,19 +11,17 @@ import (
 	"github.com/agiledragon/gomonkey/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	kruiseapi "github.com/openkruise/kruise-api"
 	kruisev1 "github.com/openkruise/kruise-api/apps/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/pointer"
-	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/spidernet-io/spiderpool/pkg/applicationcontroller/applicationinformers"
 	"github.com/spidernet-io/spiderpool/pkg/constant"
 	"github.com/spidernet-io/spiderpool/pkg/podmanager"
 )
@@ -31,13 +29,19 @@ import (
 var _ = Describe("PodManager", Label("pod_manager_test"), func() {
 	Describe("New PodManager", func() {
 		It("inputs nil client", func() {
-			manager, err := podmanager.NewPodManager(nil, fakeAPIReader)
+			manager, err := podmanager.NewPodManager(nil, fakeAPIReader, fakeDynamicClient)
 			Expect(err).To(MatchError(constant.ErrMissingRequiredParam))
 			Expect(manager).To(BeNil())
 		})
 
 		It("inputs nil API reader", func() {
-			manager, err := podmanager.NewPodManager(fakeClient, nil)
+			manager, err := podmanager.NewPodManager(fakeClient, nil, fakeDynamicClient)
+			Expect(err).To(MatchError(constant.ErrMissingRequiredParam))
+			Expect(manager).To(BeNil())
+		})
+
+		It("inputs nil Dynamic client", func() {
+			manager, err := podmanager.NewPodManager(fakeClient, fakeAPIReader, nil)
 			Expect(err).To(MatchError(constant.ErrMissingRequiredParam))
 			Expect(manager).To(BeNil())
 		})
@@ -56,7 +60,7 @@ var _ = Describe("PodManager", Label("pod_manager_test"), func() {
 			ctx = context.TODO()
 
 			atomic.AddUint64(&count, 1)
-			namespace = "default"
+			namespace = testNamespace
 			podName = fmt.Sprintf("pod-%v", count)
 			labels = map[string]string{"foo": fmt.Sprintf("bar-%v", count)}
 			podT = &corev1.Pod{
@@ -237,177 +241,40 @@ var _ = Describe("PodManager", Label("pod_manager_test"), func() {
 			})
 
 			It("Pod with third-party controller", func() {
-				err := kruiseapi.AddToScheme(scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				cloneSet := &kruisev1.CloneSet{}
-				err = controllerutil.SetControllerReference(cloneSet, podT, scheme)
+				err := controllerutil.SetControllerReference(cloneSet, podT, scheme)
 				Expect(err).NotTo(HaveOccurred())
 
 				podTopController, err := podManager.GetPodTopController(ctx, podT)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(slices.Contains(constant.K8sKinds, podTopController.Kind)).To(BeFalse())
+				Expect(podTopController.APIVersion).To(Equal(kruisev1.GroupVersion.String()))
+				Expect(podTopController.Kind).To(Equal("CloneSet"))
+				Expect(podTopController.Replicas).To(BeNil())
 			})
 
 			It("Pod with ReplicaSet controller", func() {
-				err := appsv1.AddToScheme(scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				replicaSet := &appsv1.ReplicaSet{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      podName,
-						Namespace: namespace,
-					},
-				}
-				err = fakeClient.Create(ctx, replicaSet)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = controllerutil.SetControllerReference(replicaSet, podT, scheme)
+				err := controllerutil.SetControllerReference(orphanReplicaSet, podT, scheme)
 				Expect(err).NotTo(HaveOccurred())
 
 				podTopController, err := podManager.GetPodTopController(ctx, podT)
 				Expect(err).NotTo(HaveOccurred())
+				Expect(podTopController.APIVersion).Should(Equal(appsv1.SchemeGroupVersion.String()))
 				Expect(podTopController.Kind).Should(Equal(constant.KindReplicaSet))
-			})
-
-			It("Failed to fetch ReplicaSet controller of Pod", func() {
-				methodReturn := gomonkey.ApplyMethodReturn(fakeClient, "Get", constant.ErrUnknown)
-				defer methodReturn.Reset()
-
-				err := appsv1.AddToScheme(scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				replicaSet := &appsv1.ReplicaSet{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      podName,
-						Namespace: namespace,
-					},
-				}
-				err = fakeClient.Create(ctx, replicaSet)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = controllerutil.SetControllerReference(replicaSet, podT, scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				_, err = podManager.GetPodTopController(ctx, podT)
-				Expect(err).To(HaveOccurred())
+				Expect(*podTopController.Replicas).To(Equal(int(*orphanReplicaSet.Spec.Replicas)))
 			})
 
 			It("Pod with Deployment controller", func() {
-				err := appsv1.AddToScheme(scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				replicaSet := &appsv1.ReplicaSet{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      podName,
-						Namespace: namespace,
-					},
-				}
-
-				deployment := &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      podName,
-						Namespace: namespace,
-					},
-				}
-
-				err = controllerutil.SetControllerReference(deployment, replicaSet, scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = controllerutil.SetControllerReference(replicaSet, podT, scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = fakeClient.Create(ctx, replicaSet)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = fakeClient.Create(ctx, deployment)
+				err := controllerutil.SetControllerReference(replicaSet, podT, scheme)
 				Expect(err).NotTo(HaveOccurred())
 
 				podTopController, err := podManager.GetPodTopController(ctx, podT)
 				Expect(err).NotTo(HaveOccurred())
+				Expect(podTopController.APIVersion).Should(Equal(appsv1.SchemeGroupVersion.String()))
 				Expect(podTopController.Kind).Should(Equal(constant.KindDeployment))
-			})
-
-			It("Failed to fetch Deployment controller of Pod", func() {
-				err := appsv1.AddToScheme(scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				replicaSet := &appsv1.ReplicaSet{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      podName,
-						Namespace: namespace,
-					},
-				}
-
-				deployment := &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      podName,
-						Namespace: namespace,
-					},
-				}
-
-				err = controllerutil.SetControllerReference(deployment, replicaSet, scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = controllerutil.SetControllerReference(replicaSet, podT, scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = fakeClient.Create(ctx, replicaSet)
-				Expect(err).NotTo(HaveOccurred())
-
-				_, err = podManager.GetPodTopController(ctx, podT)
-				Expect(err).To(HaveOccurred())
-			})
-
-			It("Third-party controller controls ReplicaSet", func() {
-				err := kruiseapi.AddToScheme(scheme)
-				Expect(err).NotTo(HaveOccurred())
-				err = appsv1.AddToScheme(scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				replicaSet := &appsv1.ReplicaSet{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      podName,
-						Namespace: namespace,
-					},
-				}
-				cloneSet := &kruisev1.CloneSet{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      podName,
-						Namespace: namespace,
-					},
-				}
-				err = controllerutil.SetControllerReference(replicaSet, podT, scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = controllerutil.SetControllerReference(cloneSet, replicaSet, scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = fakeClient.Create(ctx, replicaSet)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = fakeClient.Create(ctx, cloneSet)
-				Expect(err).NotTo(HaveOccurred())
-
-				podTopController, err := podManager.GetPodTopController(ctx, podT)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(slices.Contains(constant.K8sKinds, podTopController.Kind)).To(BeFalse())
+				Expect(*podTopController.Replicas).To(Equal(int(*deployment.Spec.Replicas)))
 			})
 
 			It("Pod with Job controller", func() {
-				err := batchv1.AddToScheme(scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				job := &batchv1.Job{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      podName,
-						Namespace: namespace,
-					},
-				}
-				err = fakeClient.Create(ctx, job)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = controllerutil.SetControllerReference(job, podT, scheme)
+				err := controllerutil.SetControllerReference(orphanJob, podT, scheme)
 				Expect(err).NotTo(HaveOccurred())
 
 				podTopController, err := podManager.GetPodTopController(ctx, podT)
@@ -415,85 +282,8 @@ var _ = Describe("PodManager", Label("pod_manager_test"), func() {
 				Expect(podTopController.Kind).Should(Equal(constant.KindJob))
 			})
 
-			It("Failed to fetch Job controller of Pod", func() {
-				err := batchv1.AddToScheme(scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				job := &batchv1.Job{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      podName,
-						Namespace: namespace,
-					},
-				}
-				err = controllerutil.SetControllerReference(job, podT, scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				_, err = podManager.GetPodTopController(ctx, podT)
-				Expect(err).To(HaveOccurred())
-			})
-
-			It("Third-party controller controls Job", func() {
-				err := kruiseapi.AddToScheme(scheme)
-				Expect(err).NotTo(HaveOccurred())
-				err = batchv1.AddToScheme(scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				job := &batchv1.Job{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      podName,
-						Namespace: namespace,
-					},
-				}
-				cloneSet := &kruisev1.CloneSet{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      podName,
-						Namespace: namespace,
-					},
-				}
-				err = controllerutil.SetControllerReference(job, podT, scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = controllerutil.SetControllerReference(cloneSet, job, scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = fakeClient.Create(ctx, job)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = fakeClient.Create(ctx, cloneSet)
-				Expect(err).NotTo(HaveOccurred())
-
-				podTopController, err := podManager.GetPodTopController(ctx, podT)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(slices.Contains(constant.K8sKinds, podTopController.Kind)).To(BeFalse())
-			})
-
 			It("Pod with CronJob controller", func() {
-				err := batchv1.AddToScheme(scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				job := &batchv1.Job{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      podName,
-						Namespace: namespace,
-					},
-				}
-
-				cronJob := &batchv1.CronJob{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      podName,
-						Namespace: namespace,
-					},
-				}
-				err = controllerutil.SetControllerReference(cronJob, job, scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = controllerutil.SetControllerReference(job, podT, scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = fakeClient.Create(ctx, cronJob)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = fakeClient.Create(ctx, job)
+				err := controllerutil.SetControllerReference(job, podT, scheme)
 				Expect(err).NotTo(HaveOccurred())
 
 				podTopController, err := podManager.GetPodTopController(ctx, podT)
@@ -501,50 +291,8 @@ var _ = Describe("PodManager", Label("pod_manager_test"), func() {
 				Expect(podTopController.Kind).Should(Equal(constant.KindCronJob))
 			})
 
-			It("Failed to fetch CronJob controller of Pod", func() {
-				err := batchv1.AddToScheme(scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				job := &batchv1.Job{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      podName,
-						Namespace: namespace,
-					},
-				}
-
-				cronJob := &batchv1.CronJob{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      podName,
-						Namespace: namespace,
-					},
-				}
-				err = controllerutil.SetControllerReference(cronJob, job, scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = controllerutil.SetControllerReference(job, podT, scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = fakeClient.Create(ctx, job)
-				Expect(err).NotTo(HaveOccurred())
-
-				_, err = podManager.GetPodTopController(ctx, podT)
-				Expect(err).To(HaveOccurred())
-			})
-
 			It("Pod with DaemonSet controller", func() {
-				err := appsv1.AddToScheme(scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				daemonSet := &appsv1.DaemonSet{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      podName,
-						Namespace: namespace,
-					},
-				}
-				err = fakeClient.Create(ctx, daemonSet)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = controllerutil.SetControllerReference(daemonSet, podT, scheme)
+				err := controllerutil.SetControllerReference(daemonSet, podT, scheme)
 				Expect(err).NotTo(HaveOccurred())
 
 				podTopController, err := podManager.GetPodTopController(ctx, podT)
@@ -552,37 +300,8 @@ var _ = Describe("PodManager", Label("pod_manager_test"), func() {
 				Expect(podTopController.Kind).Should(Equal(constant.KindDaemonSet))
 			})
 
-			It("Failed to fetch DaemonSet controller of Pod", func() {
-				err := appsv1.AddToScheme(scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				daemonSet := &appsv1.DaemonSet{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      podName,
-						Namespace: namespace,
-					},
-				}
-				err = controllerutil.SetControllerReference(daemonSet, podT, scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				_, err = podManager.GetPodTopController(ctx, podT)
-				Expect(err).To(HaveOccurred())
-			})
-
 			It("Pod with StatefulSet controller", func() {
-				err := appsv1.AddToScheme(scheme)
-				Expect(err).NotTo(HaveOccurred())
-
-				statefulSet := &appsv1.StatefulSet{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      podName,
-						Namespace: namespace,
-					},
-				}
-				err = fakeClient.Create(ctx, statefulSet)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = controllerutil.SetControllerReference(statefulSet, podT, scheme)
+				err := controllerutil.SetControllerReference(statefulSet, podT, scheme)
 				Expect(err).NotTo(HaveOccurred())
 
 				podTopController, err := podManager.GetPodTopController(ctx, podT)
@@ -590,21 +309,16 @@ var _ = Describe("PodManager", Label("pod_manager_test"), func() {
 				Expect(podTopController.Kind).Should(Equal(constant.KindStatefulSet))
 			})
 
-			It("Failed to fetch StatefulSet controller of Pod", func() {
-				err := appsv1.AddToScheme(scheme)
+			It("Failed to call GetPodTopController with GVR failed", func() {
+				err := controllerutil.SetControllerReference(orphanReplicaSet, podT, scheme)
 				Expect(err).NotTo(HaveOccurred())
 
-				statefulSet := &appsv1.StatefulSet{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      podName,
-						Namespace: namespace,
-					},
-				}
-				err = controllerutil.SetControllerReference(statefulSet, podT, scheme)
-				Expect(err).NotTo(HaveOccurred())
+				patch := gomonkey.ApplyFuncReturn(applicationinformers.GenerateGVR, schema.GroupVersionResource{}, constant.ErrUnknown)
+				defer patch.Reset()
 
 				_, err = podManager.GetPodTopController(ctx, podT)
 				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(constant.ErrUnknown))
 			})
 		})
 	})

--- a/pkg/subnetmanager/subnet_informer.go
+++ b/pkg/subnetmanager/subnet_informer.go
@@ -599,7 +599,7 @@ func (sc *SubnetController) removeFinalizer(ctx context.Context, subnet *spiderp
 func (sc *SubnetController) monitorThirdController(ctx context.Context, appNamespacedName spiderpooltypes.AppNamespacedName) error {
 	log := logutils.FromContext(ctx)
 
-	gvr, err := applicationinformers.GenerateGVR(appNamespacedName)
+	gvr, err := applicationinformers.GenerateGVR(appNamespacedName.APIVersion, appNamespacedName.Kind)
 	if nil != err {
 		return err
 	}

--- a/pkg/types/k8s.go
+++ b/pkg/types/k8s.go
@@ -24,8 +24,9 @@ type AppNamespacedName struct {
 
 type PodTopController struct {
 	AppNamespacedName
-	UID apitypes.UID
-	APP metav1.Object
+	UID      apitypes.UID
+	APP      metav1.Object
+	Replicas *int
 }
 
 type AnnoPodIPPoolValue struct {


### PR DESCRIPTION
In the past, the `GetTopController` method of PodManager is try to get a Pod top controller. But it implements not very well. For example, if a Third-party controller controls a StatefulSet, and the StatefulSet controls the pod, unfortunately it only searches the StatefulSet and ignores the third-party controller. And the SpiderSubnet feature counts on this Method.

this issue may influence on auto fixed IP of subnet feature for non-native controller

So I refactor it.

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)

What this PR does / why we need it:
fix bug

Which issue(s) this PR fixes:
close #2349 
