### PR TITLE
coordinator: ensure detect gateway and ip conflict in pod's netns

### DIFF
--- a/cmd/coordinator/cmd/utils.go
+++ b/cmd/coordinator/cmd/utils.go
@@ -26,7 +26,7 @@ type coordinator struct {
 	tuneMode                                    Mode
 	hostVethName, podVethName, currentInterface string
 	HijackCIDR, podNics                         []string
-	netns                                       ns.NetNS
+	netns, hostNs                               ns.NetNS
 	hostVethHwAddress, podVethHwAddress         net.HardwareAddr
 	currentAddress                              []netlink.Addr
 	v4PodOverlayNicAddr, v6PodOverlayNicAddr    *net.IPNet

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.25.0
 	golang.org/x/net v0.17.0
-	golang.org/x/sync v0.3.0
+	golang.org/x/sync v0.3.0 // indirect
 	golang.org/x/sys v0.14.0
 	golang.org/x/tools v0.11.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1

--- a/pkg/errgroup/README.md
+++ b/pkg/errgroup/README.md
@@ -1,0 +1,10 @@
+# errgroup
+
+## Background
+
+This file originates from "golang.org/x/sync/errgroup". The coordinator plugin uses errgroup to concurrently check the reachability of gateways and whether IP addresses conflict.
+However, when launching goroutines in [netns.Do]("github.com/containernetworking/plugins/pkg/ns"), the Go runtime cannot guarantee that the code will be executed in the specified 
+network namespace. Therefore, we modified the `Go()` method of errgroup: manually switch to the target network namespace when launching a goroutine and return to the original network 
+namespace after execution.
+
+Please see `errgroup.go` to find more details.

--- a/pkg/errgroup/errgroup.go
+++ b/pkg/errgroup/errgroup.go
@@ -1,0 +1,111 @@
+// Copyright 2023 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package errgroup provides synchronization, error propagation, and Context
+// cancellation for groups of goroutines working on subtasks of a common task.
+
+package errgroup
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+)
+
+type token struct{}
+
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero Group is valid, has no limit on the number of active goroutines,
+// and does not cancel on error.
+type Group struct {
+	cancel func(error)
+
+	wg sync.WaitGroup
+
+	sem chan token
+
+	errOnce sync.Once
+	err     error
+}
+
+func (g *Group) done() {
+	if g.sem != nil {
+		<-g.sem
+	}
+	g.wg.Done()
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	if g.cancel != nil {
+		g.cancel(g.err)
+	}
+	return g.err
+}
+
+// Go calls the given function in a new goroutine.
+// It blocks until the new goroutine can be added without the number of
+// active goroutines in the group exceeding the configured limit.
+//
+// The first call to return a non-nil error cancels the group's context, if the
+// group was created by calling WithContext. The error will be returned by Wait.
+//
+// UPDATED: golang each OS thread can have a different
+// network namespace, and Go's thread scheduling is highly
+// variable, callers cannot guarantee any specific namespace
+// is set unless operations that require that namespace are
+// wrapped with Do().
+// see https://github.com/golang/go/wiki/LockOSThread and
+// https://www.weave.works/blog/linux-namespaces-golang-followup
+// to more details.
+func (g *Group) Go(srcNs, targetNs ns.NetNS, f func() error) {
+	if g.sem != nil {
+		g.sem <- token{}
+	}
+
+	g.wg.Add(1)
+	go func() {
+		defer g.done()
+		runtime.LockOSThread()
+
+		// switch to pod's netns
+		if err := targetNs.Set(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = fmt.Errorf("failed to switch to pod's netns: %v", err)
+				if g.cancel != nil {
+					g.cancel(g.err)
+				}
+			})
+		}
+
+		defer func() {
+			err := srcNs.Set() // switch back
+			if err == nil {
+				// Unlock the current thread only when we successfully switched back
+				// to the original namespace; otherwise leave the thread locked which
+				// will force the runtime to scrap the current thread, that is maybe
+				// not as optimal but at least always safe to do.
+				runtime.UnlockOSThread()
+			}
+		}()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel(g.err)
+				}
+			})
+		}
+	}()
+}


### PR DESCRIPTION
The coordinator plugin uses errgroup to concurrently check the reachability of gateways and whether IP addresses conflict.However, when launching goroutines in [netns.Do]("github.com/containernetworking/plugins/pkg/ns"), the Go runtime cannot guarantee that the code will be executed in the specified network namespace. Therefore, we modified the Go method of errgroup: manually switch to the target network namespace when launching a goroutine and return to the original network namespace after execution.

## Thanks for contributing!

<!--Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>-->

#### What type of PR is this?

- release/bug 
- kind/bug

<!--
Add one of the following kinds:

Required labels:

- release/none 
- release/bug 
- release/feature

Optional labels:

- kind/bug
- kind/feature
- kind/ci-bug
- kind/doc
-->

**What this PR does / why we need it**:

coordinator: Detect gateway in pod's netns without in hostNs

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/spidernet-io/spiderpool/issues/2748

**Special notes for your reviewer**:
