### PR TITLE
coordinator: netlink default dst is zero address while not nil

### DIFF
--- a/cmd/coordinator/cmd/utils.go
+++ b/cmd/coordinator/cmd/utils.go
@@ -429,7 +429,11 @@ func (c *coordinator) tunePodRoutes(logger *zap.Logger, configDefaultRouteNIC st
 
 		if configDefaultRouteNIC == c.currentInterface {
 			for idx, route := range defaultInterfaceRoutes {
-				if route.Dst != nil {
+				zeroIPAddress := net.IPv4zero
+				if defaultInterfaceRoutes[idx].Family == netlink.FAMILY_V6 {
+					zeroIPAddress = net.IPv6zero
+				}
+				if route.Dst != nil || !route.Dst.IP.Equal(zeroIPAddress) {
 					if err := networking.AddToRuleTable(defaultInterfaceRoutes[idx].Dst, c.currentRuleTable); err != nil {
 						logger.Error("failed to AddToRuleTable", zap.Error(err))
 						return fmt.Errorf("failed to AddToRuleTable: %v", err)
@@ -453,7 +457,11 @@ func (c *coordinator) tunePodRoutes(logger *zap.Logger, configDefaultRouteNIC st
 
 		} else if configDefaultRouteNIC == podDefaultRouteNIC {
 			for idx, route := range currentInterfaceRoutes {
-				if route.Dst != nil {
+				zeroIPAddress := net.IPv4zero
+				if defaultInterfaceRoutes[idx].Family == netlink.FAMILY_V6 {
+					zeroIPAddress = net.IPv6zero
+				}
+				if route.Dst != nil || !route.Dst.IP.Equal(zeroIPAddress) {
 					if err := networking.AddToRuleTable(currentInterfaceRoutes[idx].Dst, c.currentRuleTable); err != nil {
 						logger.Error("failed to AddToRuleTable", zap.Error(err))
 						return fmt.Errorf("failed to AddToRuleTable: %v", err)

--- a/test/doc/coordinator.md
+++ b/test/doc/coordinator.md
@@ -6,8 +6,8 @@
 | C00002  | coordinator in tuneMode: overlay works well | p1      |  smoke  | done   |       |
 | C00003  | coordinator in tuneMode: underlay with two NIC | p1      |  smoke  |    |       |
 | C00004  | coordinator in tuneMode: overlay with two  NIC | p1      |  smoke  |    |       |
-| C00005  | In overlay mode: specify the NIC where the default route is located | p2     |    |  done  |       |
-| C00006  | In underlay mode: specify the NIC where the default route is located | p2     |    |       |       |
+| C00005  | In overlay mode: specify the NIC where the default route is located, use 'ip r get 8.8.8.8' to see if default route nic is the specify NIC | p2     |    |  done  |       |
+| C00006  | In underlay mode: specify the NIC where the default route is located, use 'ip r get 8.8.8.8' to see if default route nic is the specify NIC | p2     |    |       |       |
 | C00007  | ip conflict detection (ipv4, ipv6) | p2     |    |  done  |       |
 | C00008  | override pod mac prefix | p2       |       | done  |       |
 | C00009  | gateway connection detection                  | p2     |    |  done  |       |


### PR DESCRIPTION
---
name: Pull request
about: Tell us about your contribution
labels: ["pr/release/none-required"]
---

---
## Thanks for contributing !

Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/contributing/development/pullrequest/#need-review>

**What this PR does / why we need it**:

This is the bug caused by merging  https://github.com/spidernet-io/spiderpool/pull/2332, In latest netlink, For netlink.RouteList function, we can't check the route.dst == nil to determine if it is the default route or not. Now if it is the default route, its route.Dst is no longer nil, but an empty address.

This causes an additional policy routing table in the pod when the coordinator is running in overlay mode, resulting in a communication issue.


```
root@macvlan-app-hrjfg:/# ip rule
0:	from all lookup local
32763:	from 172.51.0.130 lookup 100
32764:	from all to 172.51.0.0/16 lookup 100
32765:	from all lookup 100
32766:	from all lookup main
32767:	from all lookup default
root@macvlan-app-hrjfg:/#
```

**Which issue(s) this PR fixes**:

https://github.com/spidernet-io/spiderpool/issues/2415

**Special notes for your reviewer**:

**make sure your commit is signed off**
