### PR TITLE
Fix ci calling release-chart error

### DIFF
--- a/.github/workflows/auto-version-release.yaml
+++ b/.github/workflows/auto-version-release.yaml
@@ -100,6 +100,7 @@ jobs:
     uses: ./.github/workflows/call-release-chart.yaml
     with:
       ref: ${{ needs.get-tag.outputs.tag }}
+      submit: true
     secrets: inherit
 
   release-doc:

--- a/.github/workflows/call-release-chart.yaml
+++ b/.github/workflows/call-release-chart.yaml
@@ -17,6 +17,9 @@ on:
       ref:
         required: true
         type: string
+      submit:
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       ref:
@@ -31,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       ref: ${{ steps.get_original_ref.outputs.ref }}
+      submit: ${{ steps.get_original_ref.outputs.submit }}
     steps:
       - name: Get Original Ref
         id: get_original_ref
@@ -39,10 +43,12 @@ jobs:
               echo "call by workflow_call"
               ver=${{ inputs.ref }}
               echo ::set-output name=ref::${ver}
+              echo ::set-output name=submit::${{ inputs.submit }}
           elif ${{ github.event_name == 'workflow_dispatch' }} ; then
               echo "call by self workflow_dispatch"
               ver=${{ github.event.inputs.ref }}
               echo ::set-output name=ref::${ver}
+              echo ::set-output name=submit::true
           else
               echo "unexpected event: ${{ github.event_name }}"
               exit 1
@@ -90,6 +96,7 @@ jobs:
   update_githubpage:
     runs-on: ubuntu-latest
     needs: [package_chart, get_ref]
+    if: ${{ needs.get_ref.outputs.submit == 'true' }}
     steps:
       - name: Get Base Chart URL
         id: get_base_url


### PR DESCRIPTION
**What this PR does / why we need it**:
There will be a release-chart operation in ci, but we don't want ci to update the chart every time. The field `submit` is required for control.

**Which issue(s) this PR fixes**:

**make sure your commit is signed off**
Signed-off-by: ty-dc [tao.yang@daocloud.io](mailto:tao.yang@daocloud.io)