### PR TITLE
optimize github action no disk space left

### DIFF
--- a/.github/workflows/e2e-init.yaml
+++ b/.github/workflows/e2e-init.yaml
@@ -42,6 +42,16 @@ jobs:
           - e2e_init_mode: e2e_init_cilium
             e2e_test_mode: e2e_test_cilium
     steps:
+      - name: Free disk space
+        # https://github.com/actions/virtual-environments/issues/709
+        run: |
+          echo "=========original CI disk space"
+          df -h
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          echo "=========after clean up, the left CI disk space"
+          df -h
+
       - name: Prepare
         id: prepare
         run: |


### PR DESCRIPTION
The github action fails with
```text
debugEnv.sh : E2E_KUBECONFIG /home/runner/work/spiderpool/spiderpool/test/.cluster/spiderpool1009142437/.kube/config 
output debug information to /home/runner/work/spiderpool/spiderpool/test/e2edebugLog.txt
Failed to compile affinity:

# k8s.io/client-go/informers/core
compile: writing output: write $WORK/b907/_pkg_.a: no space left on device
k8s.io/client-go/listers/events/v1: mkdir /tmp/go-build580983046/b917/: no space left on device
k8s.io/client-go/listers/events/v1beta1: mkdir /tmp/go-build580983046/b919/: no space left on device
k8s.io/client-go/listers/extensions/v1beta1: mkdir /tmp/go-build580983046/b922/: no space left on device
k8s.io/client-go/listers/flowcontrol/v1alpha1: mkdir /tmp/go-build580983046/b925/: no space left on device
k8s.io/client-go/listers/flowcontrol/v1beta1: mkdir /tmp/go-build580983046/b927/: no space left on device
```

Reference: https://github.com/actions/runner-images/issues/709

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)

**What this PR does / why we need it**:
fix CI bug

**Which issue(s) this PR fixes**:
close #2393 


