### PR TITLE
single POD without controller is forbidden to use  SpiderSubnet feature

### DIFF
--- a/docs/usage/spider-subnet-zh_CN.md
+++ b/docs/usage/spider-subnet-zh_CN.md
@@ -16,7 +16,9 @@ SpiderSubnet 资源代表 IP 地址的集合，当需要为应用分配固定的
 
 - 自动创建 IPPool : 应用管理员可在 Pod annotation 中注明使用的 Subnet 实例名，在应用创建时，Spiderpool 会自动根据 Subnet 实例中的可用 IP 地址来创建固定 IP 的 IPPool 实例，从中分配 IP 地址给 Pod。并且 Spiderpool 能够自动监控应用的扩缩容和删除事件，自动完成 IPPool 中的 IP 地址扩缩容和删除。
 
-SpiderSubnet 功能还支持众多的控制器，如：ReplicaSet、Deployment、Statefulset、Daemonset、Job、Cronjob，第三方控制器等。对于第三方控制器，您可以参考[示例](./operator.md)
+SpiderSubnet 功能还支持众多的控制器，如：ReplicaSet、Deployment、Statefulset、Daemonset、Job、Cronjob，第三方控制器等。对于第三方控制器，您可以参考[示例](./operator.md)。
+
+该功能并不支持自主式 Pod。
 
 > 注意：在 v0.7.0 版本之前，在启动 SpiderSubnet 功能下你必须得先创建一个 SpiderSubnet 资源才可以创建 SpiderIPPool 资源。在v0.7.0版本开始，支持创建一个独立的 SpiderIPPool 资源而不依赖于 SpiderSubnet 资源。
 

--- a/docs/usage/spider-subnet.md
+++ b/docs/usage/spider-subnet.md
@@ -19,6 +19,8 @@ To allocate fixed IP addresses for applications and decouple the roles of applic
 
 SpiderSubnet also supports several controllers, including ReplicaSet, Deployment, StatefulSet, DaemonSet, Job, CronJob, and k8s extended operator. If you need to use a third-party controller, you can refer to the doc [Spiderpool supports operator](./operator.md).
 
+This feature does not support the bare Pod.
+
 > Notice: Before v0.7.0 version, you have to create a SpiderSubnet resource before you create a SpiderIPPool resource with SpiderSubnet feature enabled. Since v0.7.0 version, you can create an orphan SpiderIPPool without a SpiderSubnet resource.
 
 ## Prerequisites

--- a/test/doc/subnet.md
+++ b/test/doc/subnet.md
@@ -24,3 +24,4 @@
 | I00020  | Redundant IPs for automatic IPPool, which cannot be used by other applications                                                      | p3       |       | done    |       |
 | I00021  | Pod works correctly when multiple NICs are specified by annotations for applications of the same name                               | p3       |       | done    |       |
 | I00022  | Dirty data in the subnet should be recycled.                                                                                        | p3       |       | done    |       |
+| I00023  | SpiderSubnet feature doesn't support orphan pod                                                                                     | p2       |       | done    |       |


### PR DESCRIPTION
The SpiderSubnet feature doesn't support orphan pod(pod without any controller), So once the user use it wrongly, we should return the exact error information


Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)


**What this PR does / why we need it**:
fix bug

**Which issue(s) this PR fixes**:
close #2951 