### PR TITLE
fix:  spiderpool-agent crashes when kubevirt static IP feature is off 

### DIFF
--- a/cmd/spiderpool-agent/cmd/daemon.go
+++ b/cmd/spiderpool-agent/cmd/daemon.go
@@ -342,14 +342,12 @@ func initAgentServiceManagers(ctx context.Context) {
 	}
 	agentContext.StsManager = statefulSetManager
 
-	if agentContext.Cfg.EnableKubevirtStaticIP {
-		logger.Debug("Begin to initialize Kubevirt manager")
-		kubevirtManager := kubevirtmanager.NewKubevirtManager(
-			agentContext.CRDManager.GetClient(),
-			agentContext.CRDManager.GetAPIReader(),
-		)
-		agentContext.KubevirtManager = kubevirtManager
-	}
+	logger.Debug("Begin to initialize Kubevirt manager")
+	kubevirtManager := kubevirtmanager.NewKubevirtManager(
+		agentContext.CRDManager.GetClient(),
+		agentContext.CRDManager.GetAPIReader(),
+	)
+	agentContext.KubevirtManager = kubevirtManager
 
 	logger.Debug("Begin to initialize Endpoint manager")
 	endpointManager, err := workloadendpointmanager.NewWorkloadEndpointManager(

--- a/cmd/spiderpool-controller/cmd/daemon.go
+++ b/cmd/spiderpool-controller/cmd/daemon.go
@@ -262,14 +262,12 @@ func initControllerServiceManagers(ctx context.Context) {
 	}
 	controllerContext.StsManager = statefulSetManager
 
-	if controllerContext.Cfg.EnableKubevirtStaticIP {
-		logger.Debug("Begin to initialize Kubevirt manager")
-		kubevirtManager := kubevirtmanager.NewKubevirtManager(
-			controllerContext.CRDManager.GetClient(),
-			controllerContext.CRDManager.GetAPIReader(),
-		)
-		controllerContext.KubevirtManager = kubevirtManager
-	}
+	logger.Debug("Begin to initialize Kubevirt manager")
+	kubevirtManager := kubevirtmanager.NewKubevirtManager(
+		controllerContext.CRDManager.GetClient(),
+		controllerContext.CRDManager.GetAPIReader(),
+	)
+	controllerContext.KubevirtManager = kubevirtManager
 
 	logger.Debug("Begin to initialize Endpoint manager")
 	endpointManager, err := workloadendpointmanager.NewWorkloadEndpointManager(


### PR DESCRIPTION
Once we disable kubevirt static IP feature, the spiderpool-agent pod can not start successfully.
Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)

**What this PR does / why we need it**:
fix bug

**Which issue(s) this PR fixes**:
close #2966 
