### PR TITLE
fix install-multus scripts SpiderMultusConfig none property bug

### DIFF
--- a/test/scripts/install-multus.sh
+++ b/test/scripts/install-multus.sh
@@ -155,6 +155,7 @@ spec:
     echo "${MACVLAN_CR_TEMPLATE}" \
       | sed 's?<<CNI_NAME>>?'""${MULTUS_KUBEVIRT_CNI_VLAN30}""'?g' \
       | sed 's?<<NAMESPACE>>?'"${RELEASE_NAMESPACE}"'?g' \
+      | sed 's?<<ENABLE_COORDINATOR>>?'${ENABLE_COORDINATOR}'?g' \
       | sed 's?<<MODE>>?auto?g' \
       | sed 's?<<MASTER>>?eth0?g' \
       | sed 's?<<VLAN>>?30?g' \
@@ -165,6 +166,7 @@ spec:
     echo "${MACVLAN_CR_TEMPLATE}" \
       | sed 's?<<CNI_NAME>>?'""${MULTUS_KUBEVIRT_CNI_VLAN40}""'?g' \
       | sed 's?<<NAMESPACE>>?'"${RELEASE_NAMESPACE}"'?g' \
+      | sed 's?<<ENABLE_COORDINATOR>>?'${ENABLE_COORDINATOR}'?g' \
       | sed 's?<<MODE>>?auto?g' \
       | sed 's?<<MASTER>>?eth0?g' \
       | sed 's?<<VLAN>>?40?g' \


### PR DESCRIPTION
fix install-multus scripts 

```text
The SpiderMultusConfig "kubevirt-macvlan-vlan30" is invalid: spec.enableCoordinator: Invalid value: "string": spec.enableCoordinator in body must be of type boolean: "string"
```

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)


**What this PR does / why we need it**:
fix bug

**Which issue(s) this PR fixes**:
close #2456
