### PR TITLE
Minor changes about bullets indentations and punctuations in docs/readme

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -15,15 +15,15 @@
 
 [**English**](./README.md) | **简体中文**
 
-Spiderpool 是 [CNCF](https://www.cncf.io) 的一个 [Sandbox 项目](https://landscape.cncf.io/card-mode?category=cloud-native-network&grouping=category)
+Spiderpool 是 [CNCF](https://www.cncf.io) 的一个 [Sandbox 项目](https://landscape.cncf.io/card-mode?category=cloud-native-network&grouping=category)。
 
-Spiderpool 提供了一个 Kubernetes 的 underlay 和 RDMA 网络解决方案, 它能运行在裸金属、虚拟机和公有云上
+Spiderpool 提供了一个 Kubernetes 的 underlay 和 RDMA 网络解决方案, 它能运行在裸金属、虚拟机和公有云上。
 
 ## Spiderpool 介绍
 
-Spiderpool 是一个 kubernetes 的 underlay 和 RDMA 网络解决方案，它增强了 [Macvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/macvlan),
-[ipvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/ipvlan),
-[SR-IOV CNI](https://github.com/k8snetworkplumbingwg/sriov-cni) 的功能，满足了各种网络需求，使得 underlay 网络方案可应用在**裸金属、虚拟机和公有云环境**中，可为网络 I/O 密集性、低延时应用带来优秀的网络性能，包括**存储、中间件、AI 等应用**。详细的文档可参考[文档站](https://spidernet-io.github.io/spiderpool/)
+Spiderpool 是一个 kubernetes 的 underlay 和 RDMA 网络解决方案，它增强了 [Macvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/macvlan)、
+[ipvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/ipvlan) 和
+[SR-IOV CNI](https://github.com/k8snetworkplumbingwg/sriov-cni) 的功能，满足了各种网络需求，使得 underlay 网络方案可应用在**裸金属、虚拟机和公有云环境**中，可为网络 I/O 密集性、低延时应用带来优秀的网络性能，包括**存储、中间件、AI 等应用**。详细的文档可参考[文档站](https://spidernet-io.github.io/spiderpool/)。
 
 ## Underlay CNI 的优势
 
@@ -35,7 +35,7 @@ underlay CNI 主要指 macvlan、ipvlan、SR-IOV 等能够直接访问宿主机�
 
 * 可直接对接 underlay 二层 VLAN 网络，应用可进行二层、三层网络通信，可进行组播、多播通信，数据包可受防火墙管控。
 
-* 数据包携带 Pod 的真正 IP 地址，应用可直接基于 Pod IP 进行南北向通信，多云网络天然联通。
+* 数据包携带 Pod 的真正 IP 地址，应用可直接基于 Pod IP 进行南北向通信，多云网络天然连通。
 
 * underlay CNI 可基于宿主机不同的父网卡来创建虚拟机接口，因此可为存储、观测性等网络开销大的应用提供隔离的子网。
 
@@ -49,22 +49,22 @@ underlay CNI 主要指 macvlan、ipvlan、SR-IOV 等能够直接访问宿主机�
 
 * 基于 CRD 的双栈 IPAM 能力
 
-    提供了独享、共享的 IP 地址池，支持设置各种亲和性，为中间件等有状态应用和 kubevirt 等固定 IP 地址值，为无状态应用固定 IP 地址范围，自动化管理独享的 IP 池，优秀的 IP 回收避免 IP 泄露等。并且，具备优秀的 [IPAM 分配性能](./docs/concepts/ipam-performance-zh_CN.md) 。
+    提供了独享、共享的 IP 地址池，支持设置各种亲和性，为中间件等有状态应用和 kubevirt 等固定 IP 地址值，为无状态应用固定 IP 地址范围，自动化管理独享的 IP 池，优秀的 IP 回收避免 IP 泄露等。并且，具备优秀的 [IPAM 分配性能](./docs/concepts/ipam-performance-zh_CN.md)。
 
-    Spiderpool IPAM 组件能够为任何支持第三方 IPAM 的 main CNI 使用，不仅包含了 [Macvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/macvlan), [ipvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/ipvlan), [SR-IOV CNI](https://github.com/k8snetworkplumbingwg/sriov-cni), 也包括了 [calico](https://github.com/projectcalico/calico) [weave](https://github.com/weaveworks/weave) 作为静态 IP 场景使用。
+    Spiderpool IPAM 组件能够为任何支持第三方 IPAM 的 main CNI 使用，不仅包含了 [Macvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/macvlan)、[ipvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/ipvlan) 和 [SR-IOV CNI](https://github.com/k8snetworkplumbingwg/sriov-cni), 也包括了 [calico](https://github.com/projectcalico/calico) 和 [weave](https://github.com/weaveworks/weave) 作为静态 IP 场景使用。
 
 * underlay 和 overlay CNI 的多网卡接入
 
     它包括了 “Pod 插入多个 underlay CNI 网卡”、“Pod 插入一个 overlay CNI 和 多个 underlay CNI 网卡”两种场景，Pod 具备多种 CNI 网卡，Spiderpool 能够为多个
-    underlay CNI 网卡定制不同的 IP 地址，调协所有网卡之间的策略路由，以确保请求向和回复向数据路径一致而避免丢包，它能够为 [cilium](https://github.com/cilium/cilium), [calico](https://github.com/projectcalico/calico), [kubevirt](https://github.com/kubevirt/kubevirt) 等项目进行增强。
+    underlay CNI 网卡定制不同的 IP 地址，调协所有网卡之间的策略路由，以确保请求向和回复向数据路径一致而避免丢包，它能够为 [cilium](https://github.com/cilium/cilium)、[calico](https://github.com/projectcalico/calico) 和 [kubevirt](https://github.com/kubevirt/kubevirt) 等项目进行增强。
 
 * 增强的网络连通性
 
-    众所周知，原生的 macvlan ipvlan SR-IOV 存在诸多通信限制。但是，Spiderpool 打通 Pod 和宿主机的连通性，确保 Pod 健康检测工作正常，并可通过 kube-proxy 或 eBPF kube-proxy replacement 使得 Pod 访问 service，支持 Pod 的 IP 冲突检测、网关可达性检测等。多集群网络可基于相同的 underlay 网络或者 [Submariner](https://github.com/submariner-io/submariner) 实现联通。
+    众所周知，原生的 macvlan ipvlan SR-IOV 存在诸多通信限制。但是，Spiderpool 打通 Pod 和宿主机的连通性，确保 Pod 健康检测工作正常，并可通过 kube-proxy 或 eBPF kube-proxy replacement 使得 Pod 访问 service，支持 Pod 的 IP 冲突检测、网关可达性检测等。多集群网络可基于相同的 underlay 网络或者 [Submariner](https://github.com/submariner-io/submariner) 实现连通。
 
 * eBPF 增强
 
-    kube-proxy replacement 技术极大加速了访问 service 场景，同节点上的 socket 短路技术加速了本地 Pod 的通信效率。相比 kube proxy 解析方式，[网络延时有最大 25% 的改善，网络吞吐有 50% 的提高](./docs/concepts/io-performance-zh_CN.md) 。
+    kube-proxy replacement 技术极大加速了访问 service 场景，同节点上的 socket 短路技术加速了本地 Pod 的通信效率。相比 kube proxy 解析方式，[网络延时有最大 25% 的改善，网络吞吐有 50% 的提高](./docs/concepts/io-performance-zh_CN.md)。
 
 * RDMA
 
@@ -76,7 +76,7 @@ underlay CNI 主要指 macvlan、ipvlan、SR-IOV 等能够直接访问宿主机�
 
 * 优秀的网络延时和吞吐量性能
 
-    Spiderpool 在网络延时和吞吐量方面表现出色，超过了 overlay CNI，可参考 [性能报告](./docs/concepts/io-performance-zh_CN.md)
+    Spiderpool 在网络延时和吞吐量方面表现出色，超过了 overlay CNI，可参考 [性能报告](./docs/concepts/io-performance-zh_CN.md)。
 
 * 指标
 
@@ -86,40 +86,40 @@ Spiderpool 基于 underlay CNI 提供了比 overlay CNI 还优越的网络性能
 
 * 支持运行在裸金属、虚拟机、各大公有云厂商等环境，尤其为混合云提供了统一的 underlay CNI 解决方案。
 
-* 传统的主机应用。它们希望直接使用 underlay 网络进行通信，例如直接访问 underlay 多子网、多播、组播、二层网络通信等，它们不能接受 overlay 网络的 NAT，希望进行无缝移植的 Kubernetes 。
+* 传统的主机应用。它们希望直接使用 underlay 网络进行通信，例如直接访问 underlay 多子网、多播、组播、二层网络通信等，它们不能接受 overlay 网络的 NAT，希望进行无缝移植的 Kubernetes。
 
-* 中间件、数据存储、日志观测、AI 训练等网络 I/O 密集性应用
+* 中间件、数据存储、日志观测、AI 训练等网络 I/O 密集性应用。
 
-* 网络延时敏感型应用
+* 网络延时敏感型应用。
 
 ## 快速开始
 
-参考 [快速搭建](./docs/usage/install/get-started-kind-zh_CN.md) 来使用 Spiderpool
+* 参考 [快速搭建](./docs/usage/install/get-started-kind-zh_CN.md) 来使用 Spiderpool
 
-参考 [使用](./docs/usage/readme.md) 来了解各种功能的使用方法
+* 参考 [使用](./docs/usage/readme.md) 来了解各种功能的使用方法
 
-参考 [架构](./docs/concepts/arch-zh_CN.md)
+* 参考 [架构](./docs/concepts/arch-zh_CN.md)
 
 ## Roadmap
 
-| 功能                               | macvlan  | ipvlan | SR-IOV    |
-|----------------------------------|----------|---|-----------|
-| Service By Kubeproxy             | Beta     |  Beta | Beta      |
-| Service By Kubeproxy Replacement | Alpha    |  Alpha | Alpha     |
-| Network Policy                   | In-plan  |  Alpha | In-plan   |
-| Bandwidth                        | In-plan  | Alpha  | In-plan    |
-| RDMA                             | Alpha    | Alpha | Alpha     |
-| IPAM                             | Beta     | Beta | Beta      |
-| Multi-Cluster                    | Alpha    | Alpha | Alpha     |
-| Egress Policy                    | Alpha    | Alpha | Alpha     |
-| 多网卡和路由调谐                         | beta     | beta | beta      |
-| 适用场景                             | 裸金属      | 裸金属和虚拟机 | 裸金属       |
+| 功能                              | macvlan  | ipvlan | SR-IOV    |
+|----------------------------------|----------|---------|-----------|
+| Service By Kubeproxy             | Beta     |  Beta   | Beta      |
+| Service By Kubeproxy Replacement | Alpha    |  Alpha  | Alpha     |
+| Network Policy                   | In-plan  |  Alpha  | In-plan   |
+| Bandwidth                        | In-plan  | Alpha   | In-plan   |
+| RDMA                             | Alpha    | Alpha   | Alpha     |
+| IPAM                             | Beta     | Beta    | Beta      |
+| Multi-Cluster                    | Alpha    | Alpha   | Alpha     |
+| Egress Policy                    | Alpha    | Alpha   | Alpha     |
+| 多网卡和路由调谐                  | beta     | beta    | beta      |
+| 适用场景                         | 裸金属    | 裸金属和虚拟机 | 裸金属 |
 
-关于所有的功能规划，具体可参考 [roadmap](./docs/develop/roadmap.md)
+关于所有的功能规划，具体可参考 [roadmap](./docs/develop/roadmap.md)。
 
 ## Blogs
 
-可参考 [Blogs](./docs/concepts/blog-zh_CN.md)
+可参考 [Blogs](./docs/concepts/blog-zh_CN.md)。
 
 ## Governance
 
@@ -127,15 +127,15 @@ Spiderpool 项目由一组[维护者和提交者](./AUTHORS)管理，我们的[G
 
 ## 使用者
 
-使用了 Spiderpool 项目的 [用户](./docs/USERS.md).
+使用了 Spiderpool 项目的[用户](./docs/USERS.md)。
 
 ## 参与开发
 
-可参考 [开发搭建文档](./docs/develop/contributing.md).
+可参考[开发搭建文档](./docs/develop/contributing.md)。
 
 ## 社区
 
-Spiderpool 社区致力于营造一个开放和热情的环境，并通过多种方式与其他用户和开发人员互动。 您可以访问我们的 [社区网站](https://github.com/spidernet-io/community) 了解更多信息
+Spiderpool 社区致力于营造一个开放和热情的环境，并通过多种方式与其他用户和开发人员互动。您可以访问我们的 [社区网站](https://github.com/spidernet-io/community) 了解更多信息。
 
 * Slack: 如果你想在 CNCF Slack 加入 Spiderpool 的频道, 请先得到 CNCF Slack 的 **[邀请](https://slack.cncf.io/)**
   然后加入 [#Spiderpool](https://cloud-native.slack.com/messages/spiderpool) 的频道。
@@ -156,9 +156,9 @@ Spiderpool is licensed under the Apache License, Version 2.0. See [LICENSE](./LI
 
 Copyright The Spiderpool Authors
 
-We are a [Cloud Native Computing Foundation](https://www.cncf.io) [sandbox project](https://landscape.cncf.io/card-mode?category=cloud-native-network&grouping=category)
+We are a [Cloud Native Computing Foundation](https://www.cncf.io) [sandbox project](https://landscape.cncf.io/card-mode?category=cloud-native-network&grouping=category).
 
-The Linux Foundation® (TLF) has registered trademarks and uses trademarks. For a list of TLF trademarks, see [Trademark Usage](https://www.linuxfoundation.org/legal/trademark-usage)
+The Linux Foundation® (TLF) has registered trademarks and uses trademarks. For a list of TLF trademarks, see [Trademark Usage](https://www.linuxfoundation.org/legal/trademark-usage).
 
 <p align="center">
 <img src="https://landscape.cncf.io/images/left-logo.svg" width="300"/>&nbsp;&nbsp;<img src="https://landscape.cncf.io/images/right-logo.svg" width="350"/>

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@
 
 **English** | [**简体中文**](./README-zh_CN.md)
 
-We are a [Cloud Native Computing Foundation](https://www.cncf.io) [sandbox project](https://landscape.cncf.io/card-mode?category=cloud-native-network&grouping=category)
+We are a [Cloud Native Computing Foundation](https://www.cncf.io) [sandbox project](https://landscape.cncf.io/card-mode?category=cloud-native-network&grouping=category).
 
-Spiderpool is the underlay and RDMA network solution of the Kubernetes, for bare metal, VM and any public cloud
+Spiderpool is the underlay and RDMA network solution of the Kubernetes, for bare metal, VM and any public cloud.
 
 ## Introduction
 
@@ -29,7 +29,7 @@ It could refer to [website](https://spidernet-io.github.io/spiderpool/) for more
 
 ## The Advantages Of Underlay CNI
 
-The underlay CNI is mainly including macvlan, ipvlan, and SR-IOV, which cloud access the layer 2 network of the node. It has some advantages :
+The underlay CNI is mainly including macvlan, ipvlan, and SR-IOV, which cloud access the layer 2 network of the node. It has some advantages:
 
 * macvlan, ipvlan, and SR-IOV is crucial for supporting RDMA network acceleration. RDMA significantly enhances performance for AI applicaitons, latency-sensitive and network I/O-intensive applications, surpassing overlay network solutions in terms of network performance.
 
@@ -51,17 +51,17 @@ The underlay CNI is mainly including macvlan, ipvlan, and SR-IOV, which cloud ac
 
 * CRD-based dual-stack IPAM
 
-    Spiderpool provides exclusive and shared IP address pools, supporting various affinity settings. It supports to assign static IP addresses for stateful applications such as [mysql](https://www.mysql.com) , [redis](https://github.com/redis/redis) , [kubevirt](https://github.com/kubevirt/kubevirt) , while enabling fixed IP address ranges for stateless ones. Spiderpool automates the management of exclusive IP pools, ensuring excellent IP reclamation to avoid IP leakage. In additions, it owns [wonderful IPAM performance](./docs/concepts/ipam-performance.md).
+    Spiderpool provides exclusive and shared IP address pools, supporting various affinity settings. It supports to assign static IP addresses for stateful applications such as [mysql](https://www.mysql.com), [redis](https://github.com/redis/redis), [kubevirt](https://github.com/kubevirt/kubevirt), while enabling fixed IP address ranges for stateless ones. Spiderpool automates the management of exclusive IP pools, ensuring excellent IP reclamation to avoid IP leakage. In additions, it provides [wonderful IPAM performance](./docs/concepts/ipam-performance.md).
 
-    The IPAM of Spiderpool could be available for any main CNI supporting third-party IPAM plugin, not only including [Macvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/macvlan), [ipvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/ipvlan), [SR-IOV CNI](https://github.com/k8snetworkplumbingwg/sriov-cni), but also [calico](https://github.com/projectcalico/calico) [weave](https://github.com/weaveworks/weave) as static IP usage.
+    The IPAM of Spiderpool could be available for any main CNI supporting third-party IPAM plugin, not only including [Macvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/macvlan), [ipvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/ipvlan), and [SR-IOV CNI](https://github.com/k8snetworkplumbingwg/sriov-cni), but also [calico](https://github.com/projectcalico/calico) and [weave](https://github.com/weaveworks/weave) as static IP usage.
 
 * Multiple network interfaces from underlay and overlay CNI
 
-    Spiderpool enables scenarios where Pods can have multiple underlay CNI interfaces or a combination of overlay and underlay CNI interfaces. It ensures proper IP addressing for each CNI interface and effectively manages policy routing to maintain consistent data paths, eliminating packet loss concerns. It could strengthen [cilium](https://github.com/cilium/cilium), [calico](https://github.com/projectcalico/calico), [kubevirt](https://github.com/kubevirt/kubevirt) .
+    Spiderpool enables scenarios where Pods can have multiple underlay CNI interfaces or a combination of overlay and underlay CNI interfaces. It ensures proper IP addressing for each CNI interface and effectively manages policy routing to maintain consistent data paths, eliminating packet loss concerns. It could strengthen [cilium](https://github.com/cilium/cilium), [calico](https://github.com/projectcalico/calico), and [kubevirt](https://github.com/kubevirt/kubevirt).
 
 * Enhanced network connectivity
 
-    As we know, native CNI of macvlan ipvlan SR-IOV has lots of communication limits. However, Spiderpool establishes seamless connectivity between Pods and host machines, ensuring smooth functioning of Pod health checks. It enables Pods to access services through kube-proxy or eBPF-based kube-proxy replacement. Additionally, it supports advanced features like IP conflict detection and gateway reachability checks. The network of Multi-cluster could be connected by a same underlay network, or [Submariner](https://github.com/submariner-io/submariner) .
+    As we know, native CNI of macvlan ipvlan SR-IOV has lots of communication limits. However, Spiderpool establishes seamless connectivity between Pods and host machines, ensuring smooth functioning of Pod health checks. It enables Pods to access services through kube-proxy or eBPF-based kube-proxy replacement. Additionally, it supports advanced features like IP conflict detection and gateway reachability checks. The network of Multi-cluster could be connected by a same underlay network, or [Submariner](https://github.com/submariner-io/submariner).
 
 * eBPF enhancements
 
@@ -77,7 +77,7 @@ The underlay CNI is mainly including macvlan, ipvlan, and SR-IOV, which cloud ac
 
 * Good network performance of latency and throughput
 
-    Spiderpool performs better than overlay CNI on network latency and throughput, referring to [performance report](./docs/concepts/io-performance.md)
+    Spiderpool performs better than overlay CNI on network latency and throughput, referring to [performance report](./docs/concepts/io-performance.md).
 
 * Metrics
 
@@ -87,25 +87,25 @@ Spiderpool, powered by underlay CNI, offers unparalleled network performance com
 
 * Support to deploy on the environments of bare metal, virtual machine, and public cloud, especially offer an unified underlay CNI solution for hybrid cloud.
 
-* Traditional host applications. They hope to directly use the underlay network, with the reasons such as direct access to the underlay multi-subnet, multicast, multicast, layer 2 network communication, etc. They cannot accept the NAT of the overlay network and hope to seamlessly migrate to Kubernetes .
+* Traditional host applications. They hope to directly use the underlay network, with the reasons such as direct access to the underlay multi-subnet, multicast, multicast, layer 2 network communication, etc. They cannot accept the NAT of the overlay network and hope to seamlessly migrate to Kubernetes.
 
 * Network I/O-intensive applications such as middleware, data storage, log observability, and AI training.
 
-* Applications which needs a separate network bandwidth
+* Applications which needs a separate network bandwidth.
 
 * Latency-sensitive application.
 
 ## Quick Start
 
-Refer to [Quick start](./docs/usage/install/get-started-kind.md) to explore Spiderpool quickly.
+* Refer to [Quick start](./docs/usage/install/get-started-kind.md) to explore Spiderpool quickly.
 
-Refer to [Usage Index](./docs/usage/readme.md) for usage details.
+* Refer to [Usage Index](./docs/usage/readme.md) for usage details.
 
-Refer to [Spiderpool Architecture](./docs/concepts/arch.md) for more detailed information
+* Refer to [Spiderpool Architecture](./docs/concepts/arch.md) for more detailed information
 
 ## Roadmap
 
-| Features                               | macvlan    | ipvlan            | SR-IOV      |
+| Features                         | macvlan    | ipvlan            | SR-IOV      |
 |----------------------------------|------------|-------------------|-------------|
 | Service By Kubeproxy             | Beta       | Beta              | Beta        |
 | Service By Kubeproxy Replacement | Alpha      | Alpha             | Alpha       |
@@ -113,16 +113,16 @@ Refer to [Spiderpool Architecture](./docs/concepts/arch.md) for more detailed in
 | Bandwidth                        | In-plan    | Alpha             | In-plan     |
 | RDMA                             | Alpha      | Alpha             | Alpha       |
 | IPAM                             | Beta       | Beta              | Beta        |
-| Multi-Cluster                    | Alpha    | Alpha             | Alpha     |
+| Multi-Cluster                    | Alpha      | Alpha             | Alpha       |
 | Egress Policy                    | Alpha      | Alpha             | Alpha       |
-| Multiple NIC And Routing Coordination                         | Beta       | Beta              | Beta        |
-| Scenarios                             | Bare metal | Bare metal and VM | Bare metal  |
+| Multiple NIC And Routing Coordination | Beta  | Beta              | Beta        |
+| Scenarios                        | Bare metal | Bare metal and VM | Bare metal  |
 
 For detailed information about all the planned features, please refer to the [roadmap](./docs/develop/roadmap.md).
 
 ## Blogs
 
-Refer to [Blogs](./docs/concepts/blog.md)
+Refer to [Blogs](./docs/concepts/blog.md).
 
 ## Governance
 
@@ -162,9 +162,9 @@ See [LICENSE](./LICENSE) for the full license text.
 
 Copyright The Spiderpool Authors
 
-We are a [Cloud Native Computing Foundation](https://www.cncf.io) [sandbox project](https://landscape.cncf.io/card-mode?category=cloud-native-network&grouping=category)
+We are a [Cloud Native Computing Foundation](https://www.cncf.io) [sandbox project](https://landscape.cncf.io/card-mode?category=cloud-native-network&grouping=category).
 
-The Linux Foundation® (TLF) has registered trademarks and uses trademarks. For a list of TLF trademarks, see [Trademark Usage](https://www.linuxfoundation.org/legal/trademark-usage)
+The Linux Foundation® (TLF) has registered trademarks and uses trademarks. For a list of TLF trademarks, see [Trademark Usage](https://www.linuxfoundation.org/legal/trademark-usage).
 
 <p align="center">
 <img src="https://landscape.cncf.io/images/left-logo.svg" width="300"/>&nbsp;&nbsp;<img src="https://landscape.cncf.io/images/right-logo.svg" width="350"/>

--- a/docs/README-zh_CN.md
+++ b/docs/README-zh_CN.md
@@ -15,15 +15,15 @@
 
 [**English**](./README.md) | **简体中文**
 
-Spiderpool 是 [CNCF](https://www.cncf.io) 的一个 [Sandbox 项目](https://landscape.cncf.io/card-mode?category=cloud-native-network&grouping=category)
+Spiderpool 是 [CNCF](https://www.cncf.io) 的一个 [Sandbox 项目](https://landscape.cncf.io/card-mode?category=cloud-native-network&grouping=category)。
 
-Spiderpool 提供了一个 Kubernetes 的 underlay 和 RDMA 网络解决方案, 它能运行在裸金属、虚拟机和公有云上
+Spiderpool 提供了一个 Kubernetes 的 underlay 和 RDMA 网络解决方案, 它能运行在裸金属、虚拟机和公有云上。
 
 ## Spiderpool 介绍
 
-Spiderpool 是一个 kubernetes 的 underlay 和 RDMA 网络解决方案，它增强了 [Macvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/macvlan),
-[ipvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/ipvlan),
-[SR-IOV CNI](https://github.com/k8snetworkplumbingwg/sriov-cni) 的功能，满足了各种网络需求，使得 underlay 网络方案可应用在**裸金属、虚拟机和公有云环境**中，可为网络 I/O 密集性、低延时应用带来优秀的网络性能，包括**存储、中间件、AI 等应用**。详细的文档可参考[文档站](https://spidernet-io.github.io/spiderpool/)
+Spiderpool 是一个 kubernetes 的 underlay 和 RDMA 网络解决方案，它增强了 [Macvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/macvlan)、
+[ipvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/ipvlan) 和
+[SR-IOV CNI](https://github.com/k8snetworkplumbingwg/sriov-cni) 的功能，满足了各种网络需求，使得 underlay 网络方案可应用在**裸金属、虚拟机和公有云环境**中，可为网络 I/O 密集性、低延时应用带来优秀的网络性能，包括**存储、中间件、AI 等应用**。详细的文档可参考[文档站](https://spidernet-io.github.io/spiderpool/)。
 
 ## Underlay CNI 的优势
 
@@ -45,108 +45,108 @@ underlay CNI 主要指 macvlan、ipvlan、SR-IOV 等能够直接访问宿主机�
 
 * 简化安装和使用
 
-  当前开源社区对于 underlay CNI 和 RDMA 的使用，需要手动安装 [Multus CNI](https://github.com/k8snetworkplumbingwg/multus-cni) 、RDMA、SR-IOV 等诸多相关组件，Spiderpool 简化了安装流程和运行 POD 数量，对相关的 CRD 进行了封装，提供了各种场景的完备文档，使得使用、管理更加便捷。
+    当前开源社区对于 underlay CNI 和 RDMA 的使用，需要手动安装 [Multus CNI](https://github.com/k8snetworkplumbingwg/multus-cni) 、RDMA、SR-IOV 等诸多相关组件，Spiderpool 简化了安装流程和运行 POD 数量，对相关的 CRD 进行了封装，提供了各种场景的完备文档，使得使用、管理更加便捷。
 
 * 基于 CRD 的双栈 IPAM 能力
 
-  提供了独享、共享的 IP 地址池，支持设置各种亲和性，为中间件等有状态应用和 kubevirt 等固定 IP 地址值，为无状态应用固定 IP 地址范围，自动化管理独享的 IP 池，优秀的 IP 回收避免 IP 泄露等。并且，具备优秀的 [IPAM 分配性能](./concepts/ipam-performance-zh_CN.md)。
+    提供了独享、共享的 IP 地址池，支持设置各种亲和性，为中间件等有状态应用和 kubevirt 等固定 IP 地址值，为无状态应用固定 IP 地址范围，自动化管理独享的 IP 池，优秀的 IP 回收避免 IP 泄露等。并且，具备优秀的 [IPAM 分配性能](./concepts/ipam-performance-zh_CN.md)。
 
-  Spiderpool IPAM 组件能够为任何支持第三方 IPAM 的 main CNI 使用，不仅包含了 [Macvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/macvlan), [ipvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/ipvlan), [SR-IOV CNI](https://github.com/k8snetworkplumbingwg/sriov-cni), 也包括了 [calico](https://github.com/projectcalico/calico) [weave](https://github.com/weaveworks/weave) 作为静态 IP 场景使用。
+    Spiderpool IPAM 组件能够为任何支持第三方 IPAM 的 main CNI 使用，不仅包含了 [Macvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/macvlan)、[ipvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/ipvlan) 和 [SR-IOV CNI](https://github.com/k8snetworkplumbingwg/sriov-cni)，也包括了 [calico](https://github.com/projectcalico/calico) 和 [weave](https://github.com/weaveworks/weave) 作为静态 IP 场景使用。
 
 * underlay 和 overlay CNI 的多网卡接入
 
-  它包括了 “Pod 插入多个 underlay CNI 网卡”、“Pod 插入一个 overlay CNI 和 多个 underlay CNI 网卡”两种场景，Pod 具备多种 CNI 网卡，Spiderpool 能够为多个
-  underlay CNI 网卡定制不同的 IP 地址，调协所有网卡之间的策略路由，以确保请求向和回复向数据路径一致而避免丢包。它能够为 [cilium](https://github.com/cilium/cilium), [calico](https://github.com/projectcalico/calico), [kubevirt](https://github.com/kubevirt/kubevirt) 等项目进行增强。
+    它包括了 “Pod 插入多个 underlay CNI 网卡”、“Pod 插入一个 overlay CNI 和 多个 underlay CNI 网卡”两种场景，Pod 具备多种 CNI 网卡，Spiderpool 能够为多个
+    underlay CNI 网卡定制不同的 IP 地址，调协所有网卡之间的策略路由，以确保请求向和回复向数据路径一致而避免丢包。它能够为 [cilium](https://github.com/cilium/cilium)、[calico](https://github.com/projectcalico/calico) 和 [kubevirt](https://github.com/kubevirt/kubevirt) 等项目进行增强。
 
 * 增强网络连通性
 
-  众所周知，原生的 macvlan ipvlan SR-IOV 存在诸多通信限制。但是，Spiderpool 打通 Pod 和宿主机的连通性，确保 Pod 健康检测工作正常，并可通过 kube-proxy 或 eBPF kube-proxy replacement 使得 Pod 访问 service，支持 Pod 的 IP 冲突检测、网关可达性检测等。多集群网络可基于相同的 underlay 网络或者 [Submariner](https://github.com/submariner-io/submariner) 实现联通。
+    众所周知，原生的 macvlan ipvlan SR-IOV 存在诸多通信限制。但是，Spiderpool 打通 Pod 和宿主机的连通性，确保 Pod 健康检测工作正常，并可通过 kube-proxy 或 eBPF kube-proxy replacement 使得 Pod 访问 service，支持 Pod 的 IP 冲突检测、网关可达性检测等。多集群网络可基于相同的 underlay 网络或者 [Submariner](https://github.com/submariner-io/submariner) 实现联通。
 
 * eBPF 增强
 
-  kube-proxy replacement 技术极大加速了访问 service 场景，同节点上的 socket 短路技术加速了本地 Pod 的通信效率。相比 kube proxy 解析方式，[网络延时有最大 25% 的改善，网络吞吐有 50% 的提高](./concepts/io-performance-zh_CN.md)。
+    kube-proxy replacement 技术极大加速了访问 service 场景，同节点上的 socket 短路技术加速了本地 Pod 的通信效率。相比 kube proxy 解析方式，[网络延时有最大 25% 的改善，网络吞吐有 50% 的提高](./concepts/io-performance-zh_CN.md)。
 
 * RDMA
 
-  提供了基于 RoCE、infiniband 场景下的 RDMA 解决方案，POD 能够独享或共享使用 RDMA 设备，适合 AI 等网络性能需求高的应用。
+    提供了基于 RoCE、infiniband 场景下的 RDMA 解决方案，POD 能够独享或共享使用 RDMA 设备，适合 AI 等网络性能需求高的应用。
 
 * 网络双栈支持
 
-  Spiderpool 组件和其提供的所有功能，支持 ipv4-only、ipv6-only、dual-stack 场景。
+    Spiderpool 组件和其提供的所有功能，支持 ipv4-only、ipv6-only、dual-stack 场景。
 
 * 优秀的网络延时和吞吐量性能
 
-  Spiderpool 在网络延时和吞吐量方面表现出色，超过了 overlay CNI，可参考 [性能报告](./concepts/io-performance-zh_CN.md)
+    Spiderpool 在网络延时和吞吐量方面表现出色，超过了 overlay CNI，可参考[性能报告](./concepts/io-performance-zh_CN.md)。
 
 * 指标
 
 ## 应用场景
 
-Spiderpool 基于 underlay CNI 提供了比 overlay CNI 还优越的网络性能，可参考 [性能报告](./concepts/io-performance-zh_CN.md)。具体可应用在如下：
+Spiderpool 基于 underlay CNI 提供了比 overlay CNI 还优越的网络性能，可参考[性能报告](./concepts/io-performance-zh_CN.md)。具体可应用在如下：
 
 * 支持运行在裸金属、虚拟机、各大公有云厂商等环境，尤其为混合云提供了统一的 underlay CNI 解决方案。
 
-* 传统的主机应用。它们希望直接使用 underlay 网络进行通信，例如直接访问 underlay 多子网、多播、组播、二层网络通信等，它们不能接受 overlay 网络的 NAT，希望进行无缝移植的 Kubernetes 。
+* 传统的主机应用。它们希望直接使用 underlay 网络进行通信，例如直接访问 underlay 多子网、多播、组播、二层网络通信等，它们不能接受 overlay 网络的 NAT，希望进行无缝移植的 Kubernetes。
 
-* 中间件、数据存储、日志观测、AI 训练等网络 I/O 密集性应用
+* 中间件、数据存储、日志观测、AI 训练等网络 I/O 密集性应用。
 
-* 网络延时敏感型应用
+* 网络延时敏感型应用。
 
 ## 快速开始
 
-参考 [快速搭建](./usage/install/get-started-kind-zh_CN.md) 来使用 Spiderpool
+* 参考 [快速搭建](./usage/install/get-started-kind-zh_CN.md) 来使用 Spiderpool
 
-参考 [使用](./usage/readme-zh_CN.md) 来了解各种功能的使用方法
+* 参考 [使用](./usage/readme-zh_CN.md) 来了解各种功能的使用方法
 
-参考 [架构](./concepts/arch-zh_CN.md) 来了解架构设计
+* 参考 [架构](./concepts/arch-zh_CN.md) 来了解架构设计
 
 ## Roadmap
 
-| 功能                               | macvlan  | ipvlan | SR-IOV    |
-|----------------------------------|----------|---|-----------|
-| Service By Kubeproxy             | Beta     |  Beta | Beta      |
+| 功能                              | macvlan  | ipvlan | SR-IOV    |
+|----------------------------------|----------|--------|-----------|
+| Service By Kubeproxy             | Beta     |  Beta  | Beta      |
 | Service By Kubeproxy Replacement | Alpha    |  Alpha | Alpha     |
 | Network Policy                   | In-plan  |  Alpha | In-plan   |
 | Bandwidth                        | In-plan  | Alpha  | In-plan    |
-| RDMA                             | Alpha    | Alpha | Alpha     |
-| IPAM                             | Beta     | Beta | Beta      |
-| Multi-Cluster                    | Alpha    | Alpha | Alpha     |
-| Egress Policy                    | Alpha    | Alpha | Alpha     |
-| 多网卡和路由调谐                         | beta     | beta | beta      |
-| 适用场景                             | 裸金属      | 裸金属和虚拟机 | 裸金属       |
+| RDMA                             | Alpha    | Alpha  | Alpha     |
+| IPAM                             | Beta     | Beta   | Beta      |
+| Multi-Cluster                    | Alpha    | Alpha  | Alpha     |
+| Egress Policy                    | Alpha    | Alpha  | Alpha     |
+| 多网卡和路由调谐                    | Beta     | Beta   | Beta      |
+| 适用场景                          | 裸金属    | 裸金属和虚拟机 | 裸金属 |
 
-关于所有的功能规划，具体可参考 [roadmap](./develop/roadmap.md)
+关于所有的功能规划，具体可参考 [roadmap](./develop/roadmap.md)。
 
 ## Blogs
 
-可参考 [Blogs](./concepts/blog-zh_CN.md)
+可参考 [Blog](./concepts/blog-zh_CN.md)。
 
 ## Governance
 
-Spiderpool 项目由一组[维护者和提交者](./AUTHORS)管理，我们的[Governance Document](https://github.com/spidernet-io/community/blob/main/GOVERNANCE-maintainer.md)概述了如何治理改项目。
+Spiderpool 项目由一组[维护者和提交者](./AUTHORS)管理，我们的 [Governance Document](https://github.com/spidernet-io/community/blob/main/GOVERNANCE-maintainer.md) 概述了如何治理改项目。
 
 ## 使用者
 
-使用了 Spiderpool 项目的 [用户](./USERS.md).
+使用 Spiderpool 项目的[用户](./USERS.md)。
 
 ## 参与开发
 
-可参考 [开发搭建文档](./develop/contributing.md).
+可参考[开发搭建文档](./develop/contributing.md)。
 
 ## 社区
 
-Spiderpool 社区致力于营造一个开放和热情的环境，并通过多种方式与其他用户和开发人员互动。 您可以访问我们的 [社区网站](https://github.com/spidernet-io/community) 了解更多信息
+Spiderpool 社区致力于营造一个开放和热情的环境，并通过多种方式与其他用户和开发人员互动。您可以访问我们的[社区网站](https://github.com/spidernet-io/community)了解更多信息。
 
-* Slack: 如果你想在 CNCF Slack 加入 Spiderpool 的频道, 请先得到 CNCF Slack 的 **[邀请](https://slack.cncf.io/)**
+* Slack：如果你想在 CNCF Slack 加入 Spiderpool 的频道，请先得到 CNCF Slack 的 **[邀请](https://slack.cncf.io/)**
   然后加入 [#Spiderpool](https://cloud-native.slack.com/messages/spiderpool) 的频道。
 
-* 邮件: 您可以查看 [MAINTAINERS.md](https://github.com/spidernet-io/spiderpool/blob/main/MAINTAINERS.md) 获取所有维护者的邮箱地址， 联系邮箱地址以报告任何问题。
+* 邮件：您可以查看 [MAINTAINERS.md](https://github.com/spidernet-io/spiderpool/blob/main/MAINTAINERS.md) 获取所有维护者的邮箱地址， 联系邮箱地址以报告任何问题。
 
-* 社区会议: 欢迎加入到我们每个月1号举行的[社区会议](https://docs.google.com/document/d/1tpNzxRWOz9-jVd30xGS2n5X02uXQuvqJAdNZzwBLTmI/edit?usp=sharing)，可以在这里讨论任何有关 Spiderpool 的问题。
+* 社区会议：欢迎加入到我们每个月1号举行的[社区会议](https://docs.google.com/document/d/1tpNzxRWOz9-jVd30xGS2n5X02uXQuvqJAdNZzwBLTmI/edit?usp=sharing)，可以在这里讨论任何有关 Spiderpool 的问题。
 
-* 微信群: 您可以扫描微信二维码，加入到 Spiderpool 技术交流群与我们进一步交流。
+* 微信群：您可以扫描微信二维码，加入到 Spiderpool 技术交流群与我们进一步交流。
 
-![Wechat QR-Code](./images/wechat.png)
+    ![Wechat QR-Code](./images/wechat.png)
 
 ## License
 
@@ -156,9 +156,9 @@ Spiderpool is licensed under the Apache License, Version 2.0. See [LICENSE](./LI
 
 Copyright The Spiderpool Authors
 
-We are a [Cloud Native Computing Foundation](https://www.cncf.io) [sandbox project](https://landscape.cncf.io/card-mode?category=cloud-native-network&grouping=category)
+We are a [Cloud Native Computing Foundation](https://www.cncf.io) [sandbox project](https://landscape.cncf.io/card-mode?category=cloud-native-network&grouping=category).
 
-The Linux Foundation® (TLF) has registered trademarks and uses trademarks. For a list of TLF trademarks, see [Trademark Usage](https://www.linuxfoundation.org/legal/trademark-usage)
+The Linux Foundation® (TLF) has registered trademarks and uses trademarks. For a list of TLF trademarks, see [Trademark Usage](https://www.linuxfoundation.org/legal/trademark-usage).
 
 <p align="center">
 <img src="https://landscape.cncf.io/images/left-logo.svg" width="300"/>&nbsp;&nbsp;<img src="https://landscape.cncf.io/images/right-logo.svg" width="350"/>

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ It could refer to [website](https://spidernet-io.github.io/spiderpool/) for more
 
 ## The Advantages Of Underlay CNI
 
-The underlay CNI is mainly including macvlan, ipvlan, and SR-IOV, which cloud access the layer 2 network of the node. It has some advantages :
+The underlay CNI is mainly including macvlan, ipvlan, and SR-IOV, which cloud access the layer 2 network of the node. It has some advantages:
 
 * macvlan, ipvlan, and SR-IOV is crucial for supporting RDMA network acceleration. RDMA significantly enhances performance for AI applicaitons, latency-sensitive and network I/O-intensive applications, surpassing overlay network solutions in terms of network performance.
 
@@ -49,37 +49,37 @@ The underlay CNI is mainly including macvlan, ipvlan, and SR-IOV, which cloud ac
 
 * Simplified installation and usage
 
-  Through eliminating the need for manually installing multiple components such as [Multus CNI](https://github.com/k8snetworkplumbingwg/multus-cni) , RDMA and SR-IOV, Spiderpool simplifies the installation process and decreases the number of running PODs. It provides streamlined installation procedures, encapsulates relevant CRDs, and offers comprehensive documentation for easy setup and management.
+    Through eliminating the need for manually installing multiple components such as [Multus CNI](https://github.com/k8snetworkplumbingwg/multus-cni), RDMA and SR-IOV, Spiderpool simplifies the installation process and decreases the number of running PODs. It provides streamlined installation procedures, encapsulates relevant CRDs, and offers comprehensive documentation for easy setup and management.
 
 * CRD-based dual-stack IPAM
 
-  Spiderpool provides exclusive and shared IP address pools, supporting various affinity settings. It supports to assign static IP addresses for stateful applications such as [mysql](https://www.mysql.com) , [redis](https://github.com/redis/redis) , [kubevirt](https://github.com/kubevirt/kubevirt) , while enabling fixed IP address ranges for stateless ones. Spiderpool automates the management of exclusive IP pools, ensuring excellent IP reclamation to avoid IP leakage. In additions, it owns [wonderful IPAM performance](./concepts/ipam-performance.md).
+    Spiderpool provides exclusive and shared IP address pools, supporting various affinity settings. It supports to assign static IP addresses for stateful applications such as [mysql](https://www.mysql.com), [redis](https://github.com/redis/redis), and [kubevirt](https://github.com/kubevirt/kubevirt), while enabling fixed IP address ranges for stateless ones. Spiderpool automates the management of exclusive IP pools, ensuring excellent IP reclamation to avoid IP leakage. In additions, it provides [wonderful IPAM performance](./concepts/ipam-performance.md).
 
-  The IPAM of Spiderpool could be available for any main CNI supporting third-party IPAM plugin, not only including [Macvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/macvlan), [ipvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/ipvlan), [SR-IOV CNI](https://github.com/k8snetworkplumbingwg/sriov-cni), but also [calico](https://github.com/projectcalico/calico) [weave](https://github.com/weaveworks/weave) as static IP usage.
+    The IPAM of Spiderpool could be available for any main CNI supporting third-party IPAM plugin, not only including [Macvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/macvlan), [ipvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/ipvlan), and [SR-IOV CNI](https://github.com/k8snetworkplumbingwg/sriov-cni), but also [calico](https://github.com/projectcalico/calico) and [weave](https://github.com/weaveworks/weave) as static IP usage.
 
 * Multiple network interfaces from underlay and overlay CNI
 
-  Spiderpool enables scenarios where Pods can have multiple underlay CNI interfaces or a combination of overlay and underlay CNI interfaces. It ensures proper IP addressing for each CNI interface and effectively manages policy routing to maintain consistent data paths, eliminating packet loss concerns. It could strengthen [cilium](https://github.com/cilium/cilium), [calico](https://github.com/projectcalico/calico), [kubevirt](https://github.com/kubevirt/kubevirt) .
+    Spiderpool enables scenarios where Pods can have multiple underlay CNI interfaces or a combination of overlay and underlay CNI interfaces. It ensures proper IP addressing for each CNI interface and effectively manages policy routing to maintain consistent data paths, eliminating packet loss concerns. It could strengthen [cilium](https://github.com/cilium/cilium), [calico](https://github.com/projectcalico/calico), and [kubevirt](https://github.com/kubevirt/kubevirt).
 
 * Enhanced network connectivity
 
-  As we know, native CNI of macvlan ipvlan SR-IOV has lots of communication limits. However, Spiderpool establishes seamless connectivity between Pods and host machines, ensuring smooth functioning of Pod health checks. It enables Pods to access services through kube-proxy or eBPF-based kube-proxy replacement. Additionally, it supports advanced features like IP conflict detection and gateway reachability checks. The network of Multi-cluster could be connected by a same underlay network, or [Submariner](https://github.com/submariner-io/submariner) .
+    As we know, native CNI of macvlan ipvlan SR-IOV has lots of communication limits. However, Spiderpool establishes seamless connectivity between Pods and host machines, ensuring smooth functioning of Pod health checks. It enables Pods to access services through kube-proxy or eBPF-based kube-proxy replacement. Additionally, it supports advanced features like IP conflict detection and gateway reachability checks. The network of Multi-cluster could be connected by a same underlay network, or [Submariner](https://github.com/submariner-io/submariner).
 
 * eBPF enhancements
 
-  The eBPF-based kube-proxy replacement significantly accelerates service access, while socket short-circuiting technology improves local Pod communication efficiency within the same node. Compared with kube-proxy manner, [the improvement of the performance is Up to 25% on network delay, up to 50% on network throughput](./concepts/io-performance.md). 
+    The eBPF-based kube-proxy replacement significantly accelerates service access, while socket short-circuiting technology improves local Pod communication efficiency within the same node. Compared with kube-proxy manner, [the improvement of the performance is Up to 25% on network delay, up to 50% on network throughput](./concepts/io-performance.md).
 
 * RDMA support
 
-  Spiderpool offers RDMA solutions based on RoCE and InfiniBand technologies. POD could use the RDMA device in shared or exclusive mode, and it is fit for AI workloads.
+    Spiderpool offers RDMA solutions based on RoCE and InfiniBand technologies. POD could use the RDMA device in shared or exclusive mode, and it is fit for AI workloads.
 
 * Dual-stack network support
 
-  Spiderpool supports IPv4-only, IPv6-only, and dual-stack environments.
+    Spiderpool supports IPv4-only, IPv6-only, and dual-stack environments.
 
 * Good network performance of latency and throughput
 
-  Spiderpool performs better than overlay CNI on network latency and throughput, referring to [performance report](./concepts/io-performance.md)
+    Spiderpool performs better than overlay CNI on network latency and throughput, refer to [performance report](./concepts/io-performance.md).
 
 * Metrics
 
@@ -87,27 +87,27 @@ The underlay CNI is mainly including macvlan, ipvlan, and SR-IOV, which cloud ac
 
 Spiderpool, powered by underlay CNI, offers unparalleled network performance compared to overlay CNI solutions, as evidenced in [I/O Performance](./concepts/io-performance.md). It can be effectively applied in various scenarios, including:
 
-* Support to deploy on the environments of bare metal, virtual machine, and public cloud, especially offer an unified underlay CNI solution for hybrid cloud.
+* Support to deploy on the environments of bare metal, virtual machine, and public cloud, especially offer a unified underlay CNI solution for hybrid cloud.
 
-* Traditional host applications. They hope to directly use the underlay network, with the reasons such as direct access to the underlay multi-subnet, multicast, multicast, layer 2 network communication, etc. They cannot accept the NAT of the overlay network and hope to seamlessly migrate to Kubernetes .
+* Traditional host applications. They hope to directly use the underlay network, with the reasons such as direct access to the underlay multi-subnet, multicast, multicast, layer 2 network communication, etc. They cannot accept the NAT of the overlay network and hope to seamlessly migrate to Kubernetes.
 
 * Network I/O-intensive applications such as middleware, data storage, log observability, and AI training.
 
-* Applications which needs a separate network bandwidth
+* Applications which needs a separate network bandwidth.
 
 * Latency-sensitive application.
 
 ## Quick start
 
-Refer to [Quick start](./usage/install/get-started-kind.md) to explore Spiderpool quickly.
+* Refer to [Quick start](./usage/install/get-started-kind.md) to explore Spiderpool quickly.
 
-Refer to [Usage Index](./usage/readme.md) for usage details.
+* Refer to [Usage Index](./usage/readme.md) for usage details.
 
-Refer to [Spiderpool Architecture](./concepts/arch.md) for more detailed information.
+* Refer to [Spiderpool Architecture](./concepts/arch.md) for more detailed information.
 
 ## Roadmap
 
-| Features                               | macvlan    | ipvlan            | SR-IOV      |
+| Features                         | macvlan    | ipvlan            | SR-IOV      |
 |----------------------------------|------------|-------------------|-------------|
 | Service By Kubeproxy             | Beta       | Beta              | Beta        |
 | Service By Kubeproxy Replacement | Alpha      | Alpha             | Alpha       |
@@ -115,16 +115,16 @@ Refer to [Spiderpool Architecture](./concepts/arch.md) for more detailed informa
 | Bandwidth                        | In-plan    | Alpha             | In-plan     |
 | RDMA                             | Alpha      | Alpha             | Alpha       |
 | IPAM                             | Beta       | Beta              | Beta        |
-| Multi-Cluster                    | Alpha    | Alpha             | Alpha     |
+| Multi-Cluster                    | Alpha      | Alpha             | Alpha       |
 | Egress Policy                    | Alpha      | Alpha             | Alpha       |
-| Multiple NIC And Routing Coordination                         | Beta       | Beta              | Beta        |
-| Scenarios                             | Bare metal | Bare metal and VM | Bare metal  |
+| Multiple NIC And Routing Coordination | Beta  | Beta              | Beta        |
+| Scenarios                        | Bare metal | Bare metal and VM | Bare metal  |
 
 For detailed information about all the planned features, please refer to the [roadmap](./develop/roadmap.md).
 
 ## Blogs
 
-Refer to [Blogs](./concepts/blog.md)
+Refer to [Blogs](./concepts/blog.md).
 
 ## Governance
 
@@ -147,7 +147,7 @@ You can find out more information by visiting our [community repository](https:/
 
 * Community Meeting: Welcome to our [community meeting](https://docs.google.com/document/d/1tpNzxRWOz9-jVd30xGS2n5X02uXQuvqJAdNZzwBLTmI/edit?usp=sharing) held on the 1st of every month. Feel free to join and discuss any questions or topics related to Spiderpool.
 
-* Email: refer to the [MAINTAINERS.md](https://github.com/spidernet-io/spiderpool/blob/main/MAINTAINERS.md)  to find the email addresses of all maintainers. Feel free to contact them via email to report any issues or ask questions.
+* Email: refer to the [MAINTAINERS.md](https://github.com/spidernet-io/spiderpool/blob/main/MAINTAINERS.md) to find the email addresses of all maintainers. Feel free to contact them via email to report any issues or ask questions.
 
 * WeChat group: scan the QR code below to join the Spiderpool technical discussion group and engage in further conversations with us.
 
@@ -162,9 +162,9 @@ See [LICENSE](./LICENSE) for the full license text.
 
 Copyright The Spiderpool Authors
 
-We are a [Cloud Native Computing Foundation](https://www.cncf.io) [sandbox project](https://landscape.cncf.io/card-mode?category=cloud-native-network&grouping=category)
+We are a [Cloud Native Computing Foundation](https://www.cncf.io) [sandbox project](https://landscape.cncf.io/card-mode?category=cloud-native-network&grouping=category).
 
-The Linux Foundation® (TLF) has registered trademarks and uses trademarks. For a list of TLF trademarks, see [Trademark Usage](https://www.linuxfoundation.org/legal/trademark-usage)
+The Linux Foundation® (TLF) has registered trademarks and uses trademarks. For a list of TLF trademarks, see [Trademark Usage](https://www.linuxfoundation.org/legal/trademark-usage).
 
 <p align="center">
 <img src="https://landscape.cncf.io/images/left-logo.svg" width="300"/>&nbsp;&nbsp;<img src="https://landscape.cncf.io/images/right-logo.svg" width="350"/>


### PR DESCRIPTION
The docs is built with MkDocs with an indentation of 4 spaces by default for bullets.

Indent from 2 spaces to 4 spaces in the `/docs` folder.

<img width="1246" alt="image" src="https://github.com/spidernet-io/spiderpool/assets/79828097/7810ff5e-809b-4821-bf7c-2189592c1848">
