### PR TITLE
spidercoordinator: It should update the status to NotReady if any errors occur

### DIFF
--- a/pkg/coordinatormanager/coordinator_informer.go
+++ b/pkg/coordinatormanager/coordinator_informer.go
@@ -320,7 +320,6 @@ func (cc *CoordinatorController) syncHandler(ctx context.Context, coordinatorNam
 	coordCopy, err = cc.fetchPodAndServerCIDR(ctx, logger, coordCopy)
 	if err != nil {
 		logger.Sugar().Errorf("failed to handle spidercoordinator: %v", err)
-		return err
 	}
 
 	if !reflect.DeepEqual(coordCopy.Status, coord.Status) {
@@ -328,6 +327,7 @@ func (cc *CoordinatorController) syncHandler(ctx context.Context, coordinatorNam
 			logger.Sugar().Errorf("failed to patch spidercoordinator phase: %v", err.Error())
 			return err
 		}
+		logger.Sugar().Infof("Success to patch coordinator's status to %v", coordCopy.Status)
 	}
 
 	return


### PR DESCRIPTION
## Thanks for contributing!

<!--Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>-->

#### What type of PR is this?

- release/none 

<!--
Add one of the following kinds:

Required labels:

- release/none 
- release/bug 
- release/feature

Optional labels:

- kind/bug
- kind/feature
- kind/ci-bug
- kind/doc
-->

**What this PR does / why we need it**:

If obtaining the CIDR information of the cluster fails, we should update its status to NotReady. This prevents the normal creation of pods. Otherwise, the pod will use the incorrect CIDR. Causing communication issues.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/spidernet-io/spiderpool/issues/2928

**Special notes for your reviewer**:
