### PR TITLE
set logger for controller-runtime framework

### DIFF
--- a/cmd/spiderpool-agent/cmd/crd_manager.go
+++ b/cmd/spiderpool-agent/cmd/crd_manager.go
@@ -6,12 +6,14 @@ package cmd
 import (
 	"strconv"
 
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	controllerruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	spiderpoolv2beta1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1"
@@ -26,10 +28,13 @@ func init() {
 }
 
 func newCRDManager() (ctrl.Manager, error) {
+	// set logger for controller-runtime framework
+	// The controller-runtime would print debug stack if we do not init the log previously: https://github.com/kubernetes-sigs/controller-runtime/pull/2357
+	ctrl.SetLogger(logr.New(controllerruntimelog.NullLogSink{}))
+
 	config := ctrl.GetConfigOrDie()
 	config.Burst = 100
 	config.QPS = 50
-
 	mgr, err := ctrl.NewManager(config, ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{

--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,11 @@ require (
 )
 
 require (
+	github.com/go-logr/logr v1.2.4
+	k8s.io/klog/v2 v2.100.1 // indirect
+)
+
+require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.2 // indirect
@@ -84,7 +89,6 @@ require (
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
-	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-openapi/analysis v0.21.4 // indirect
@@ -173,7 +177,6 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	k8s.io/component-base v0.28.1 // indirect
 	k8s.io/gengo v0.0.0-20230306165830-ab3349d207d4 // indirect
-	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 // indirect
 	k8s.io/kubectl v0.26.3 // indirect
 	kubevirt.io/containerized-data-importer-api v1.57.0-alpha1 // indirect


### PR DESCRIPTION
controller-runtime framework add stack print for no logger initialization: https://github.com/kubernetes-sigs/controller-runtime/pull/2357

```golang
		if logFullfilled.CompareAndSwap(false, true) {
			stack := debug.Stack()
			stackLines := bytes.Count(stack, []byte{'\n'})
			sep := []byte{'\n', '\t', '>', ' ', ' '}

			fmt.Fprintf(os.Stderr,
				"[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.\nDetected at:%s%s", sep,
				// prefix every line, so it's clear this is a stack trace related to the above message
				bytes.Replace(stack, []byte{'\n'}, sep, stackLines-1),
			)
			SetLogger(logr.New(NullLogSink{}))
		}
	}
```

And the controller-runtime would set null logger for its usage. So, I just pre-do it in spiderpool to avoid debug stack print.




Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)


**What this PR does / why we need it**:
enhancement

**Which issue(s) this PR fixes**:
close #2450 

