### PR TITLE
improve GetTopController method

### DIFF
--- a/pkg/applicationcontroller/app_controller.go
+++ b/pkg/applicationcontroller/app_controller.go
@@ -228,13 +228,6 @@ func (sac *SubnetAppController) controllerAddOrUpdateHandler() applicationinform
 				return nil
 			}
 
-			// check the app whether is the top controller or not
-			owner := metav1.GetControllerOf(newObject)
-			if owner != nil {
-				log.Sugar().Debugf("app has a owner '%s/%s', we would not create or scale IPPool for it", owner.Kind, owner.Name)
-				return nil
-			}
-
 			newAppReplicas = applicationinformers.GetAppReplicas(newObject.Spec.Replicas)
 			newSubnetConfig, err = applicationinformers.GetSubnetAnnoConfig(newObject.Spec.Template.Annotations, log)
 			if nil != err {
@@ -270,7 +263,7 @@ func (sac *SubnetAppController) controllerAddOrUpdateHandler() applicationinform
 
 			// check the app whether is the top controller or not
 			owner := metav1.GetControllerOf(newObject)
-			if owner != nil {
+			if owner != nil && owner.APIVersion == appsv1.SchemeGroupVersion.String() && owner.Kind == constant.KindDeployment {
 				log.Sugar().Debugf("app has a owner '%s/%s', we would not create or scale IPPool for it", owner.Kind, owner.Name)
 				return nil
 			}
@@ -305,13 +298,6 @@ func (sac *SubnetAppController) controllerAddOrUpdateHandler() applicationinform
 			// no need reconcile for HostNetwork application
 			if newObject.Spec.Template.Spec.HostNetwork {
 				log.Debug("HostNetwork mode, we would not create or scale IPPool for it")
-				return nil
-			}
-
-			// check the app whether is the top controller or not
-			owner := metav1.GetControllerOf(newObject)
-			if owner != nil {
-				log.Sugar().Debugf("app has a owner '%s/%s', we would not create or scale IPPool for it", owner.Kind, owner.Name)
 				return nil
 			}
 
@@ -350,7 +336,7 @@ func (sac *SubnetAppController) controllerAddOrUpdateHandler() applicationinform
 
 			// check the app whether is the top controller or not
 			owner := metav1.GetControllerOf(newObject)
-			if owner != nil {
+			if owner != nil && owner.APIVersion == batchv1.SchemeGroupVersion.String() && owner.Kind == constant.KindCronJob {
 				log.Sugar().Debugf("app has a owner '%s/%s', we would not create or scale IPPool for it", owner.Kind, owner.Name)
 				return nil
 			}
@@ -388,13 +374,6 @@ func (sac *SubnetAppController) controllerAddOrUpdateHandler() applicationinform
 				return nil
 			}
 
-			// check the app whether is the top controller or not
-			owner := metav1.GetControllerOf(newObject)
-			if owner != nil {
-				log.Sugar().Debugf("app has a owner '%s/%s', we would not create or scale IPPool for it", owner.Kind, owner.Name)
-				return nil
-			}
-
 			newAppReplicas = applicationinformers.CalculateJobPodNum(newObject.Spec.JobTemplate.Spec.Parallelism, newObject.Spec.JobTemplate.Spec.Completions)
 			newSubnetConfig, err = applicationinformers.GetSubnetAnnoConfig(newObject.Spec.JobTemplate.Spec.Template.Annotations, log)
 			if nil != err {
@@ -425,13 +404,6 @@ func (sac *SubnetAppController) controllerAddOrUpdateHandler() applicationinform
 			// no need reconcile for HostNetwork application
 			if newObject.Spec.Template.Spec.HostNetwork {
 				log.Debug("HostNetwork mode, we would not create or scale IPPool for it")
-				return nil
-			}
-
-			// check the app whether is the top controller or not
-			owner := metav1.GetControllerOf(newObject)
-			if owner != nil {
-				log.Sugar().Debugf("app has a owner '%s/%s', we would not create or scale IPPool for it", owner.Kind, owner.Name)
 				return nil
 			}
 

--- a/pkg/applicationcontroller/app_controller_test.go
+++ b/pkg/applicationcontroller/app_controller_test.go
@@ -560,8 +560,15 @@ var _ = Describe("AppController", Label("app_controller_test"), func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			It("the replicaSet has owner", func() {
+			It("the replicaSet has third-party controller owner", func() {
 				err := controllerutil.SetControllerReference(cloneSet, replicaSet1, scheme)
+				Expect(err).NotTo(HaveOccurred())
+				err = reconcileFunc(ctx, nil, replicaSet1)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("the replicaSet has deployment controller owner", func() {
+				err := controllerutil.SetControllerReference(deployment1, replicaSet1, scheme)
 				Expect(err).NotTo(HaveOccurred())
 				err = reconcileFunc(ctx, nil, replicaSet1)
 				Expect(err).NotTo(HaveOccurred())
@@ -680,8 +687,15 @@ var _ = Describe("AppController", Label("app_controller_test"), func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			It("the job has owner", func() {
+			It("the job has third-party controller owner", func() {
 				err := controllerutil.SetControllerReference(cloneSet, job1, scheme)
+				Expect(err).NotTo(HaveOccurred())
+				err = reconcileFunc(ctx, nil, job1)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("the job has cronJob controller owner", func() {
+				err := controllerutil.SetControllerReference(cronJob1, job1, scheme)
 				Expect(err).NotTo(HaveOccurred())
 				err = reconcileFunc(ctx, nil, job1)
 				Expect(err).NotTo(HaveOccurred())
@@ -728,6 +742,12 @@ var _ = Describe("AppController", Label("app_controller_test"), func() {
 			})
 		})
 
+		Context("unrecognized controller", func() {
+			It("do not support third-party controller", func() {
+				err := reconcileFunc(ctx, nil, cloneSet)
+				Expect(err).To(HaveOccurred())
+			})
+		})
 	})
 
 	Describe("test application delete event hook handler", func() {
@@ -828,6 +848,12 @@ var _ = Describe("AppController", Label("app_controller_test"), func() {
 			})
 		})
 
+		Context("unrecognized controller", func() {
+			It("do not support third-party controller", func() {
+				err := cleanupFunc(ctx, cloneSet)
+				Expect(err).To(HaveOccurred())
+			})
+		})
 	})
 
 	Describe("test deleteAutoPools", func() {

--- a/pkg/applicationcontroller/applicationcontroller_suite_test.go
+++ b/pkg/applicationcontroller/applicationcontroller_suite_test.go
@@ -12,6 +12,7 @@ import (
 
 	kruiseapi "github.com/openkruise/kruise-api"
 	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -40,7 +41,9 @@ type subnetApplicationController struct {
 
 var _ = BeforeSuite(func() {
 	scheme = runtime.NewScheme()
-	err := spiderpoolv2beta1.AddToScheme(scheme)
+	err := clientgoscheme.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = spiderpoolv2beta1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 	err = kruiseapi.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())

--- a/pkg/podmanager/pod_manager_test.go
+++ b/pkg/podmanager/pod_manager_test.go
@@ -391,7 +391,7 @@ var _ = Describe("PodManager", Label("pod_manager_test"), func() {
 
 				podTopController, err := podManager.GetPodTopController(ctx, podT)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(slices.Contains(constant.K8sKinds, podTopController.Kind)).To(BeFalse())
+				Expect(podTopController.Kind).Should(Equal(constant.KindReplicaSet))
 			})
 
 			It("Pod with Job controller", func() {
@@ -464,7 +464,7 @@ var _ = Describe("PodManager", Label("pod_manager_test"), func() {
 
 				podTopController, err := podManager.GetPodTopController(ctx, podT)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(slices.Contains(constant.K8sKinds, podTopController.Kind)).To(BeFalse())
+				Expect(podTopController.Kind).Should(Equal(constant.KindJob))
 			})
 
 			It("Pod with CronJob controller", func() {


### PR DESCRIPTION
In the SpiderSubnet feature, I noticed a situation that spiderpool can't handle with it well.
The RedisCluster -> StatefulSet -> Pod. If we set SpiderSubnet auto pool annotations for it, the pod would not up successfully. With what #2349  describes.

All in all, the `GetTopController` method need to be improved. So I commit a PR #2347 
But I noticed that in the RedisCluster situation, the pod will lose the StatefulSet static IP feature. So I abandon that PR.

Finally, I made a decision. If a third-party controller controls the pod directly, I'll regard the third-party controller is the top controller no matter any other controllers controls the third-party controller.
And If some third-party controller controls the native kubernetes controller like StatefulSet (RedisCluster situation), I'll regard the StatefulSet is the pod's top controller.

With this, the pod will inherit the StatefulSet pod static IP feature and be able to use SpiderSubnet feature auto pool dynamic IP numbers feature.(In the past, the third-party controller use the auto-pool must in fixed IP number).


Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)


**What this PR does / why we need it**:
fix bug

**Which issue(s) this PR fixes**:
close #2349 
