### PR TITLE
e2e: add nodeName affinity e2e for spiderpool

### DIFF
--- a/test/doc/ippoolcr.md
+++ b/test/doc/ippoolcr.md
@@ -12,8 +12,8 @@
 | D00008  | Manually ippool inherits subnet attributes (including routes, vlanId, etc.) | p3      |       |     |       |
 | D00009  | multusName matches, IP can be assigned                | p2      |       |   done  |       |
 | D00010  | multusName mismatch, unable to assign IP              | p3      |       |   done  |       |
-| D00011  | The node where the pod is located matches the nodeName, and the IP can be assigned  | p2      |       |     |       |
-| D00012  | The node where the pod resides does not match the nodeName, and the IP cannot be assigned  | p3      |       |     |       |
+| D00011  | The node where the pod is located matches the nodeName, and the IP can be assigned         | p2    |   |  done   |       |
+| D00012  | The node where the pod resides does not match the nodeName, and the IP cannot be assigned  | p3    |   |  done   |       |
 | D00013  | nodeName has higher priority than nodeAffinity        | p3      |       |     |       |
 | D00014  | The namespace where the pod is located matches the namespaceName, and the IP can be assigned     | p2      |       |     |       |
 | D00015  | The namespace where the pod resides does not match the namespaceName, and the IP cannot be assigned      | p2      |       |     |       |


### PR DESCRIPTION
**What this PR does / why we need it**:
e2e: add nodeName affinity e2e for spiderpool

**Which issue(s) this PR fixes**:
```
NONE
```

**make sure your commit is signed off**
Signed-off-by: ty-dc [tao.yang@daocloud.io](mailto:tao.yang@daocloud.io)