### PR TITLE
Add and improve the e2e use case of the NIC where the default route is located

### DIFF
--- a/cmd/coordinator/cmd/utils.go
+++ b/cmd/coordinator/cmd/utils.go
@@ -429,7 +429,11 @@ func (c *coordinator) tunePodRoutes(logger *zap.Logger, configDefaultRouteNIC st
 
 		if configDefaultRouteNIC == c.currentInterface {
 			for idx, route := range defaultInterfaceRoutes {
-				if route.Dst != nil {
+				zeroIPAddress := net.IPv4zero
+				if defaultInterfaceRoutes[idx].Family == netlink.FAMILY_V6 {
+					zeroIPAddress = net.IPv6zero
+				}
+				if !route.Dst.IP.Equal(zeroIPAddress) {
 					if err := networking.AddToRuleTable(defaultInterfaceRoutes[idx].Dst, c.currentRuleTable); err != nil {
 						logger.Error("failed to AddToRuleTable", zap.Error(err))
 						return fmt.Errorf("failed to AddToRuleTable: %v", err)
@@ -453,7 +457,11 @@ func (c *coordinator) tunePodRoutes(logger *zap.Logger, configDefaultRouteNIC st
 
 		} else if configDefaultRouteNIC == podDefaultRouteNIC {
 			for idx, route := range currentInterfaceRoutes {
-				if route.Dst != nil {
+				zeroIPAddress := net.IPv4zero
+				if defaultInterfaceRoutes[idx].Family == netlink.FAMILY_V6 {
+					zeroIPAddress = net.IPv6zero
+				}
+				if !route.Dst.IP.Equal(zeroIPAddress) {
 					if err := networking.AddToRuleTable(currentInterfaceRoutes[idx].Dst, c.currentRuleTable); err != nil {
 						logger.Error("failed to AddToRuleTable", zap.Error(err))
 						return fmt.Errorf("failed to AddToRuleTable: %v", err)

--- a/test/Makefile
+++ b/test/Makefile
@@ -179,6 +179,15 @@ setup_spiderpool:
 		fi ; \
 		if [ "$(E2E_SPIDERPOOL_ENABLE_COORDINATOR)" == "true" ] ; then \
 		    HELM_OPTION+=" --set coordinator.enabled=true " ; \
+			if [ "$(INSTALL_CILIUM)" == "true" ] ; then \
+				if [ "$(E2E_IP_FAMILY)" == "ipv4" ] ; then \
+			    	HELM_OPTION+=" --set coordinator.hijackCIDR={$(CILIUM_CLUSTER_POD_SUBNET_V4)} " ; \
+				elif [ "$(E2E_IP_FAMILY)" == "ipv6" ] ; then \
+			    	HELM_OPTION+=" --set coordinator.hijackCIDR={$(CILIUM_CLUSTER_POD_SUBNET_V6)} " ; \
+				else \
+					HELM_OPTION+=" --set coordinator.hijackCIDR={$(CILIUM_CLUSTER_POD_SUBNET_V4),$(CILIUM_CLUSTER_POD_SUBNET_V6)} " ; \
+				fi ; \
+			fi ; \
 		else \
 		  	HELM_OPTION+=" --set coordinator.enabled=false " ; \
 		fi ; \

--- a/test/doc/coordinator.md
+++ b/test/doc/coordinator.md
@@ -6,9 +6,10 @@
 | C00002  | coordinator in tuneMode: overlay works well | p1      |  smoke  | done   |       |
 | C00003  | coordinator in tuneMode: underlay with two NIC | p1      |  smoke  |    |       |
 | C00004  | coordinator in tuneMode: overlay with two  NIC | p1      |  smoke  |    |       |
-| C00005  | In overlay mode: specify the NIC where the default route is located | p2     |    |  done  |       |
-| C00006  | In underlay mode: specify the NIC where the default route is located | p2     |    |       |       |
+| C00005  | In overlay mode: specify the NIC (eth0) where the default route is located, use 'ip r get 8.8.8.8' to see if default route nic is the specify NIC | p2     |    |  done  |       |
+| C00006  | In underlay mode: specify the NIC (eth0) where the default route is located, use 'ip r get 8.8.8.8' to see if default route nic is the specify NIC | p2     |    |       |       |
 | C00007  | ip conflict detection (ipv4, ipv6) | p2     |    |  done  |       |
 | C00008  | override pod mac prefix | p2       |       | done  |       |
 | C00009  | gateway connection detection                  | p2     |    |  done  |       |
 | C00010  | auto clean up the dirty rules(routing\neighborhood) while pod starting | p2 | | |
+| C00011  | In the default scenario (Do not specify the NIC where the default route is located in any way) , use 'ip r get 8.8.8.8' to see if default route NIC is `net1` | p2 | | |

--- a/test/e2e/common/constant.go
+++ b/test/e2e/common/constant.go
@@ -42,6 +42,12 @@ const (
 	SpiderPoolConfigmapNameSpace = "kube-system"
 )
 
+// Kubeadm configurations
+const (
+	KubeadmConfigmapName      = "kubeadm-config"
+	KubeadmConfigmapNameSpace = "kube-system"
+)
+
 // Network configurations
 var (
 	// multus CNI


### PR DESCRIPTION
**What this PR does / why we need it**:

- Add and improve the e2e use case of the NIC where the default route is located. Assist in verifying the repair status of the PR #2411 

The changes are as follows:

1. Add a new case. Without setting any annotations or PodDefaultRouteNIC (default situation), the default route should be on net1.

2. Change the existing use case, specify PodDefaultRouteNIC as eth0, and check that the default route should be on eth0

**Which issue(s) this PR fixes**:
```
NONE
```

**make sure your commit is signed off**
Signed-off-by: ty-dc [tao.yang@daocloud.io](mailto:tao.yang@daocloud.io)
