### PR TITLE
coordinator: improve tuning polocy of routes to support kubevirt

### DIFF
--- a/docs/concepts/coordinator-zh_CN.md
+++ b/docs/concepts/coordinator-zh_CN.md
@@ -19,7 +19,7 @@ Spiderpool 内置一个叫 `coordinator` 的 CNI meta-plugin, 它在 Main CNI �
 | type      | CNI 的类型     | 字符串 | required   |coordinator     |
 | mode      | coordinator 运行的模式. "auto": coordinator 自动判断运行在 Underlay 或者 Overlay; "underlay": 为 Pod 创建一对 Veth 设备，用于转发集群东西向流量。由 Pod 的 Underlay 网卡转发南北向流量; "overlay": 不额外创建 veth 设备，运行在多网卡模式。由 overlay 类型的 CNI(calico，cilium) 转发集群东西向流量，由 underlay 网卡转发南北向流量; "disable": 禁用 coordinator           | 字符串 | optional   | auto |
 | tunePodRoutes | Pod 多网卡模式下，是否调协 Pod 的路由，解决访问来回路径不一致的问题 | 布尔型 | optional | true |
-| podDefaultRouteNic | 配置 Pod 的默认路由网卡 | 字符串 | optional | "" |
+| podDefaultRouteNic | Pod 多网卡时，配置 Pod 的默认路由网卡。默认为 "", 其 value 实际为 Pod 第一张拥有默认路由的网卡| 字符串 | optional | "" |
 | podDefaultCniNic | K8s 中 Pod 默认的第一张网卡 | 布尔型 | optional | eth0 |
 | detectGateway | 创建 Pod 时是否检查网关是否可达 | 布尔型 | optional | false |
 | detectIPConflict | 创建 Pod 时是否检查 Pod 的 IP 是否可达  | 布尔型 | optional | false |

--- a/docs/concepts/coordinator.md
+++ b/docs/concepts/coordinator.md
@@ -19,7 +19,7 @@ Let's delve into how coordinator implements these features.
 | type      | The name of this Spidercoordinators resource      | string | required   |coordinator     |
 | mode      | the mode in which the coordinator run. "auto": Automatically determine if it's overlay or underlay; "underlay": All NICs for pods are underlay NICs, and in this case the coordinator will create veth-pairs device to solve the problem of underlay pods accessing services; "overlay": The coordinator does not create veth-pair devices, but the first NIC of the pod cannot be an underlay NIC, which is created by overlay CNI (e.g. calico, cilium). Solve the problem of pod access to service through the first NIC; "disable": The coordinator does nothing and exits directly            | string | optional   | auto |
 | tunePodRoutes | Tune the pod's routing tables while a pod is in multi-NIC mode | bool | optional | true |
-| podDefaultRouteNic | Configure the default routed NIC for the pod while a pod is in multi-NIC mode | string | optional | "" |
+| podDefaultRouteNic | Configure the default routed NIC for the pod while a pod is in multi-NIC mode, The default value is 0, indicate that the first network interface of the pod has the default route. | string | optional | "" |
 | podDefaultCniNic | The name of the pod's first NIC defaults to eth0 in kubernetes | bool | optional | eth0 |
 | detectGateway | Enable gateway detection while creating pods, which prevent pod creation if the gateway is unreachable | bool | optional | false |
 | detectIPConflict | Enable IP conflicting checking for pods, which prevent pod creation if the pod's ip is conflicting | bool | optional | false |

--- a/docs/usage/underlay_cni_service-zh_CN.md
+++ b/docs/usage/underlay_cni_service-zh_CN.md
@@ -76,26 +76,21 @@ kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future versi
 # ip rule
 0: from all lookup local
 32759: from 10.233.105.154 lookup 100
-32761: from all to 169.254.1.1 lookup 100
-32762: from all to 10.233.64.0/18 lookup 100
-32763: from all to 10.233.0.0/18 lookup 100
-32765: from all to 10.6.212.102 lookup 100
 32766: from all lookup main
 32767: from all lookup default
 # ip r
-default via 10.6.0.1 dev net1
-10.6.0.0/16 dev net1 proto kernel scope link src 10.6.212.227
-# ip r show table 100
 default via 169.254.1.1 dev eth0
 10.6.212.102 dev eth0 scope link
 10.233.0.0/18 via 10.6.212.102 dev eth0
 10.233.64.0/18 via 10.6.212.102 dev eth0
 169.254.1.1 dev eth0 scope link
+# ip r show table 100
+default via 10.6.0.1 dev net1
+10.6.0.0/16 dev net1 proto kernel scope link src 10.6.212.227
 ```
 
-- **32759: from 10.233.105.154 lookup 100**: 确保从 `eth0` (calico 网卡)发出的数据包走 table 100
-- **32762: from all to 10.233.64.0/18 lookup 100**: 确保 Pod 访问 ClusterIP 时走 table 100，从 `eth0` 转发出去。
-- 默认情况下，net1 的所有子网路由保留在 Main 表; `eth0` 的子网路由保留在 Table 100。
+- **32759: from 10.233.105.154 lookup 100**: 确保从 `eth0` (calico 网卡)发出的数据包走 table 100。
+- 默认情况下: 除了默认路由，所有路由都保留在 Main 表，但会把 net1 的默认路由移动到 table 100。
 
 这些策略路由确保多网卡场景下，Underlay Pod 也能够正常访问 Service。
 

--- a/docs/usage/underlay_cni_service.md
+++ b/docs/usage/underlay_cni_service.md
@@ -85,30 +85,25 @@ When creating a Pod in Overlay mode and entering the Pod network command space, 
 ```shell
 root@controller:~# kubectl exec -it macvlan-overlay-97bf89fdd-kdgrb sh
 kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
-#
+
 # ip rule
 0: from all lookup local
-32759: from 10.233.105.154 lookup 100
-32761: from all to 169.254.1.1 lookup 100
-32762: from all to 10.233.64.0/18 lookup 100
-32763: from all to 10.233.0.0/18 lookup 100
-32765: from all to 10.6.212.102 lookup 100
+32765: from 10.6.212.227 lookup 100
 32766: from all lookup main
 32767: from all lookup default
 # ip r
-default via 10.6.0.1 dev net1
-10.6.0.0/16 dev net1 proto kernel scope link src 10.6.212.227
-# ip r show table 100
 default via 169.254.1.1 dev eth0
 10.6.212.102 dev eth0 scope link
 10.233.0.0/18 via 10.6.212.102 dev eth0
 10.233.64.0/18 via 10.6.212.102 dev eth0
 169.254.1.1 dev eth0 scope link
+# ip r show table 100
+default via 10.6.0.1 dev net1
+10.6.0.0/16 dev net1 proto kernel scope link src 10.6.212.227
 ```
 
-- **32759: from 10.233.105.154 lookup 100**: Ensure that packets sent from `eth0` (calico network card) go through table 100
 - **32762: from all to 10.233.64.0/18 lookup 100**: Ensure that when Pods access ClusterIP, they go through table 100 and are forwarded out from `eth0`.
-- By default, all subnet routes of net1 are reserved in the Main table; subnet routes of `eth0` are reserved in Table 100.
+- In the default configuration: Except for the default route, all routes are retained in the Main table, but the default route for 'net1' is moved to table 100.
 
 These policy routes ensure that Underlay Pods can also normally access Service in multi-network card scenarios.
 

--- a/test/e2e/coordinator/macvlan-overlay-one/macvlan_overlay_one_test.go
+++ b/test/e2e/coordinator/macvlan-overlay-one/macvlan_overlay_one_test.go
@@ -295,7 +295,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 					ctx, cancel = context.WithTimeout(context.Background(), common.ExecCommandTimeout)
 					defer cancel()
 
-					// In this use case, the default routing NIC is specified as eth0 (originally the default is net1) through `CoordinatorSpec.PodDefaultRouteNIC`
+					// In this use case, the default routing NIC is specified as eth0 through `CoordinatorSpec.PodDefaultRouteNIC`
 					// ip r get <address outside the cluster>, should flow out from the correct NIC(eth0).
 					GinkgoWriter.Println("ip -4 r get <address outside the cluster>")
 					runGetIPString := "ip -4 r get '8.8.8.8' "
@@ -733,7 +733,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 			})
 		})
 
-		It("In the default scenario, the `ip rules` should be as expected and the default route should be on net1", Label("C00011"), func() {
+		It("In the default scenario, the `ip rules` should be as expected and the default route should be on eth0", Label("C00011"), func() {
 			podIppoolsAnno := types.AnnoPodIPPoolsValue{
 				types.AnnoIPPoolItem{
 					NIC: common.NIC2,
@@ -777,7 +777,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 					executeCommandResult, err := frame.ExecCommandInPod(pod.Name, pod.Namespace, runGetIPString, ctx)
 					GinkgoWriter.Println("Execute command result: ", string(executeCommandResult))
 					Expect(err).NotTo(HaveOccurred(), "failed to execute command, error is: %v ", err)
-					Expect(string(executeCommandResult)).Should(ContainSubstring(common.NIC2), "Expected NIC %v mismatch", common.NIC2)
+					Expect(string(executeCommandResult)).Should(ContainSubstring(common.NIC1), "Expected NIC %v mismatch", common.NIC2)
 
 					// ip r get <IP in eth0 subnet>, should flow out from eth0
 					GinkgoWriter.Println("ip -4 r get <IP in eth0 subnet>")
@@ -819,7 +819,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 					executeCommandResult, err := frame.ExecCommandInPod(pod.Name, pod.Namespace, runGetIPString, ctx)
 					GinkgoWriter.Println("Execute ipv6 command result: ", string(executeCommandResult))
 					Expect(err).NotTo(HaveOccurred(), "failed to execute ipv6 command, error is: %v ", err)
-					Expect(string(executeCommandResult)).Should(ContainSubstring(common.NIC2), "Expected NIC %v mismatch", common.NIC2)
+					Expect(string(executeCommandResult)).Should(ContainSubstring(common.NIC1), "Expected NIC %v mismatch", common.NIC2)
 
 					// ip r get <IP in eth0 subnet>, should flow out from eth0
 					GinkgoWriter.Println("ip -6 r get <IP in eth0 subnet>")


### PR DESCRIPTION
In multi-NIC mode, all routes for each NIC, including both the routes for the cluster and service subnet are retained in both the main table and a new policy routing table, except for the default route. The default route for each NIC can only exist in a unique policy routing table.

## Thanks for contributing!

<!--Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>-->

#### What type of PR is this?


- release/feature

<!--
Add one of the following kinds:

Required labels:

- release/none 
- release/bug 
- release/feature

Optional labels:

- kind/bug
- kind/feature
- kind/ci-bug
- kind/doc
-->

**What this PR does / why we need it**:

- In multi-NIC mode, The KubeVirt project aims to include the routes for each network interface in the main table. all routes for each NIC, including both the routes for the cluster and service subnet are retained in both the main table and a new policy routing table, except for the default route. The default route for each NIC can only exist in a unique policy routing table. 

- By default, the first network interface with the default route is selected as the default route interface for the pod. The default routes of other interfaces are moved to a new policy routing table


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/spidernet-io/spiderpool/issues/2176
Fixes https://github.com/spidernet-io/spiderpool/issues/2491

**Special notes for your reviewer**:
