### PR TITLE
fix path typo in spiderpool-agent yaml

### DIFF
--- a/charts/spiderpool/templates/daemonset.yaml
+++ b/charts/spiderpool/templates/daemonset.yaml
@@ -246,7 +246,7 @@ spec:
           mountPath: /tmp/spiderpool/config-map
           readOnly: true
         - name: cni-bin-path
-          mountPath: /host/{{ .Values.global.cniBinHostPath }}
+          mountPath: /host{{ .Values.global.cniBinHostPath }}
         - name: ipam-unix-socket-dir
           mountPath: {{ dir .Values.global.ipamUNIXSocketHostPath }}
         {{- if .Values.spiderpoolAgent.extraVolumes }}


### PR DESCRIPTION
The previous spiderpool-agent container volumeMounts cni-bin-path is `host//opt/cni/bin`.
It works well but displays ugly

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)