### PR TITLE
add kubernetes 1.28 version support to e2e

### DIFF
--- a/.github/workflows/auto-diff-k8s-ci.yaml
+++ b/.github/workflows/auto-diff-k8s-ci.yaml
@@ -114,7 +114,7 @@ jobs:
       fail-fast: false
       matrix:
         # Synchronise with the latest releases of each version
-        version: [v1.22.7, v1.23.5, v1.24.4, v1.25.3, v1.26.2, v1.27.1]
+        version: [v1.22.7, v1.23.5, v1.24.4, v1.25.3, v1.26.2, v1.27.1, v1.28.0]
     needs: [call_build_ci_image, get_ref, call_release_chart]
     uses: ./.github/workflows/e2e-init.yaml
     with:


### PR DESCRIPTION
**What this PR does / why we need it**:
add kubernetes 1.28 version support to e2e

**Which issue(s) this PR fixes**:
```
NONE
```

**make sure your commit is signed off**
Signed-off-by: ty-dc [tao.yang@daocloud.io](mailto:tao.yang@daocloud.io)