### PR TITLE
docker-image: build new image for all plugins 

### DIFF
--- a/.github/workflows/build-image-plugins.yaml
+++ b/.github/workflows/build-image-plugins.yaml
@@ -1,0 +1,222 @@
+name: Auto Build Image Plugins
+
+# final packed image : ${ONLINE_REGISTER}/${IMAGE_REPO}/${IMAGE_NAME}:${inputs.tag}
+# image dockerfile path on the repo: ${IMAGE_ROOT_PATH}/${IMAGE_NAME}/Dockerfile
+env:
+  IMAGE_NAME: plugins
+  IMAGE_REPO: ${{ github.repository }}
+  ONLINE_REGISTER: ghcr.io
+  IMAGE_ROOT_PATH: images
+  BUILD_PLATFORM: linux/amd64,linux/arm64
+  ONLINE_REGISTER_USER: ${{ github.actor }}
+  ONLINE_REGISTER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'sha, Tag'
+        required: true
+        default: main
+      tag:
+        description: 'image tag'
+        required: true
+        default: v0.8.0
+      cni_version:
+        description: 'the version of cni-plugins'
+        required: false
+        default: ""
+      ovs_version:
+        description: 'the version of ovs-cni plugin'
+        required: false
+        default: ""
+      rdma_version:
+        description: 'the version of rdma-cni plugin'
+        required: false
+        default: "latest"
+  push:
+    branches:
+      - main
+    paths:
+      # can not use env here
+      - images/plugins/**
+
+permissions: write-all
+
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.sha }}
+#   cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    timeout-minutes: 30
+    environment: release-base-images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.0.0
+
+      - name: Inspect builder
+        run: |
+          echo "Name:      ${{ steps.buildx.outputs.name }}"
+          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
+          echo "Status:    ${{ steps.buildx.outputs.status }}"
+          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
+          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
+
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v3.0.0
+
+      - name: Get Code Version Before Checkout
+        id: get_event_version
+        continue-on-error: false
+        run: |
+          echo "trigger by workflow_dispatch"
+          if ${{ github.event_name == 'workflow_dispatch' }}; then
+            cni_version=${{ github.event.inputs.cni_version }}
+            if [ -z "${cni_version}" ]; then
+               cni_version=$(curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/containernetworking/plugins/releases/latest | jq '.tag_name' | tr -d '"')
+            fi
+
+            if [ -z "${cni_version}" ] ; then
+              echo "unable to get cni version" && exit 1
+            fi
+
+            ovs_version=${{ github.event.inputs.ovs_version }}
+            if [ -z "${ovs_version}" ]; then
+               ovs_version=$(curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/k8snetworkplumbingwg/ovs-cni/releases/latest | jq '.tag_name' | tr -d '"')
+            fi
+
+            if [ -z "${ovs_version}" ] ; then
+              echo "unable to get ovs version" && exit 1
+            fi
+
+            rdma_version=${{ github.event.inputs.rdma_version }}
+            if [ -z "${rdma_version}" ]; then
+               rdma_version=$(curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/k8snetworkplumbingwg/rdma-cni/releases/latest | jq '.tag_name' | tr -d '"')
+            elif [ "${rdma_version}" = "latest" ] ; then
+               # rdma don't release any more, we use main branch to build.
+               git clone https://github.com/k8snetworkplumbingwg/rdma-cni.git
+               cd rdma-cni && rdma_version=$(git show -s --format='format:%H') && cd ..
+            fi
+
+            if [ -z "${rdma_version}" ] ; then
+              echo "unable to get rdma version" && exit 1
+            fi
+
+            echo "cni version: ${cni_version}"
+            echo "ovs version: ${ovs_version}"
+            echo "rdma version: ${rdma_version}"
+
+            ref=${{ github.event.inputs.ref }}
+            tag=${{ github.event.inputs.tag }}
+            echo "event_ref=${ref}" >> $GITHUB_ENV
+            echo "event_tag=${tag}" >> $GITHUB_ENV
+            echo "event_cni_version=${cni_version}" >> $GITHUB_ENV
+            echo "event_ovs_version=${ovs_version}" >> $GITHUB_ENV
+            echo "event_rdma_version=${rdma_version}" >> $GITHUB_ENV
+          else ${{ github.event_name == 'push' }} ; then
+            echo "trigger by push"
+            echo "event_ref=${{ github.ref }}" >> $GITHUB_ENV
+            echo "event_tag=${{ github.sha }}" >> $GITHUB_ENV
+          else
+            echo "unexpected event"
+            exit 1
+          fi
+
+      - name: Checkout Source Code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          # fetch-depth: 0
+          ref: ${{ steps.get_event_version.outputs.event_ref }}
+
+      - name: Getting Build Arg
+        id: arg
+        run: |
+          GIT_COMMIT_VERSION=$( git show -s --format='format:%H')
+          GIT_COMMIT_TIME=$( git show -s --format='format:%aI')
+          echo "commit_hash=${GIT_COMMIT_HASH}" >> $GITHUB_ENV
+          echo "commit_time=${GIT_COMMIT_TIME}" >> $GITHUB_ENV
+
+      # check whether we have upload the same base image to online register , if so, we could not build it
+      - name: Checking if tag already exists
+        id: tag-in-repositories
+        shell: bash
+        run: |
+          if docker buildx imagetools inspect ${{ env.ONLINE_REGISTER }}/${{ env.IMAGE_REPO }}/${{ env.IMAGE_NAME }}:${{  steps.get_event_version.outputs.tag }} &>/dev/null; then
+            echo ::set-output name=exists::"true"
+            echo "the target base image exist , no need to build it "
+          else
+            echo ::set-output name=exists::"false"
+            echo "the target base image does not exist , build it "
+          fi
+
+      - name: Login to online register
+        if: ${{ steps.tag-in-repositories.outputs.exists == 'false' }}
+        uses: docker/login-action@v3.0.0
+        with:
+          username: ${{ env.ONLINE_REGISTER_USER }}
+          password: ${{ env.ONLINE_REGISTER_PASSWORD }}
+          registry: ${{ env.ONLINE_REGISTER }}
+
+      - name: Release build ${{ env.IMAGE_NAME }}
+        if: ${{ steps.tag-in-repositories.outputs.exists == 'false' }}
+        uses: docker/build-push-action@v5.0.0
+        continue-on-error: false
+        id: docker_build_release
+        with:
+          context: ./${{ env.IMAGE_ROOT_PATH }}/${{ env.IMAGE_NAME }}
+          file: ./${{ env.IMAGE_ROOT_PATH }}/${{ env.IMAGE_NAME }}/Dockerfile
+          push: true
+          provenance: false
+          github-token: ${{ secrets.WELAN_PAT }}
+          platforms: ${{ env.BUILD_PLATFORM }}
+          tags: |
+            ${{ env.ONLINE_REGISTER }}/${{ env.IMAGE_REPO }}/${{ env.IMAGE_NAME }}:${{ steps.get_event_version.outputs.tag }}
+          build-args:
+            GIT_COMMIT_HASH=${{ steps.arg.outputs.commit_version }}
+            GIT_COMMIT_TIME=${{ steps.arg.outputs.commit_time }}
+            CNI_VERSION=${{ steps.get_event_version.outputs.cni_version }}
+            OVS_VERSION=${{ steps.get_event_version.outputs.ovs_version }}
+            RDMA_VERSION=${{ steps.get_event_version.outputs.rdma_version }}
+
+      - name: Image Release Digest
+        if: ${{ steps.tag-in-repositories.outputs.exists == 'false' }}
+        shell: bash
+        run: |
+          mkdir -p image-digest/
+          echo "## ${{ env.IMAGE_NAME }}" > image-digest/${{ env.IMAGE_NAME }}.txt
+          echo "" >> image-digest/${{ env.IMAGE_NAME }}.txt
+          echo "\`${{ env.ONLINE_REGISTER }}/${{ env.IMAGE_REPO }}/${{ env.IMAGE_NAME }}:${{ steps.get_event_version.outputs.tag }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ env.IMAGE_NAME }}.txt
+          echo "" >> image-digest/${{ env.IMAGE_NAME }}.txt
+
+      - name: Upload artifact digests
+        if: ${{ steps.tag-in-repositories.outputs.exists == 'false' }}
+        uses: actions/upload-artifact@v3.1.3
+        with:
+          name: image-digest ${{ env.IMAGE_NAME }}
+          path: image-digest
+          retention-days: 1
+
+  image-digests:
+    name: Display Digests
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    steps:
+      - name: Downloading Image Digests
+        shell: bash
+        run: |
+          mkdir -p image-digest/
+
+      - name: Download digests of all images built
+        uses: actions/download-artifact@v3
+        with:
+          path: image-digest/
+
+      - name: Image Digests Output
+        shell: bash
+        run: |
+          cd image-digest/
+          find -type f | sort | xargs -d '\n' cat

--- a/images/plugins/.dockerignore
+++ b/images/plugins/.dockerignore
@@ -1,0 +1,2 @@
+# Copyright 2023 Authors of spidernet-io
+# SPDX-License-Identifier: Apache-2.0

--- a/images/plugins/Dockerfile
+++ b/images/plugins/Dockerfile
@@ -1,0 +1,55 @@
+# Copyright 2023 Authors of spidernet-io
+# SPDX-License-Identifier: Apache-2.0
+
+ARG GOLANG_IMAGE=docker.io/library/golang:1.20@sha256:f69d47fedd3b2ebd23bcf473c0b78522ebbc1823f06b7d47f45f04a30bdc901d
+
+#======= build rdma & ovs bin ==========
+FROM --platform=${BUILDPLATFORM} ${GOLANG_IMAGE} as builder
+ARG TARGETOS
+ARG TARGETARCH
+ARG RDMA_VERSION
+ARG OVS_VERSION=v0.31.1
+ARG CNI_VERSION=v1.3.0
+
+WORKDIR /src
+
+RUN touch VERSION.info && \
+    printf "CNI_VERSION: %s\n" "$CNI_VERSION" >> VERSION.info && \
+    printf "OVS_VERSION: %s\n" "$OVS_VERSION" >> VERSION.info && \
+    printf "RDMA_COMMIT_HASH: %s\n" "$RDMA_VERSION" >> VERSION.info
+
+RUN mkdir -p /src/cni/bin && \
+    curl -L -O https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-${TARGETARCH}-${CNI_VERSION}.tgz && \
+    tar -xvf cni-plugins-linux-${TARGETARCH}-${CNI_VERSION}.tgz -C /src/cni/bin/ && \
+    echo "save cni-plguins: ${CNI_VERSION} done"
+
+RUN git clone https://github.com/k8snetworkplumbingwg/rdma-cni.git
+RUN git clone -b ${OVS_VERSION} --depth 1 https://github.com/k8snetworkplumbingwg/ovs-cni.git
+
+WORKDIR /src/rdma-cni
+RUN if [[ "${RDMA_VERSION}" != "latest" ]]; then git checkout ${RDMA_VERSION} ;fi && make TARGET_ARCH=${TARGETARCH}   \
+          TARGET_OS=${TARGETOS} build
+
+WORKDIR /src/ovs-cni
+RUN mkdir -p build && GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -tags no_openssl -mod vendor -o build/ovs ./cmd/plugin
+
+FROM alpine:3
+LABEL maintainer="maintainer@spidernet-io"
+
+# TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETOS
+# TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETARCH
+
+ARG GIT_COMMIT_HASH
+ENV GIT_COMMIT_HASH=${GIT_COMMIT_HASH}
+ARG GIT_COMMIT_TIME
+ENV GIT_COMMIT_TIME=${GIT_COMMIT_TIME}
+
+WORKDIR /
+COPY --from=builder /src/rdma-cni/build/rdma  /usr/src/cni/rdma-cni/
+COPY --from=builder /src/ovs-cni/build/ovs  /usr/src/cni/ovs-cni/
+COPY --from=builder /src/cni/bin/  /usr/src/cni/bin/
+COPY --from=builder /src/VERSION.info /
+
+ADD ./entrypoint.sh /

--- a/images/plugins/entrypoint.sh
+++ b/images/plugins/entrypoint.sh
@@ -1,0 +1,89 @@
+# Copyright 2023 Authors of spidernet-io
+# SPDX-License-Identifier: Apache-2.0
+
+#!/bin/bash
+
+set -e
+
+function usage()
+{
+    echo -e "--install-cni enable install cni-plugins"
+    echo -e "--install-ovs enable install ovs-plugin"
+    echo -e "--install-rdma enable install rdma-plugin"
+    echo -e "--copy-dst-dir specifies the path to these plugins installed"
+}
+
+COPY_DST_DIR="/host/opt/cni/bin"
+CNI_SRC_DIR="/usr/src/cni/bin"
+OVS_SRC_DIR="/usr/src/cni/ovs-cni/ovs"
+RDMA_SRC_DIR="/usr/src/cni/rdma-cni/rdma"
+INSTALL_CNI_PLUGINS=${INSTALL_CNI_PLUGINS:-false}
+INSTALL_OVS_PLUGIN=${INSTALL_OVS_PLUGIN:-false}
+INSTALL_RDMA_PLUGIN=${INSTALL_RDMA_PLUGIN:-false}
+
+# Parse parameters given as arguments to this script.
+while [ "$1" != "" ]; do
+    PARAM=`echo $1 | awk -F= '{print $1}'`
+    VALUE=`echo $1 | awk -F= '{print $2}'`
+    case $PARAM in
+        -h | --help)
+            usage
+            exit
+            ;;
+        --install-cni)
+            INSTALL_CNI_PLUGINS=$VALUE
+            ;;
+        --install-ovs)
+            INSTALL_OVS_PLUGIN=$VALUE
+            ;;
+        --install-rdma)
+            INSTALL_RDMA_PLUGIN=$VALUE
+            ;;
+        --copy-dst-dir)
+            COPY_DST_DIR=$VALUE
+            ;;
+        *)
+            warn "unknown parameter \"$PARAM\""
+            ;;
+    esac
+    shift
+done
+
+if [ -f "${SRC_DIR}" ]; then
+  echo "source plugins dir: ${SRC_DIR} not exist"
+  exit 1
+fi
+
+mkdir -p ${COPY_DST_DIR}
+
+if [ "$INSTALL_CNI_PLUGINS" = "true" ]; then
+    CNI_VERSION=$(cat VERSION.info | grep CNI_VERSION | awk '{print $2}')
+    echo "Installing CNI-Plugins: ${CNI_VERSION} ..."
+    for plugin in "${CNI_SRC_DIR}"/*; do
+      ITEM=${plugin##*/}
+      rm -f ${COPY_DST_DIR}/${ITEM}.old || true
+      ( [ -f "${COPY_DST_DIR}/${ITEM}" ] && mv ${COPY_DST_DIR}/${ITEM} ${COPY_DST_DIR}/${ITEM}.old ) || true
+      cp ${plugin} ${COPY_DST_DIR}
+      rm -f ${COPY_DST_DIR}/${ITEM}.old &>/dev/null  || true
+    done
+fi
+
+if [ "$INSTALL_OVS_PLUGIN" = "true" ]; then
+   OVS_VERSION=$(cat VERSION.info | grep OVS_VERSION | awk '{print $2}')
+   echo "Installing OVS-Plugin: ${OVS_VERSION} ..."
+   rm -f ${COPY_DST_DIR}/ovs.old || true
+   ( [ -f "${COPY_DST_DIR}/ovs" ] && mv ${COPY_DST_DIR}/ovs ${COPY_DST_DIR}/ovs.old ) || true
+   cp ${OVS_SRC_DIR} ${COPY_DST_DIR}
+   rm -f ${COPY_DST_DIR}/ovs.old &>/dev/null  || true
+fi
+
+if [ "$INSTALL_RDMA_PLUGIN" = "true" ]; then
+   RDMA_VERSION=$(cat VERSION.info | grep RDMA_VERSION | awk '{print $2}')
+   echo "Installing RDMA-Plugin: ${RDMA_VERSION} ..."
+   rm -f ${COPY_DST_DIR}/rdma.old || true
+   ( [ -f "${COPY_DST_DIR}/rdma" ] && mv ${COPY_DST_DIR}/rdma ${COPY_DST_DIR}/rdma.old ) || true
+   cp ${RDMA_SRC_DIR} ${COPY_DST_DIR}
+   rm -f ${COPY_DST_DIR}/rdma.old &>/dev/null  || true
+fi
+
+echo Done.


### PR DESCRIPTION
We put all plugins of ovs, cni bin and rdma into the image of ghcr.io/spidernet.io/plugins.

---
name: Pull request
about: Tell us about your contribution
labels: ["pr/release/none-required"]
---

---
## Thanks for contributing !

Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>

**What this PR does / why we need it**:

We put all plugins of ovs, cni bin and rdma into the image of ghcr.io/spidernet.io/plugins.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**make sure your commit is signed off**
