### PR TITLE
fix ipam block with ip address used out

### DIFF
--- a/pkg/ippoolmanager/utils.go
+++ b/pkg/ippoolmanager/utils.go
@@ -123,3 +123,17 @@ func (b ByPoolPriority) Less(i, j int) bool {
 
 	return false
 }
+
+// findAllocatedIPFromRecords try to find pod NIC previous allocated IP from the IPPool.Status.AllocatedIPs
+// this function serves for the issue: https://github.com/spidernet-io/spiderpool/issues/2517
+func findAllocatedIPFromRecords(allocatedRecords spiderpoolv2beta1.PoolIPAllocations, nic, namespacedName, podUID string) (previousIP string, hasFound bool) {
+	for tmpIP, poolIPAllocation := range allocatedRecords {
+		if poolIPAllocation.NIC == nic &&
+			poolIPAllocation.NamespacedName == namespacedName &&
+			poolIPAllocation.PodUID == podUID {
+			return tmpIP, true
+		}
+	}
+
+	return "", false
+}


### PR DESCRIPTION
As issue #2517 described, we need try to circulate traversal the whole IPPool allocated IPs to find the previous allocated IP address once the whole IPPool IP addresses used out.

It might reduce performance, but this is the simplest and cause less impaction to solve this problem.

And we only do this when we meet IP addresses used out case. In other case, the spiderpool-agent component still find new free IP address to allocate for the pod and the spiderpool-controller component will use GC scanAll to release the previous IP addresses.


Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)

**What this PR does / why we need it**:
fix bug

**Which issue(s) this PR fixes**:
close #2517 

