### PR TITLE
cherrypick 2518, 2514 and 2544 to release v0.7

### DIFF
--- a/charts/spiderpool/templates/daemonset.yaml
+++ b/charts/spiderpool/templates/daemonset.yaml
@@ -154,6 +154,14 @@ spec:
                 - {{ .Values.spiderpoolAgent.binName }}
                 - shutdown
         env:
+        - name: SPIDERPOOL_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: SPIDERPOOL_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: SPIDERPOOL_LOG_LEVEL
           value: {{ .Values.spiderpoolAgent.debug.logLevel | quote }}
         - name: SPIDERPOOL_ENABLED_METRIC

--- a/cmd/spiderpool-agent/cmd/config.go
+++ b/cmd/spiderpool-agent/cmd/config.go
@@ -52,6 +52,8 @@ var envInfo = []envConf{
 	{"SPIDERPOOL_LOG_LEVEL", logutils.LogInfoLevelStr, true, &agentContext.Cfg.LogLevel, nil, nil},
 	{"SPIDERPOOL_ENABLED_METRIC", "false", false, nil, &agentContext.Cfg.EnableMetric, nil},
 	{"SPIDERPOOL_ENABLED_DEBUG_METRIC", "false", false, nil, &agentContext.Cfg.EnableDebugLevelMetric, nil},
+	{"SPIDERPOOL_POD_NAMESPACE", "", true, &agentContext.Cfg.AgentPodNamespace, nil, nil},
+	{"SPIDERPOOL_POD_NAME", "", true, &agentContext.Cfg.AgentPodName, nil, nil},
 	{"SPIDERPOOL_HEALTH_PORT", "5710", true, &agentContext.Cfg.HttpPort, nil, nil},
 	{"SPIDERPOOL_METRIC_HTTP_PORT", "5711", true, &agentContext.Cfg.MetricHttpPort, nil, nil},
 	{"SPIDERPOOL_GOPS_LISTEN_PORT", "5712", false, &agentContext.Cfg.GopsListenPort, nil, nil},
@@ -77,6 +79,8 @@ type Config struct {
 	LogLevel               string
 	EnableMetric           bool
 	EnableDebugLevelMetric bool
+	AgentPodNamespace      string
+	AgentPodName           string
 
 	HttpPort         string
 	MetricHttpPort   string
@@ -90,16 +94,12 @@ type Config struct {
 	MultusClusterNetwork string
 
 	// configmap
-	IpamUnixSocketPath                string   `yaml:"ipamUnixSocketPath"`
-	EnableIPv4                        bool     `yaml:"enableIPv4"`
-	EnableIPv6                        bool     `yaml:"enableIPv6"`
-	EnableStatefulSet                 bool     `yaml:"enableStatefulSet"`
-	EnableSpiderSubnet                bool     `yaml:"enableSpiderSubnet"`
-	ClusterDefaultIPv4IPPool          []string `yaml:"clusterDefaultIPv4IPPool"`
-	ClusterDefaultIPv6IPPool          []string `yaml:"clusterDefaultIPv6IPPool"`
-	ClusterDefaultIPv4Subnet          []string `yaml:"clusterDefaultIPv4Subnet"`
-	ClusterDefaultIPv6Subnet          []string `yaml:"clusterDefaultIPv6Subnet"`
-	ClusterSubnetDefaultFlexibleIPNum int      `yaml:"clusterSubnetDefaultFlexibleIPNumber"`
+	IpamUnixSocketPath                string `yaml:"ipamUnixSocketPath"`
+	EnableIPv4                        bool   `yaml:"enableIPv4"`
+	EnableIPv6                        bool   `yaml:"enableIPv6"`
+	EnableStatefulSet                 bool   `yaml:"enableStatefulSet"`
+	EnableSpiderSubnet                bool   `yaml:"enableSpiderSubnet"`
+	ClusterSubnetDefaultFlexibleIPNum int    `yaml:"clusterSubnetDefaultFlexibleIPNumber"`
 }
 
 type AgentContext struct {

--- a/cmd/spiderpool-agent/cmd/daemon.go
+++ b/cmd/spiderpool-agent/cmd/daemon.go
@@ -131,14 +131,13 @@ func DaemonMain() {
 
 	logger.Info("Begin to initialize IPAM")
 	ipamConfig := ipam.IPAMConfig{
-		EnableIPv4:               agentContext.Cfg.EnableIPv4,
-		EnableIPv6:               agentContext.Cfg.EnableIPv6,
-		ClusterDefaultIPv4IPPool: agentContext.Cfg.ClusterDefaultIPv4IPPool,
-		ClusterDefaultIPv6IPPool: agentContext.Cfg.ClusterDefaultIPv6IPPool,
-		EnableSpiderSubnet:       agentContext.Cfg.EnableSpiderSubnet,
-		EnableStatefulSet:        agentContext.Cfg.EnableStatefulSet,
-		OperationRetries:         agentContext.Cfg.WaitSubnetPoolMaxRetries,
-		OperationGapDuration:     time.Duration(agentContext.Cfg.WaitSubnetPoolTime) * time.Second,
+		EnableIPv4:           agentContext.Cfg.EnableIPv4,
+		EnableIPv6:           agentContext.Cfg.EnableIPv6,
+		EnableSpiderSubnet:   agentContext.Cfg.EnableSpiderSubnet,
+		EnableStatefulSet:    agentContext.Cfg.EnableStatefulSet,
+		OperationRetries:     agentContext.Cfg.WaitSubnetPoolMaxRetries,
+		OperationGapDuration: time.Duration(agentContext.Cfg.WaitSubnetPoolTime) * time.Second,
+		AgentNamespace:       agentContext.Cfg.AgentPodNamespace,
 	}
 	if len(agentContext.Cfg.MultusClusterNetwork) != 0 {
 		ipamConfig.MultusClusterNetwork = pointer.String(agentContext.Cfg.MultusClusterNetwork)

--- a/pkg/ipam/allocate.go
+++ b/pkg/ipam/allocate.go
@@ -548,7 +548,9 @@ func (i *ipam) selectByPod(ctx context.Context, version types.IPVersion, ipPool 
 
 			multusNS = netNsName
 			if multusNS == "" {
-				multusNS = pod.Namespace
+				// Reference from Multus source codes: The CRD object of default network should only be defined in multusNamespace
+				// In multus, multusNamespace serves for (clusterNetwork/defaultNetworks)
+				multusNS = i.config.AgentNamespace
 			}
 			multusName = networkName
 		} else {
@@ -572,6 +574,12 @@ func (i *ipam) selectByPod(ctx context.Context, version types.IPVersion, ipPool 
 				}
 			}
 
+			// Refer from the multus-cni source codes, for annotation "k8s.v1.cni.cncf.io/networks" value without Namespace,
+			// we will regard the pod Namespace as the value's namespace
+			if multusNS == "" {
+				multusNS = pod.ObjectMeta.Namespace
+			}
+
 			// impossible
 			if !isFound {
 				return fmt.Errorf("%w: no matched multus object for NIC '%s'. The multus network-attachments: %v", constant.ErrUnknown, nic, podAnno[constant.MultusNetworkAttachmentAnnot])
@@ -581,7 +589,9 @@ func (i *ipam) selectByPod(ctx context.Context, version types.IPVersion, ipPool 
 		for index := range ipPool.Spec.MultusName {
 			expectedMultusName := ipPool.Spec.MultusName[index]
 			if !strings.Contains(expectedMultusName, "/") {
-				expectedMultusName = fmt.Sprintf("%s/%s", pod.Namespace, expectedMultusName)
+				// for the ippool.spec.multusName property, if the user doesn't specify the net-attach-def resource namespace,
+				// we'll regard it in the Spiderpool installation namespace
+				expectedMultusName = fmt.Sprintf("%s/%s", i.config.AgentNamespace, expectedMultusName)
 			}
 
 			if strings.Compare(expectedMultusName, fmt.Sprintf("%s/%s", multusNS, multusName)) == 0 {

--- a/pkg/ipam/config.go
+++ b/pkg/ipam/config.go
@@ -15,10 +15,8 @@ import (
 )
 
 type IPAMConfig struct {
-	EnableIPv4               bool
-	EnableIPv6               bool
-	ClusterDefaultIPv4IPPool []string
-	ClusterDefaultIPv6IPPool []string
+	EnableIPv4 bool
+	EnableIPv6 bool
 
 	EnableSpiderSubnet bool
 	EnableStatefulSet  bool
@@ -27,6 +25,7 @@ type IPAMConfig struct {
 	OperationGapDuration time.Duration
 
 	MultusClusterNetwork *string
+	AgentNamespace       string
 }
 
 func setDefaultsForIPAMConfig(config IPAMConfig) IPAMConfig {

--- a/pkg/ippoolmanager/ippool_manager.go
+++ b/pkg/ippoolmanager/ippool_manager.go
@@ -139,6 +139,13 @@ func (im *ipPoolManager) AllocateIP(ctx context.Context, poolName, nic string, p
 }
 
 func (im *ipPoolManager) genRandomIP(ctx context.Context, nic string, ipPool *spiderpoolv2beta1.SpiderIPPool, pod *corev1.Pod) (net.IP, error) {
+	logger := logutils.FromContext(ctx)
+
+	key, err := cache.MetaNamespaceKeyFunc(pod)
+	if err != nil {
+		return nil, err
+	}
+
 	reservedIPs, err := im.rIPManager.AssembleReservedIPs(ctx, *ipPool.Spec.IPVersion)
 	if err != nil {
 		return nil, err
@@ -165,14 +172,20 @@ func (im *ipPoolManager) genRandomIP(ctx context.Context, nic string, ipPool *sp
 
 	availableIPs := spiderpoolip.IPsDiffSet(totalIPs, append(reservedIPs, usedIPs...), false)
 	if len(availableIPs) == 0 {
-		return nil, constant.ErrIPUsedOut
+		// traverse the usedIPs to find the previous allocated IPs if there be
+		// reference issue: https://github.com/spidernet-io/spiderpool/issues/2517
+		allocatedIPFromRecords, hasFound := findAllocatedIPFromRecords(allocatedRecords, nic, key, string(pod.UID))
+		if !hasFound {
+			return nil, constant.ErrIPUsedOut
+		}
+
+		availableIPs, err = spiderpoolip.ParseIPRange(*ipPool.Spec.IPVersion, allocatedIPFromRecords)
+		if nil != err {
+			return nil, err
+		}
+		logger.Sugar().Warnf("find previous IP '%s' from IPPool '%s' recorded IP allocations", allocatedIPFromRecords, ipPool.Name)
 	}
 	resIP := availableIPs[0]
-
-	key, err := cache.MetaNamespaceKeyFunc(pod)
-	if err != nil {
-		return nil, err
-	}
 
 	if allocatedRecords == nil {
 		allocatedRecords = spiderpoolv2beta1.PoolIPAllocations{}

--- a/pkg/ippoolmanager/ippool_manager_test.go
+++ b/pkg/ippoolmanager/ippool_manager_test.go
@@ -5,6 +5,7 @@ package ippoolmanager_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"sync/atomic"
@@ -19,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -349,6 +351,60 @@ var _ = Describe("IPPoolManager", Label("ippool_manager_test"), func() {
 				ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs, ip.String())
 				ipPoolT.Spec.Gateway = pointer.String(gateway)
 				ipPoolT.Spec.Vlan = pointer.Int64(vlan)
+
+				err = fakeClient.Create(ctx, ipPoolT)
+				Expect(err).NotTo(HaveOccurred())
+				err = tracker.Add(ipPoolT)
+				Expect(err).NotTo(HaveOccurred())
+
+				res, err := ipPoolManager.AllocateIP(ctx, ipPoolName, nic, podT)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(*res.Nic).To(Equal(nic))
+				Expect(*res.Version).To(Equal(ipVersion))
+				Expect(*res.Address).To(Equal(allocatedIP))
+				Expect(res.IPPool).To(Equal(ipPoolT.Name))
+				Expect(res.Gateway).To(Equal(gateway))
+				Expect(res.Vlan).To(Equal(vlan))
+			})
+
+			It("allocate IP address from the previous records", func() {
+				mockRIPManager.EXPECT().
+					AssembleReservedIPs(gomock.Eq(ctx), gomock.Eq(constant.IPv4)).
+					Return(nil, nil).
+					Times(1)
+
+				ipVersion := constant.IPv4
+				allocatedIP := "172.18.40.40/24"
+				gateway := "172.18.40.1"
+				vlan := int64(0)
+
+				ip, ipNet, err := net.ParseCIDR(allocatedIP)
+				Expect(err).NotTo(HaveOccurred())
+
+				ipPoolT.Spec.IPVersion = pointer.Int64(ipVersion)
+				ipPoolT.Spec.Subnet = ipNet.String()
+				ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs, ip.String())
+				ipPoolT.Spec.Gateway = pointer.String(gateway)
+				ipPoolT.Spec.Vlan = pointer.Int64(vlan)
+
+				key, err := cache.MetaNamespaceKeyFunc(podT)
+				Expect(err).NotTo(HaveOccurred())
+
+				records := spiderpoolv2beta1.PoolIPAllocations{
+					ip.String(): spiderpoolv2beta1.PoolIPAllocation{
+						NIC:            nic,
+						NamespacedName: key,
+						PodUID:         string(podT.UID),
+					},
+				}
+				allocatedIPs, err := json.Marshal(records)
+				Expect(err).NotTo(HaveOccurred())
+
+				ipPoolT.Status = spiderpoolv2beta1.IPPoolStatus{
+					AllocatedIPs:     pointer.String(string(allocatedIPs)),
+					TotalIPCount:     pointer.Int64(1),
+					AllocatedIPCount: pointer.Int64(1),
+				}
 
 				err = fakeClient.Create(ctx, ipPoolT)
 				Expect(err).NotTo(HaveOccurred())

--- a/pkg/ippoolmanager/utils.go
+++ b/pkg/ippoolmanager/utils.go
@@ -123,3 +123,17 @@ func (b ByPoolPriority) Less(i, j int) bool {
 
 	return false
 }
+
+// findAllocatedIPFromRecords try to find pod NIC previous allocated IP from the IPPool.Status.AllocatedIPs
+// this function serves for the issue: https://github.com/spidernet-io/spiderpool/issues/2517
+func findAllocatedIPFromRecords(allocatedRecords spiderpoolv2beta1.PoolIPAllocations, nic, namespacedName, podUID string) (previousIP string, hasFound bool) {
+	for tmpIP, poolIPAllocation := range allocatedRecords {
+		if poolIPAllocation.NIC == nic &&
+			poolIPAllocation.NamespacedName == namespacedName &&
+			poolIPAllocation.PodUID == podUID {
+			return tmpIP, true
+		}
+	}
+
+	return "", false
+}

--- a/test/e2e/common/spiderpool.go
+++ b/test/e2e/common/spiderpool.go
@@ -19,12 +19,10 @@ import (
 	. "github.com/onsi/gomega"
 	frame "github.com/spidernet-io/e2eframework/framework"
 	"github.com/spidernet-io/e2eframework/tools"
-	"github.com/spidernet-io/spiderpool/cmd/spiderpool-agent/cmd"
 	"github.com/spidernet-io/spiderpool/pkg/constant"
 	ip "github.com/spidernet-io/spiderpool/pkg/ip"
 	"github.com/spidernet-io/spiderpool/pkg/types"
 
-	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	api_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -308,39 +306,6 @@ func CheckPodIpRecordInIppool(f *frame.Framework, v4IppoolNameList, v6IppoolName
 		}
 		return false, false, true, nil
 	}
-}
-
-func GetClusterDefaultIppool(f *frame.Framework) (v4IppoolList, v6IppoolList []string, e error) {
-	if f == nil {
-		return nil, nil, errors.New("wrong input")
-	}
-
-	configMap, e := f.GetConfigmap(SpiderPoolConfigmapName, SpiderPoolConfigmapNameSpace)
-	if e != nil {
-		return nil, nil, e
-	}
-	GinkgoWriter.Printf("configmap: %+v \n", configMap.Data)
-
-	data, ok := configMap.Data["conf.yml"]
-	if !ok || len(data) == 0 {
-		return nil, nil, errors.New("failed to find cluster default ippool")
-	}
-
-	conf := cmd.Config{}
-	if err := yaml.Unmarshal([]byte(data), &conf); nil != err {
-		GinkgoWriter.Printf("failed to decode yaml config: %v \n", data)
-		return nil, nil, errors.New("failed to find cluster default ippool")
-	}
-	GinkgoWriter.Printf("yaml config: %v \n", conf)
-
-	if conf.EnableIPv4 && len(conf.ClusterDefaultIPv4IPPool) == 0 {
-		return nil, nil, errors.New("IPv4 IPPool is not specified when IPv4 is enabled")
-	}
-	if conf.EnableIPv6 && len(conf.ClusterDefaultIPv6IPPool) == 0 {
-		return nil, nil, errors.New("IPv6 IPPool is not specified when IPv6 is enabled")
-	}
-
-	return conf.ClusterDefaultIPv4IPPool, conf.ClusterDefaultIPv6IPPool, nil
 }
 
 func GetNamespaceDefaultIppool(f *frame.Framework, namespace string) (v4IppoolList, v6IppoolList []string, e error) {

--- a/test/e2e/common/spidersubnet.go
+++ b/test/e2e/common/spidersubnet.go
@@ -11,15 +11,12 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
-	"github.com/spidernet-io/spiderpool/cmd/spiderpool-agent/cmd"
 	"github.com/spidernet-io/spiderpool/pkg/constant"
-	"github.com/spidernet-io/spiderpool/pkg/lock"
-	"github.com/spidernet-io/spiderpool/pkg/utils/convert"
-	"gopkg.in/yaml.v3"
-
 	ip "github.com/spidernet-io/spiderpool/pkg/ip"
 	spiderpool "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1"
+	"github.com/spidernet-io/spiderpool/pkg/lock"
 	"github.com/spidernet-io/spiderpool/pkg/types"
+	"github.com/spidernet-io/spiderpool/pkg/utils/convert"
 	"k8s.io/utils/pointer"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -443,39 +440,6 @@ OUTER_FOR:
 	wg.Wait()
 	Expect(len(subnetNameList)).To(Equal(subnetNums))
 	return subnetNameList, nil
-}
-
-func GetClusterDefaultSubnet(f *frame.Framework) (v4SubnetList, v6SubnetList []string, e error) {
-	if f == nil {
-		return nil, nil, errors.New("wrong input")
-	}
-
-	configMap, e := f.GetConfigmap(SpiderPoolConfigmapName, SpiderPoolConfigmapNameSpace)
-	if e != nil {
-		return nil, nil, e
-	}
-	GinkgoWriter.Printf("configmap: %+v \n", configMap.Data)
-
-	data, ok := configMap.Data["conf.yml"]
-	if !ok || len(data) == 0 {
-		return nil, nil, errors.New("failed to find cluster default subnet")
-	}
-
-	conf := cmd.Config{}
-	if err := yaml.Unmarshal([]byte(data), &conf); nil != err {
-		GinkgoWriter.Printf("failed to decode yaml config: %v \n", data)
-		return nil, nil, errors.New("failed to find cluster default subnet")
-	}
-	GinkgoWriter.Printf("yaml config: %v \n", conf)
-
-	if conf.EnableIPv4 && len(conf.ClusterDefaultIPv4Subnet) != 0 {
-		v4SubnetList = conf.ClusterDefaultIPv4Subnet
-	}
-	if conf.EnableIPv6 && len(conf.ClusterDefaultIPv6Subnet) != 0 {
-		v6SubnetList = conf.ClusterDefaultIPv6Subnet
-	}
-
-	return v4SubnetList, v6SubnetList, nil
 }
 
 func GetAllSubnet(f *frame.Framework, opts ...client.ListOption) (*spiderpool.SpiderSubnetList, error) {

--- a/test/e2e/subnet/subnet_test.go
+++ b/test/e2e/subnet/subnet_test.go
@@ -1314,7 +1314,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 	Context("The default subnet should support different controller types.", func() {
 		var ClusterDefaultV4SubnetList, ClusterDefaultV6SubnetList []string
 		var v4PoolNameList, v6PoolNameList []string
-		var err error
+		//var err error
 		var replicasNum int32 = 1
 		var controllerNum int = 4
 		var controllerNameList []string
@@ -1324,8 +1324,8 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 			// Get the default subnet
 			// and verify that the default subnet functions properly
 			By("get cluster default subnet")
-			ClusterDefaultV4SubnetList, ClusterDefaultV6SubnetList, err = common.GetClusterDefaultSubnet(frame)
-			Expect(err).NotTo(HaveOccurred())
+			// TODO(ty-dc), Default subnet to be determined for now
+			// ClusterDefaultV4SubnetList, ClusterDefaultV6SubnetList, err = common.GetClusterDefaultSubnet(frame)				Expect(err).NotTo(HaveOccurred())
 			if frame.Info.IpV4Enabled && len(ClusterDefaultV4SubnetList) == 0 {
 				Skip("v4 Default Subnet function is not enabled")
 			}


### PR DESCRIPTION
⚠️⚠️⚠️ If you update release v0.7 to v0.7.1, please update the spiderpool-agent yaml rather than just update the image directly! 

Because I added the additional ENV parameters for spiderpool-agent:
```text
        - name: SPIDERPOOL_POD_NAME
          valueFrom:
            fieldRef:
              fieldPath: metadata.name
        - name: SPIDERPOOL_POD_NAMESPACE
          valueFrom:
            fieldRef:
              fieldPath: metadata.namespace
``` 


Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)

What this PR does / why we need it:
cherry-pick

Which issue(s) this PR fixes:
close https://github.com/spidernet-io/spiderpool/issues/2547
close https://github.com/spidernet-io/spiderpool/issues/2521