### PR TITLE
add validation for IPAM IPPools annotation usage

### DIFF
--- a/cmd/spiderpool/cmd/command_add.go
+++ b/cmd/spiderpool/cmd/command_add.go
@@ -182,5 +182,9 @@ func assembleResult(cniVersion, IfName string, ipamResponse *daemonset.PostIpamI
 		}
 	}
 
+	if len(result.IPs) == 0 {
+		return nil, fmt.Errorf("no Interface %s IP allocation found", IfName)
+	}
+
 	return result, nil
 }

--- a/pkg/ipam/pool_selections.go
+++ b/pkg/ipam/pool_selections.go
@@ -49,7 +49,7 @@ func (i *ipam) getPoolCandidates(ctx context.Context, addArgs *models.IpamAddArg
 
 	// Select IPPool candidates through the Pod annotation "ipam.spidernet.io/ippools".
 	if anno, ok := pod.Annotations[constant.AnnoPodIPPools]; ok {
-		return getPoolFromPodAnnoPools(ctx, anno)
+		return getPoolFromPodAnnoPools(ctx, anno, *addArgs.IfName)
 	}
 
 	// Select IPPool candidates through the Pod annotation "ipam.spidernet.io/ippool".
@@ -305,7 +305,7 @@ func (i *ipam) applyThirdControllerAutoPool(ctx context.Context, subnetName stri
 	return pool, nil
 }
 
-func getPoolFromPodAnnoPools(ctx context.Context, anno string) (ToBeAllocateds, error) {
+func getPoolFromPodAnnoPools(ctx context.Context, anno, currentNIC string) (ToBeAllocateds, error) {
 	logger := logutils.FromContext(ctx)
 	logger.Sugar().Infof("Use IPPools from Pod annotation '%s'", constant.AnnoPodIPPools)
 
@@ -317,7 +317,7 @@ func getPoolFromPodAnnoPools(ctx context.Context, anno string) (ToBeAllocateds, 
 	}
 
 	// validate and mutate the IPPools annotation value
-	err = validateAndMutateMultipleNICAnnotations(annoPodIPPools)
+	err = validateAndMutateMultipleNICAnnotations(annoPodIPPools, currentNIC)
 	if nil != err {
 		return nil, fmt.Errorf("%w: %v", errPrefix, err)
 	}

--- a/test/doc/annotation.md
+++ b/test/doc/annotation.md
@@ -1,7 +1,7 @@
 # E2E Cases for Annotation
 
 | Case ID | Title                                                                                                                       | Priority | Smoke | Status | Other |
-| ------- |-----------------------------------------------------------------------------------------------------------------------------|----------|-------|--------|-------|
+|---------|-----------------------------------------------------------------------------------------------------------------------------|----------|-------|--------|-------|
 | A00001  | It fails to run a pod with different VLANs for IPv4 and IPv6 IPPools                                                        | p3       |       | done   |       |
 | A00002  | Added fields such as `"dist":"1.0.0.0/16"`, `"gw":"1.0.0.1"`, and `nics` and the pod was running successfully               | p2       |       | done   |       |
 | A00003  | Failed to run a pod with invalid annotations                                                                                | p3       |       | done   |       |
@@ -13,3 +13,5 @@
 | A00010  | Modify the annotated IPPool for a pod running on multiple NICs                                                              | p3       |       | done   |       |
 | A00011  | Use the ippool route with `cleanGateway=false` in the pod annotation as a default route                                     | p3       |       | done   |       |
 | A00012  | Specify the default NIC through Pod annotations                                                                             | p2       |       |        |       |
+| A00013  | It's invalid to specify one NIC corresponding IPPool in IPPools annotation with multiple NICs                               | p2       |       | done   |       |
+| A00014  | It's invalid to specify same NIC name for IPPools annotation with multiple NICs                                             | p2       |       | done   |       |


### PR DESCRIPTION
1. Once multiple NICs use spiderpool as IPAM, if you use annotaion `ipam.spidernet.io/ippools`, you have to specify the same correct IPPool slice for multiple NICs. Add strong validation in this PR.
For instance, if you have 2 NICs and use `ipam.spidernet.io/ippools` to specify the IPPools, you need to specify each NIC corresponding IPPools

```text
// Bad
ipam.spidernet.io/ippools: '[{"interface": "net1","ipv4": ["ens6-v4"],"ipv6":["ens6-v6"]}]'
---
// Good
ipam.spidernet.io/ippools: '[{"interface": "eth0","ipv4": ["ens5-v4"],"ipv6":["ens5-v6"]},{"interface": "net1","ipv4": ["ens6-v4"],"ipv6":["ens6-v6"]}]'
```

2. Add validation for same NICs name in `ipam.spidernet.io/ippools`. 

```text
// Bad
ipam.spidernet.io/ippools: '[{"interface": "eth0","ipv4": ["ens5-v4"],"ipv6":["ens5-v6"]},{"interface": "eth0","ipv4": ["ens6-v4"],"ipv6":["ens6-v6"]}]'
```

3. Add validation for spiderpool IPAM binary with NIC address.


Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)

**What this PR does / why we need it**:
fix bug

**Which issue(s) this PR fixes**:
close #2901 #2903 

