### PR TITLE
e2e-fix: Use the default calico version when getting the calico version fails

### DIFF
--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -130,6 +130,7 @@ E2E_MULTUS_IMAGE_NAME ?= $(E2E_MULTUS_IMAGE_REGISTER)/k8snetworkplumbingwg/multu
 
 #================= calico
 CALICO_VERSION ?=
+DEFAULT_CALICO_VERSION ?= v3.26.4
 
 ifeq ($(E2E_CHINA_IMAGE_REGISTRY),true)
   CALICO_IMAGE_REPO ?= docker.m.daocloud.io

--- a/test/scripts/install-default-cni.sh
+++ b/test/scripts/install-default-cni.sh
@@ -56,9 +56,9 @@ CILIUM_CLUSTER_POD_SUBNET_V6=${CILIUM_CLUSTER_POD_SUBNET_V6:-"fd00:10:244::/112"
 function install_calico() {
     cp ${PROJECT_ROOT_PATH}/test/yamls/calico.yaml $CLUSTER_PATH/calico.yaml
     if [ -z "${CALICO_VERSION}" ]; then
-      [ -n "${HTTP_PROXY}" ] && CALICO_VERSION=$(curl --retry 3 -x "${HTTP_PROXY}" -s https://api.github.com/repos/projectcalico/calico/releases/latest | jq -r '.tag_name')
-      [ -z "${HTTP_PROXY}" ] && CALICO_VERSION=$(curl --retry 3 -s https://api.github.com/repos/projectcalico/calico/releases/latest | jq -r '.tag_name')
-      [ "${CALICO_VERSION}" == "null" ] && { echo "failed get calico version"; exit 1; }
+      [ -n "${HTTP_PROXY}" ] && { CALICO_VERSION_INFO=$(curl --retry 3 --retry-delay 5 -x "${HTTP_PROXY}" -s https://api.github.com/repos/projectcalico/calico/releases/latest); echo ${CALICO_VERSION_INFO}; CALICO_VERSION=$(echo ${CALICO_VERSION_INFO} | jq -r '.tag_name'); }
+      [ -z "${HTTP_PROXY}" ] && { CALICO_VERSION_INFO=$(curl --retry 3 --retry-delay 5 -s https://api.github.com/repos/projectcalico/calico/releases/latest ); echo ${CALICO_VERSION_INFO}; CALICO_VERSION=$(echo ${CALICO_VERSION_INFO} | jq -r '.tag_name'); }
+      [ "${CALICO_VERSION}" == "null" ] && { echo "failed to get the calico version, will try to use default version."; CALICO_VERSION=${DEFAULT_CALICO_VERSION}; }
     else
       CALICO_VERSION=${CALICO_VERSION}
     fi


### PR DESCRIPTION
#### What type of PR is this?
- release/none 
- release/bug 

<!--
Add one of the following kinds:

Required labels:

- release/none 
- release/bug 
- release/feature

Optional labels:

- kind/bug
- kind/feature
- kind/ci-bug
- kind/doc
-->

**What this PR does / why we need it**:
e2e-fix: specify the calico version manually when failed to retrieve it specify the calico version manually when failed to retrieve it

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
close #2718

**Special notes for your reviewer**:
