### PR TITLE
fix inherit subnet properties for ippool failure 

### DIFF
--- a/pkg/ippoolmanager/ippool_mutate.go
+++ b/pkg/ippoolmanager/ippool_mutate.go
@@ -71,7 +71,7 @@ func (iw *IPPoolWebhook) mutateIPPool(ctx context.Context, ipPool *spiderpoolv2b
 
 		// inherit gateway,vlan,routes from corresponding SpiderSubnet if not set
 		if subnet != nil {
-			inheritSubnetProperties(subnet, ipPool)
+			InheritSubnetProperties(subnet, ipPool)
 		}
 	}
 
@@ -143,13 +143,9 @@ func (iw *IPPoolWebhook) setControllerSubnet(ctx context.Context, ipPool *spider
 	return subnet, nil
 }
 
-func inheritSubnetProperties(subnet *spiderpoolv2beta1.SpiderSubnet, ipPool *spiderpoolv2beta1.SpiderIPPool) {
+func InheritSubnetProperties(subnet *spiderpoolv2beta1.SpiderSubnet, ipPool *spiderpoolv2beta1.SpiderIPPool) {
 	if subnet.Spec.Gateway != nil && ipPool.Spec.Gateway == nil {
 		ipPool.Spec.Gateway = pointer.String(*subnet.Spec.Gateway)
-	}
-
-	if subnet.Spec.Vlan != nil && ipPool.Spec.Vlan == nil {
-		ipPool.Spec.Vlan = pointer.Int64(*subnet.Spec.Vlan)
 	}
 
 	// if customer set empty route for this IPPool, it would not inherit the SpiderSubnet.Spec.Routes

--- a/pkg/subnetmanager/subnet_informer.go
+++ b/pkg/subnetmanager/subnet_informer.go
@@ -439,6 +439,7 @@ func (sc *SubnetController) syncControllerSubnet(ctx context.Context, subnet *sp
 		}
 
 		if orphan {
+			ippoolmanager.InheritSubnetProperties(subnet, poolCopy)
 			if err := sc.Client.Update(ctx, poolCopy); err != nil {
 				return err
 			}

--- a/test/e2e/ippoolcr/ippoolcr_test.go
+++ b/test/e2e/ippoolcr/ippoolcr_test.go
@@ -24,366 +24,477 @@ import (
 )
 
 var _ = Describe("test ippool CR", Label("ippoolCR"), func() {
-	var nsName string
-	var v4PoolName, v6PoolName, deployName string
-	var v4PoolObj, v6PoolObj *spiderpoolv2beta1.SpiderIPPool
-	var v4PoolNameList, v6PoolNameList []string
-	var disable = new(bool)
-	var v4SubnetName, v6SubnetName string
-	var v4SubnetObject, v6SubnetObject *spiderpoolv2beta1.SpiderSubnet
+	Context("Need create IPPool before", func() {
+		var nsName string
+		var v4PoolName, v6PoolName, deployName string
+		var v4PoolObj, v6PoolObj *spiderpoolv2beta1.SpiderIPPool
+		var v4PoolNameList, v6PoolNameList []string
+		var disable = new(bool)
+		var v4SubnetName, v6SubnetName string
+		var v4SubnetObject, v6SubnetObject *spiderpoolv2beta1.SpiderSubnet
 
-	BeforeEach(func() {
-		if frame.Info.SpiderSubnetEnabled {
-			if frame.Info.IpV4Enabled {
-				v4SubnetName, v4SubnetObject = common.GenerateExampleV4SubnetObject(frame, 20)
-				Expect(v4SubnetObject).NotTo(BeNil())
-				Expect(common.CreateSubnet(frame, v4SubnetObject)).NotTo(HaveOccurred())
-			}
-			if frame.Info.IpV6Enabled {
-				v6SubnetName, v6SubnetObject = common.GenerateExampleV6SubnetObject(frame, 20)
-				Expect(v6SubnetObject).NotTo(BeNil())
-				Expect(common.CreateSubnet(frame, v6SubnetObject)).NotTo(HaveOccurred())
-			}
-		}
-		// Init namespace name and create
-		nsName = "ns" + tools.RandomName()
-		GinkgoWriter.Printf("create namespace %v \n", nsName)
-		err := frame.CreateNamespaceUntilDefaultServiceAccountReady(nsName, common.ServiceAccountReadyTimeout)
-		Expect(err).NotTo(HaveOccurred(), "failed to create namespace %v", nsName)
-
-		// Create IPv4 pools and IPv6 pools
-		if frame.Info.IpV4Enabled {
-			v4PoolName, v4PoolObj = common.GenerateExampleIpv4poolObject(5)
-			Expect(v4PoolObj.Spec.IPs).NotTo(BeNil())
-			GinkgoWriter.Printf("Succeeded to create ippool %v \n", v4PoolObj.Name)
+		BeforeEach(func() {
 			if frame.Info.SpiderSubnetEnabled {
-				ctx, cancel := context.WithTimeout(context.Background(), common.PodStartTimeout)
-				defer cancel()
-				err := common.CreateIppoolInSpiderSubnet(ctx, frame, v4SubnetName, v4PoolObj, 5)
-				Expect(err).NotTo(HaveOccurred())
-			} else {
-				Expect(common.CreateIppool(frame, v4PoolObj)).To(Succeed())
-			}
-			v4PoolNameList = append(v4PoolNameList, v4PoolName)
-		}
-		if frame.Info.IpV6Enabled {
-			v6PoolName, v6PoolObj = common.GenerateExampleIpv6poolObject(5)
-			Expect(v6PoolObj.Spec.IPs).NotTo(BeNil())
-			GinkgoWriter.Printf("Succeeded to create ippool %v \n", v6PoolObj.Name)
-			if frame.Info.SpiderSubnetEnabled {
-				ctx, cancel := context.WithTimeout(context.Background(), common.PodStartTimeout)
-				defer cancel()
-				err := common.CreateIppoolInSpiderSubnet(ctx, frame, v6SubnetName, v6PoolObj, 5)
-				Expect(err).NotTo(HaveOccurred())
-			} else {
-				Expect(common.CreateIppool(frame, v6PoolObj)).To(Succeed())
-			}
-
-			v6PoolNameList = append(v6PoolNameList, v6PoolName)
-		}
-
-		DeferCleanup(func() {
-			if CurrentSpecReport().Failed() {
-				GinkgoWriter.Println("If the use case fails, the cleanup step will be skipped")
-				return
-			}
-
-			GinkgoWriter.Println("Clean test ENV")
-			err = frame.DeleteNamespace(nsName)
-			Expect(err).NotTo(HaveOccurred(), "Failed to delete namespace %v, err: %v", nsName, err)
-
-			if frame.Info.IpV4Enabled {
-				Expect(common.DeleteIPPoolByName(frame, v4PoolName)).NotTo(HaveOccurred())
-				if frame.Info.SpiderSubnetEnabled {
-					Expect(common.DeleteSubnetByName(frame, v4SubnetName)).NotTo(HaveOccurred())
-				}
-			}
-			if frame.Info.IpV6Enabled {
-				Expect(common.DeleteIPPoolByName(frame, v6PoolName)).NotTo(HaveOccurred())
-				if frame.Info.SpiderSubnetEnabled {
-					Expect(common.DeleteSubnetByName(frame, v6SubnetName)).NotTo(HaveOccurred())
-				}
-			}
-		})
-	})
-
-	Context("test ippool CR", func() {
-		var v4PoolName1, v6PoolName1 string
-		var v4PoolObj1, v6PoolObj1 *spiderpoolv2beta1.SpiderIPPool
-
-		It("fails to append an ip that already exists in another ippool to the ippool",
-			Label("D00001"), func() {
-				// In IPv4 and IPv6 scenarios
-				// Create an IPPool with the same IPs as the former.
 				if frame.Info.IpV4Enabled {
-					GinkgoWriter.Printf("Create an ipv4 IPPool with the same IPs %v \n", v4PoolObj.Spec.IPs)
-					v4PoolName1, v4PoolObj1 = common.GenerateExampleIpv4poolObject(5)
-					v4PoolObj1.Spec.Subnet = v4PoolObj.Spec.Subnet
-					v4PoolObj1.Spec.IPs = v4PoolObj.Spec.IPs
-
-					Expect(common.CreateIppool(frame, v4PoolObj1)).NotTo(Succeed())
-					GinkgoWriter.Printf("Failed to create an IPv4 IPPool %v with the same IP as another IPPool %v \n", v4PoolName1, v4PoolName)
+					v4SubnetName, v4SubnetObject = common.GenerateExampleV4SubnetObject(frame, 20)
+					Expect(v4SubnetObject).NotTo(BeNil())
+					Expect(common.CreateSubnet(frame, v4SubnetObject)).NotTo(HaveOccurred())
 				}
 				if frame.Info.IpV6Enabled {
-					GinkgoWriter.Printf("Create an IPv6 IPPool with the same IPs %v \n", v6PoolObj.Spec.IPs)
-					v6PoolName1, v6PoolObj1 = common.GenerateExampleIpv6poolObject(5)
-					v6PoolObj1.Spec.Subnet = v6PoolObj.Spec.Subnet
-					v6PoolObj1.Spec.IPs = v6PoolObj.Spec.IPs
+					v6SubnetName, v6SubnetObject = common.GenerateExampleV6SubnetObject(frame, 20)
+					Expect(v6SubnetObject).NotTo(BeNil())
+					Expect(common.CreateSubnet(frame, v6SubnetObject)).NotTo(HaveOccurred())
+				}
+			}
+			// Init namespace name and create
+			nsName = "ns" + tools.RandomName()
+			GinkgoWriter.Printf("create namespace %v \n", nsName)
+			err := frame.CreateNamespaceUntilDefaultServiceAccountReady(nsName, common.ServiceAccountReadyTimeout)
+			Expect(err).NotTo(HaveOccurred(), "failed to create namespace %v", nsName)
 
-					Expect(common.CreateIppool(frame, v6PoolObj1)).NotTo(Succeed())
-					GinkgoWriter.Printf("Failed to create an IPv6 IPPool %v with the same IP as another IPPool %v \n", v6PoolName1, v6PoolName)
+			// Create IPv4 pools and IPv6 pools
+			if frame.Info.IpV4Enabled {
+				v4PoolName, v4PoolObj = common.GenerateExampleIpv4poolObject(5)
+				Expect(v4PoolObj.Spec.IPs).NotTo(BeNil())
+				GinkgoWriter.Printf("Succeeded to create ippool %v \n", v4PoolObj.Name)
+				if frame.Info.SpiderSubnetEnabled {
+					ctx, cancel := context.WithTimeout(context.Background(), common.PodStartTimeout)
+					defer cancel()
+					err := common.CreateIppoolInSpiderSubnet(ctx, frame, v4SubnetName, v4PoolObj, 5)
+					Expect(err).NotTo(HaveOccurred())
+				} else {
+					Expect(common.CreateIppool(frame, v4PoolObj)).To(Succeed())
+				}
+				v4PoolNameList = append(v4PoolNameList, v4PoolName)
+			}
+			if frame.Info.IpV6Enabled {
+				v6PoolName, v6PoolObj = common.GenerateExampleIpv6poolObject(5)
+				Expect(v6PoolObj.Spec.IPs).NotTo(BeNil())
+				GinkgoWriter.Printf("Succeeded to create ippool %v \n", v6PoolObj.Name)
+				if frame.Info.SpiderSubnetEnabled {
+					ctx, cancel := context.WithTimeout(context.Background(), common.PodStartTimeout)
+					defer cancel()
+					err := common.CreateIppoolInSpiderSubnet(ctx, frame, v6SubnetName, v6PoolObj, 5)
+					Expect(err).NotTo(HaveOccurred())
+				} else {
+					Expect(common.CreateIppool(frame, v6PoolObj)).To(Succeed())
+				}
+
+				v6PoolNameList = append(v6PoolNameList, v6PoolName)
+			}
+
+			DeferCleanup(func() {
+				if CurrentSpecReport().Failed() {
+					GinkgoWriter.Println("If the use case fails, the cleanup step will be skipped")
+					return
+				}
+
+				GinkgoWriter.Println("Clean test ENV")
+				err = frame.DeleteNamespace(nsName)
+				Expect(err).NotTo(HaveOccurred(), "Failed to delete namespace %v, err: %v", nsName, err)
+
+				if frame.Info.IpV4Enabled {
+					Expect(common.DeleteIPPoolByName(frame, v4PoolName)).NotTo(HaveOccurred())
+					if frame.Info.SpiderSubnetEnabled {
+						Expect(common.DeleteSubnetByName(frame, v4SubnetName)).NotTo(HaveOccurred())
+					}
+				}
+				if frame.Info.IpV6Enabled {
+					Expect(common.DeleteIPPoolByName(frame, v6PoolName)).NotTo(HaveOccurred())
+					if frame.Info.SpiderSubnetEnabled {
+						Expect(common.DeleteSubnetByName(frame, v6SubnetName)).NotTo(HaveOccurred())
+					}
 				}
 			})
-	})
+		})
 
-	It(`a "true" value of ippool.Spec.disabled should fobide IP allocation, but still allow ip deallocation`, Label("D00004", "D00005"), Pending, func() {
-		var (
-			deployOriginialNum int = 1
-			deployScaleupNum   int = 2
-		)
-		// ippool.Spec.disabled set to true
-		*disable = true
-		deployName = "deploy" + tools.RandomName()
+		Context("test ippool CR", func() {
+			var v4PoolName1, v6PoolName1 string
+			var v4PoolObj1, v6PoolObj1 *spiderpoolv2beta1.SpiderIPPool
 
-		// Create Deployment with types.AnnoPodIPPoolValue and The Pods IP is recorded in the IPPool.
-		deploy := common.CreateDeployWithPodAnnoation(frame, deployName, nsName, deployOriginialNum, common.NIC1, v4PoolNameList, v6PoolNameList)
-		podList := common.CheckPodIpReadyByLabel(frame, deploy.Spec.Selector.MatchLabels, v4PoolNameList, v6PoolNameList)
+			It("fails to append an ip that already exists in another ippool to the ippool",
+				Label("D00001"), func() {
+					// In IPv4 and IPv6 scenarios
+					// Create an IPPool with the same IPs as the former.
+					if frame.Info.IpV4Enabled {
+						GinkgoWriter.Printf("Create an ipv4 IPPool with the same IPs %v \n", v4PoolObj.Spec.IPs)
+						v4PoolName1, v4PoolObj1 = common.GenerateExampleIpv4poolObject(5)
+						v4PoolObj1.Spec.Subnet = v4PoolObj.Spec.Subnet
+						v4PoolObj1.Spec.IPs = v4PoolObj.Spec.IPs
 
-		// D00004: Failed to delete an IPPool whose IP is not de-allocated at all
-		// Delete IPPool when the IP in IPPool has already been allocated and expect the deletion to fail
-		if frame.Info.IpV4Enabled {
-			Expect(common.DeleteIPPoolByName(frame, v4PoolName)).NotTo(Succeed())
-		}
-		if frame.Info.IpV6Enabled {
-			Expect(common.DeleteIPPoolByName(frame, v6PoolName)).NotTo(Succeed())
-		}
+						Expect(common.CreateIppool(frame, v4PoolObj1)).NotTo(Succeed())
+						GinkgoWriter.Printf("Failed to create an IPv4 IPPool %v with the same IP as another IPPool %v \n", v4PoolName1, v4PoolName)
+					}
+					if frame.Info.IpV6Enabled {
+						GinkgoWriter.Printf("Create an IPv6 IPPool with the same IPs %v \n", v6PoolObj.Spec.IPs)
+						v6PoolName1, v6PoolObj1 = common.GenerateExampleIpv6poolObject(5)
+						v6PoolObj1.Spec.Subnet = v6PoolObj.Spec.Subnet
+						v6PoolObj1.Spec.IPs = v6PoolObj.Spec.IPs
 
-		// Check the Pod IP recorded in IPPool again
-		GinkgoWriter.Println("check podIP record in ippool again")
-		ok2, _, _, err := common.CheckPodIpRecordInIppool(frame, v4PoolNameList, v6PoolNameList, podList)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ok2).To(BeTrue())
+						Expect(common.CreateIppool(frame, v6PoolObj1)).NotTo(Succeed())
+						GinkgoWriter.Printf("Failed to create an IPv6 IPPool %v with the same IP as another IPPool %v \n", v6PoolName1, v6PoolName)
+					}
+				})
+		})
 
-		// D00005: A "true" value of IPPool.Spec.disabled should forbid IP allocation, but still allow ip de-allocation
-		// Set the value of IPPool.Spec.disabled to "true"
-		if frame.Info.IpV4Enabled {
-			desiredV4PoolObj, err := common.GetIppoolByName(frame, v4PoolName)
-			Expect(err).NotTo(HaveOccurred())
-			desiredV4PoolObj.Spec.Disable = disable
-			err = common.PatchIppool(frame, desiredV4PoolObj, v4PoolObj)
-			Expect(err).NotTo(HaveOccurred(), "Failed to update %v.Spec.Disable form `false` to `true` for v4 pool", v4PoolName)
-			GinkgoWriter.Printf("Succeeded to update %v.Spec.Disable form `false` to `true` for v4 pool \n", v4PoolName)
-		}
-		if frame.Info.IpV6Enabled {
-			desiredV6PoolObj, err := common.GetIppoolByName(frame, v6PoolName)
-			Expect(err).NotTo(HaveOccurred())
-			desiredV6PoolObj.Spec.Disable = disable
-			err = common.PatchIppool(frame, desiredV6PoolObj, v6PoolObj)
-			Expect(err).NotTo(HaveOccurred(), "Failed to update %v.Spec.Disable form `false` to `true` for v6 pool", v6PoolName)
-			GinkgoWriter.Println("Succeeded to update %v.Spec.Disable form `false` to `true` for v6 pool \n", v6PoolName)
-		}
+		It(`a "true" value of ippool.Spec.disabled should fobide IP allocation, but still allow ip deallocation`, Label("D00004", "D00005"), Pending, func() {
+			var (
+				deployOriginialNum int = 1
+				deployScaleupNum   int = 2
+			)
+			// ippool.Spec.disabled set to true
+			*disable = true
+			deployName = "deploy" + tools.RandomName()
 
-		// The value of IPPool.Spec.disabled is "true" and the Scale deployment
-		ctx1, cancel1 := context.WithTimeout(context.Background(), common.PodReStartTimeout)
-		defer cancel1()
-		pods, _, err := common.ScaleDeployUntilExpectedReplicas(ctx1, frame, deploy, deployScaleupNum, false)
-		Expect(err).NotTo(HaveOccurred(), "Failed to scale deployment")
+			// Create Deployment with types.AnnoPodIPPoolValue and The Pods IP is recorded in the IPPool.
+			deploy := common.CreateDeployWithPodAnnoation(frame, deployName, nsName, deployOriginialNum, common.NIC1, v4PoolNameList, v6PoolNameList)
+			podList := common.CheckPodIpReadyByLabel(frame, deploy.Spec.Selector.MatchLabels, v4PoolNameList, v6PoolNameList)
 
-		// Failed to run pod and Get the Pod Scale failure Event
-		ctx2, cancel2 := context.WithTimeout(context.Background(), common.EventOccurTimeout)
-		defer cancel2()
-		for _, pod := range pods {
-			Expect(frame.WaitExceptEventOccurred(ctx2, common.OwnerPod, pod.Name, pod.Namespace, common.CNIFailedToSetUpNetwork)).To(Succeed())
-			GinkgoWriter.Printf("Pod %v/%v IP allocation failed when iPv4/iPv6 PoolObj.Spec.Disable is true", pod.Namespace, pod.Name)
-		}
-
-		// Delete the deployment and then check that the Pod IP in the IPPool has been reclaimed correctly.
-		Expect(frame.DeleteDeploymentUntilFinish(deployName, nsName, common.ResourceDeleteTimeout)).To(Succeed())
-		GinkgoWriter.Printf("Succeeded to delete deployment %v/%v \n", nsName, deployName)
-		Expect(common.WaitIPReclaimedFinish(frame, v4PoolNameList, v6PoolNameList, podList, common.IPReclaimTimeout)).To(Succeed())
-		GinkgoWriter.Printf("The Pod %v/%v IP in the IPPool was reclaimed correctly \n", nsName, deployName)
-	})
-
-	It("add a route with `routes` and `gateway` fields in the ippool spec", Label("D00002", "D00003", "smoke", "A00011"), func() {
-		podName1 := "pod" + tools.RandomName()
-		podName2 := "pod" + tools.RandomName()
-		var v4Gateway, v6Gateway, v4Dst, v6Dst, v4Via, v6Via string
-		var v4InvalidGateway, v6InvalidGateway string
-		var v4Pool, v6Pool *spiderpoolv2beta1.SpiderIPPool
-
-		// Generate Invalid Gateway and Dst
-		v4InvalidGateway = common.GenerateRandomIPV4()
-		v6InvalidGateway = common.GenerateRandomIPV6()
-
-		annoPodIPPools := types.AnnoPodIPPoolsValue{
-			types.AnnoIPPoolItem{
-				NIC: common.NIC1,
-			},
-		}
-		// Generate valid Gateway and Dst
-		if frame.Info.IpV4Enabled {
-			annoPodIPPools[0].IPv4Pools = []string{v4PoolName}
-			v4Gateway = strings.Split(v4PoolObj.Spec.Subnet, "0/")[0] + "1"
-			v4Dst = strings.Split(v4PoolObj.Spec.Subnet, ".")[0] + "." + strings.Split(v4PoolObj.Spec.Subnet, "/")[1] + ".0.0/16"
-			v4Via = strings.Split(v4PoolObj.Spec.Subnet, "0/")[0] + "254"
-		}
-		if frame.Info.IpV6Enabled {
-			annoPodIPPools[0].IPv6Pools = []string{v6PoolName}
-			v6Gateway = strings.Split(v6PoolObj.Spec.Subnet, "/")[0] + "1"
-			v6Dst = strings.Split(v6PoolObj.Spec.Subnet, "/")[0] + "/32"
-			v6Via = strings.Split(v6PoolObj.Spec.Subnet, "/")[0] + "fe"
-		}
-
-		if frame.Info.IpV4Enabled {
-			By("update v4 pool: invalid `gateway` and valid `route`")
-			// Get the IPv4 pool, use a invalid "gateway" and valid "route" to update the IPv4 ippool and expect the update to fails.
-			originalV4Pool, err := common.GetIppoolByName(frame, v4PoolName)
-			Expect(err).NotTo(HaveOccurred())
-			v4Pool, err = common.GetIppoolByName(frame, v4PoolName)
-			Expect(err).NotTo(HaveOccurred())
-
-			v4Pool.Spec.Gateway = &v4InvalidGateway
-			route := spiderpoolv2beta1.Route{
-				Dst: v4Dst,
-				Gw:  v4Via,
+			// D00004: Failed to delete an IPPool whose IP is not de-allocated at all
+			// Delete IPPool when the IP in IPPool has already been allocated and expect the deletion to fail
+			if frame.Info.IpV4Enabled {
+				Expect(common.DeleteIPPoolByName(frame, v4PoolName)).NotTo(Succeed())
 			}
-			v4Pool.Spec.Routes = []spiderpoolv2beta1.Route{route}
-			Expect(common.PatchIppool(frame, v4Pool, originalV4Pool)).NotTo(Succeed(), "error: we expect failed to update v4 ippool: %v with invalid gateway: %v, and valid route: %+v\n", v4PoolName, v4InvalidGateway, route)
-
-			By("update v4 pool: valid `gateway` and invalid `route`")
-			// Get the IPv4 pool, use a valid "gateway" and invalid "route" to update the IPv4 ippool and expect the update to fails.
-			v4Pool, err = common.GetIppoolByName(frame, v4PoolName)
-			Expect(err).NotTo(HaveOccurred())
-
-			v4Pool.Spec.Gateway = &v4Gateway
-			route = spiderpoolv2beta1.Route{
-				Dst: v4Dst,
-				Gw:  v4InvalidGateway,
+			if frame.Info.IpV6Enabled {
+				Expect(common.DeleteIPPoolByName(frame, v6PoolName)).NotTo(Succeed())
 			}
-			v4Pool.Spec.Routes = []spiderpoolv2beta1.Route{route}
-			Expect(common.PatchIppool(frame, v4Pool, originalV4Pool)).NotTo(Succeed(), "error: we expect failed to update v4 ippool: %v with valid gateway: %v, and invalid route: %+v\n", v4PoolName, v4InvalidGateway, route)
 
-			By("update v4 pool: valid `gateway` and `route`")
-			// Get the IPv4 pool, use a valid "gateway" and "route" to update the IPv4 ippool and expect the update to succeed.
-			v4Pool, err = common.GetIppoolByName(frame, v4PoolName)
+			// Check the Pod IP recorded in IPPool again
+			GinkgoWriter.Println("check podIP record in ippool again")
+			ok2, _, _, err := common.CheckPodIpRecordInIppool(frame, v4PoolNameList, v6PoolNameList, podList)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(ok2).To(BeTrue())
 
-			v4Pool.Spec.Gateway = &v4Gateway
-			route = spiderpoolv2beta1.Route{
-				Dst: v4Dst,
-				Gw:  v4Via,
+			// D00005: A "true" value of IPPool.Spec.disabled should forbid IP allocation, but still allow ip de-allocation
+			// Set the value of IPPool.Spec.disabled to "true"
+			if frame.Info.IpV4Enabled {
+				desiredV4PoolObj, err := common.GetIppoolByName(frame, v4PoolName)
+				Expect(err).NotTo(HaveOccurred())
+				desiredV4PoolObj.Spec.Disable = disable
+				err = common.PatchIppool(frame, desiredV4PoolObj, v4PoolObj)
+				Expect(err).NotTo(HaveOccurred(), "Failed to update %v.Spec.Disable form `false` to `true` for v4 pool", v4PoolName)
+				GinkgoWriter.Printf("Succeeded to update %v.Spec.Disable form `false` to `true` for v4 pool \n", v4PoolName)
 			}
-			v4Pool.Spec.Routes = []spiderpoolv2beta1.Route{route}
-			Expect(common.PatchIppool(frame, v4Pool, originalV4Pool)).To(Succeed(), "failed to update v4 ippool: %v with valid gateway: %v, and route: %+v\n", v4PoolName, v4Gateway, route)
-		}
-		if frame.Info.IpV6Enabled {
-			By("update v6 pool: invalid `gateway` and valid `route`")
-			// Get the IPv6 pool, use a invalid "gateway" and valid "route" to update the IPv6 ippool and expect the update to fails.
-			originalV6Pool, err := common.GetIppoolByName(frame, v6PoolName)
-			Expect(err).NotTo(HaveOccurred())
-			v6Pool, err = common.GetIppoolByName(frame, v6PoolName)
-			Expect(err).NotTo(HaveOccurred())
-
-			v6Pool.Spec.Gateway = &v6InvalidGateway
-			route := spiderpoolv2beta1.Route{
-				Dst: v6Dst,
-				Gw:  v6Via,
+			if frame.Info.IpV6Enabled {
+				desiredV6PoolObj, err := common.GetIppoolByName(frame, v6PoolName)
+				Expect(err).NotTo(HaveOccurred())
+				desiredV6PoolObj.Spec.Disable = disable
+				err = common.PatchIppool(frame, desiredV6PoolObj, v6PoolObj)
+				Expect(err).NotTo(HaveOccurred(), "Failed to update %v.Spec.Disable form `false` to `true` for v6 pool", v6PoolName)
+				GinkgoWriter.Println("Succeeded to update %v.Spec.Disable form `false` to `true` for v6 pool \n", v6PoolName)
 			}
-			v6Pool.Spec.Routes = []spiderpoolv2beta1.Route{route}
-			Expect(common.PatchIppool(frame, v6Pool, originalV6Pool)).NotTo(Succeed(), "error: we expect failed to update v6 ippool: %v with invalid gateway: %v, and valid route: %+v\n", v6PoolName, v6InvalidGateway, route)
 
-			By("update v6 pool: valid `gateway` and invalid `route`")
-			// Get the IPv6 pool, use a valid "gateway" and invalid "route" to update the IPv6 ippool and expect the update to fails.
-			v6Pool, err = common.GetIppoolByName(frame, v6PoolName)
-			Expect(err).NotTo(HaveOccurred())
+			// The value of IPPool.Spec.disabled is "true" and the Scale deployment
+			ctx1, cancel1 := context.WithTimeout(context.Background(), common.PodReStartTimeout)
+			defer cancel1()
+			pods, _, err := common.ScaleDeployUntilExpectedReplicas(ctx1, frame, deploy, deployScaleupNum, false)
+			Expect(err).NotTo(HaveOccurred(), "Failed to scale deployment")
 
-			v6Pool.Spec.Gateway = &v6Gateway
-			route = spiderpoolv2beta1.Route{
-				Dst: v6Dst,
-				Gw:  v6InvalidGateway,
+			// Failed to run pod and Get the Pod Scale failure Event
+			ctx2, cancel2 := context.WithTimeout(context.Background(), common.EventOccurTimeout)
+			defer cancel2()
+			for _, pod := range pods {
+				Expect(frame.WaitExceptEventOccurred(ctx2, common.OwnerPod, pod.Name, pod.Namespace, common.CNIFailedToSetUpNetwork)).To(Succeed())
+				GinkgoWriter.Printf("Pod %v/%v IP allocation failed when iPv4/iPv6 PoolObj.Spec.Disable is true", pod.Namespace, pod.Name)
 			}
-			v6Pool.Spec.Routes = []spiderpoolv2beta1.Route{route}
-			Expect(common.PatchIppool(frame, v6Pool, originalV6Pool)).NotTo(Succeed(), "error: we expect failed to update v6 ippool: %v with valid gateway: %v, and invalid route: %+v\n", v6PoolName, v6InvalidGateway, route)
 
-			By("update v6 pool: valid `gateway` and `route`")
-			// Get the IPv6 pool, use a valid "gateway" and "route" to update the IPv6 ippool and expect the update to succeed.
-			v6Pool, err = common.GetIppoolByName(frame, v6PoolName)
-			Expect(err).NotTo(HaveOccurred())
+			// Delete the deployment and then check that the Pod IP in the IPPool has been reclaimed correctly.
+			Expect(frame.DeleteDeploymentUntilFinish(deployName, nsName, common.ResourceDeleteTimeout)).To(Succeed())
+			GinkgoWriter.Printf("Succeeded to delete deployment %v/%v \n", nsName, deployName)
+			Expect(common.WaitIPReclaimedFinish(frame, v4PoolNameList, v6PoolNameList, podList, common.IPReclaimTimeout)).To(Succeed())
+			GinkgoWriter.Printf("The Pod %v/%v IP in the IPPool was reclaimed correctly \n", nsName, deployName)
+		})
 
-			v6Pool.Spec.Gateway = &v6Gateway
-			route = spiderpoolv2beta1.Route{
-				Dst: v6Dst,
-				Gw:  v6Via,
+		It("add a route with `routes` and `gateway` fields in the ippool spec", Label("D00002", "D00003", "smoke", "A00011"), func() {
+			podName1 := "pod" + tools.RandomName()
+			podName2 := "pod" + tools.RandomName()
+			var v4Gateway, v6Gateway, v4Dst, v6Dst, v4Via, v6Via string
+			var v4InvalidGateway, v6InvalidGateway string
+			var v4Pool, v6Pool *spiderpoolv2beta1.SpiderIPPool
+
+			// Generate Invalid Gateway and Dst
+			v4InvalidGateway = common.GenerateRandomIPV4()
+			v6InvalidGateway = common.GenerateRandomIPV6()
+
+			annoPodIPPools := types.AnnoPodIPPoolsValue{
+				types.AnnoIPPoolItem{
+					NIC: common.NIC1,
+				},
 			}
-			v6Pool.Spec.Routes = []spiderpoolv2beta1.Route{route}
-			Expect(common.PatchIppool(frame, v6Pool, originalV6Pool)).To(Succeed(), "failed to update v6 ippool: %v with valid gateway: %v, and route: %+v\n", v6PoolName, v6Gateway, route)
-		}
+			// Generate valid Gateway and Dst
+			if frame.Info.IpV4Enabled {
+				annoPodIPPools[0].IPv4Pools = []string{v4PoolName}
+				v4Gateway = strings.Split(v4PoolObj.Spec.Subnet, "0/")[0] + "1"
+				v4Dst = strings.Split(v4PoolObj.Spec.Subnet, ".")[0] + "." + strings.Split(v4PoolObj.Spec.Subnet, "/")[1] + ".0.0/16"
+				v4Via = strings.Split(v4PoolObj.Spec.Subnet, "0/")[0] + "254"
+			}
+			if frame.Info.IpV6Enabled {
+				annoPodIPPools[0].IPv6Pools = []string{v6PoolName}
+				v6Gateway = strings.Split(v6PoolObj.Spec.Subnet, "/")[0] + "1"
+				v6Dst = strings.Split(v6PoolObj.Spec.Subnet, "/")[0] + "/32"
+				v6Via = strings.Split(v6PoolObj.Spec.Subnet, "/")[0] + "fe"
+			}
 
-		// The ippool specified by annotation then creates the pod
-		// A00011: Use the ippool route with cleanGateway=false in the pod annotation as a default route
-		podNameCleanGatewayMap := map[string]bool{
-			podName1: false,
-			podName2: true,
-		}
-		for k, v := range podNameCleanGatewayMap {
-			annoPodIPPools[0].CleanGateway = v
-			b, err := json.Marshal(annoPodIPPools)
-			Expect(err).NotTo(HaveOccurred())
-			annoPodIPPoolsStr := string(b)
-			podYaml := common.GenerateExamplePodYaml(k, nsName)
-			podYaml.Annotations = map[string]string{constant.AnnoPodIPPools: annoPodIPPoolsStr}
-			common.CreatePodUntilReady(frame, podYaml, k, nsName, common.PodStartTimeout)
-		}
+			if frame.Info.IpV4Enabled {
+				By("update v4 pool: invalid `gateway` and valid `route`")
+				// Get the IPv4 pool, use a invalid "gateway" and valid "route" to update the IPv4 ippool and expect the update to fails.
+				originalV4Pool, err := common.GetIppoolByName(frame, v4PoolName)
+				Expect(err).NotTo(HaveOccurred())
+				v4Pool, err = common.GetIppoolByName(frame, v4PoolName)
+				Expect(err).NotTo(HaveOccurred())
 
-		// Check whether the route information is effective
-		GinkgoWriter.Println("check whether the route information is effective.")
-		if frame.Info.IpV4Enabled {
-			for k := range podNameCleanGatewayMap {
-				ctx, cancel := context.WithTimeout(context.Background(), common.ExecCommandTimeout)
+				v4Pool.Spec.Gateway = &v4InvalidGateway
+				route := spiderpoolv2beta1.Route{
+					Dst: v4Dst,
+					Gw:  v4Via,
+				}
+				v4Pool.Spec.Routes = []spiderpoolv2beta1.Route{route}
+				Expect(common.PatchIppool(frame, v4Pool, originalV4Pool)).NotTo(Succeed(), "error: we expect failed to update v4 ippool: %v with invalid gateway: %v, and valid route: %+v\n", v4PoolName, v4InvalidGateway, route)
+
+				By("update v4 pool: valid `gateway` and invalid `route`")
+				// Get the IPv4 pool, use a valid "gateway" and invalid "route" to update the IPv4 ippool and expect the update to fails.
+				v4Pool, err = common.GetIppoolByName(frame, v4PoolName)
+				Expect(err).NotTo(HaveOccurred())
+
+				v4Pool.Spec.Gateway = &v4Gateway
+				route = spiderpoolv2beta1.Route{
+					Dst: v4Dst,
+					Gw:  v4InvalidGateway,
+				}
+				v4Pool.Spec.Routes = []spiderpoolv2beta1.Route{route}
+				Expect(common.PatchIppool(frame, v4Pool, originalV4Pool)).NotTo(Succeed(), "error: we expect failed to update v4 ippool: %v with valid gateway: %v, and invalid route: %+v\n", v4PoolName, v4InvalidGateway, route)
+
+				By("update v4 pool: valid `gateway` and `route`")
+				// Get the IPv4 pool, use a valid "gateway" and "route" to update the IPv4 ippool and expect the update to succeed.
+				v4Pool, err = common.GetIppoolByName(frame, v4PoolName)
+				Expect(err).NotTo(HaveOccurred())
+
+				v4Pool.Spec.Gateway = &v4Gateway
+				route = spiderpoolv2beta1.Route{
+					Dst: v4Dst,
+					Gw:  v4Via,
+				}
+				v4Pool.Spec.Routes = []spiderpoolv2beta1.Route{route}
+				Expect(common.PatchIppool(frame, v4Pool, originalV4Pool)).To(Succeed(), "failed to update v4 ippool: %v with valid gateway: %v, and route: %+v\n", v4PoolName, v4Gateway, route)
+			}
+			if frame.Info.IpV6Enabled {
+				By("update v6 pool: invalid `gateway` and valid `route`")
+				// Get the IPv6 pool, use a invalid "gateway" and valid "route" to update the IPv6 ippool and expect the update to fails.
+				originalV6Pool, err := common.GetIppoolByName(frame, v6PoolName)
+				Expect(err).NotTo(HaveOccurred())
+				v6Pool, err = common.GetIppoolByName(frame, v6PoolName)
+				Expect(err).NotTo(HaveOccurred())
+
+				v6Pool.Spec.Gateway = &v6InvalidGateway
+				route := spiderpoolv2beta1.Route{
+					Dst: v6Dst,
+					Gw:  v6Via,
+				}
+				v6Pool.Spec.Routes = []spiderpoolv2beta1.Route{route}
+				Expect(common.PatchIppool(frame, v6Pool, originalV6Pool)).NotTo(Succeed(), "error: we expect failed to update v6 ippool: %v with invalid gateway: %v, and valid route: %+v\n", v6PoolName, v6InvalidGateway, route)
+
+				By("update v6 pool: valid `gateway` and invalid `route`")
+				// Get the IPv6 pool, use a valid "gateway" and invalid "route" to update the IPv6 ippool and expect the update to fails.
+				v6Pool, err = common.GetIppoolByName(frame, v6PoolName)
+				Expect(err).NotTo(HaveOccurred())
+
+				v6Pool.Spec.Gateway = &v6Gateway
+				route = spiderpoolv2beta1.Route{
+					Dst: v6Dst,
+					Gw:  v6InvalidGateway,
+				}
+				v6Pool.Spec.Routes = []spiderpoolv2beta1.Route{route}
+				Expect(common.PatchIppool(frame, v6Pool, originalV6Pool)).NotTo(Succeed(), "error: we expect failed to update v6 ippool: %v with valid gateway: %v, and invalid route: %+v\n", v6PoolName, v6InvalidGateway, route)
+
+				By("update v6 pool: valid `gateway` and `route`")
+				// Get the IPv6 pool, use a valid "gateway" and "route" to update the IPv6 ippool and expect the update to succeed.
+				v6Pool, err = common.GetIppoolByName(frame, v6PoolName)
+				Expect(err).NotTo(HaveOccurred())
+
+				v6Pool.Spec.Gateway = &v6Gateway
+				route = spiderpoolv2beta1.Route{
+					Dst: v6Dst,
+					Gw:  v6Via,
+				}
+				v6Pool.Spec.Routes = []spiderpoolv2beta1.Route{route}
+				Expect(common.PatchIppool(frame, v6Pool, originalV6Pool)).To(Succeed(), "failed to update v6 ippool: %v with valid gateway: %v, and route: %+v\n", v6PoolName, v6Gateway, route)
+			}
+
+			// The ippool specified by annotation then creates the pod
+			// A00011: Use the ippool route with cleanGateway=false in the pod annotation as a default route
+			podNameCleanGatewayMap := map[string]bool{
+				podName1: false,
+				podName2: true,
+			}
+			for k, v := range podNameCleanGatewayMap {
+				annoPodIPPools[0].CleanGateway = v
+				b, err := json.Marshal(annoPodIPPools)
+				Expect(err).NotTo(HaveOccurred())
+				annoPodIPPoolsStr := string(b)
+				podYaml := common.GenerateExamplePodYaml(k, nsName)
+				podYaml.Annotations = map[string]string{constant.AnnoPodIPPools: annoPodIPPoolsStr}
+				common.CreatePodUntilReady(frame, podYaml, k, nsName, common.PodStartTimeout)
+			}
+
+			// Check whether the route information is effective
+			GinkgoWriter.Println("check whether the route information is effective.")
+			if frame.Info.IpV4Enabled {
+				for k := range podNameCleanGatewayMap {
+					ctx, cancel := context.WithTimeout(context.Background(), common.ExecCommandTimeout)
+					defer cancel()
+					checkGatewayCommand := fmt.Sprintf("ip r | grep 'default via %s'", v4Gateway)
+					checkRouteCommand := fmt.Sprintf("ip r | grep '%s via %s'", v4Dst, v4Via)
+					output1, err1 := frame.ExecCommandInPod(k, nsName, checkGatewayCommand, ctx)
+					output2, err2 := frame.ExecCommandInPod(k, nsName, checkRouteCommand, ctx)
+					if k == podName1 {
+						Expect(output1).NotTo(BeEmpty())
+						Expect(err1).NotTo(HaveOccurred())
+					}
+					if k == podName2 {
+						Expect(output1).To(BeEmpty())
+						Expect(err1).To(HaveOccurred(), "cleanGateway=true, will not be used as the default route:%v \n", err1)
+					}
+					Expect(err2).NotTo(HaveOccurred())
+					Expect(output2).NotTo(BeEmpty())
+				}
+			}
+			if frame.Info.IpV6Enabled {
+				for k := range podNameCleanGatewayMap {
+					ctx, cancel := context.WithTimeout(context.Background(), common.ExecCommandTimeout)
+					defer cancel()
+					checkGatewayCommand := "ip -6 r show table main | grep -v veth0 | grep 'default via' | awk '{print $3}'"
+					checkRouteDstCommand := fmt.Sprintf("ip -6 r show table main | grep -v veth0 | grep 'via' | grep -w '%s' | grep -v 'default' | awk '{print $1}'", common.NIC1)
+					checkRouteViaCommand := fmt.Sprintf("ip -6 r show table main | grep -v veth0 | grep 'via' | grep -w '%s' | grep -v 'default' | awk '{print $3}'", common.NIC1)
+					effectiveIpv6Gw, err1 := frame.ExecCommandInPod(k, nsName, checkGatewayCommand, ctx)
+					effectiveIpv6Dst, err2 := frame.ExecCommandInPod(k, nsName, checkRouteDstCommand, ctx)
+					effectiveIpv6Via, err3 := frame.ExecCommandInPod(k, nsName, checkRouteViaCommand, ctx)
+					if k == podName1 {
+						Expect(common.ContrastIpv6ToIntValues(strings.TrimSpace(string(effectiveIpv6Gw)), v6Gateway)).NotTo(HaveOccurred())
+						Expect(err1).NotTo(HaveOccurred(), "failed execute command %v,error:%v", checkGatewayCommand, err1)
+					}
+					if k == podName2 {
+						Expect(effectiveIpv6Gw).To(BeEmpty())
+					}
+					Expect(common.ContrastIpv6ToIntValues(strings.TrimSpace(string(effectiveIpv6Dst)), v6Dst)).NotTo(HaveOccurred())
+					Expect(common.ContrastIpv6ToIntValues(strings.TrimSpace(string(effectiveIpv6Via)), v6Via)).NotTo(HaveOccurred())
+					Expect(err2).NotTo(HaveOccurred(), "failed execute command %v,error:%v", checkRouteDstCommand, err2)
+					Expect(err3).NotTo(HaveOccurred(), "failed execute command %v,error:%v", checkRouteViaCommand, err3)
+				}
+			}
+
+			// delete pod
+			Expect(frame.DeletePod(podName1, nsName)).To(Succeed())
+			Expect(frame.DeletePod(podName2, nsName)).To(Succeed())
+		})
+
+		Context("Test IPPool namespace Affinity", Label("namespaceName"), func() {
+			It("The namespace where the pod is located matches the namespaceName, and the IP can be assigned", Label("D00014"), func() {
+				Eventually(func() error {
+					if frame.Info.IpV4Enabled {
+						v4Pool, err := common.GetIppoolByName(frame, v4PoolObj.Name)
+						if nil != err {
+							return err
+						}
+						v4Pool.Spec.NamespaceName = []string{nsName}
+						err = frame.UpdateResource(v4Pool)
+						if nil != err {
+							return err
+						}
+						GinkgoWriter.Printf("update IPPool %s with NamespaceName %s successfully", v4Pool.Name, nsName)
+					}
+					if frame.Info.IpV6Enabled {
+						v6Pool, err := common.GetIppoolByName(frame, v6PoolObj.Name)
+						if nil != err {
+							return err
+						}
+						v6Pool.Spec.NamespaceName = []string{nsName}
+						err = frame.UpdateResource(v6Pool)
+						if nil != err {
+							return err
+						}
+						GinkgoWriter.Printf("update IPPool %s with NamespaceName %s successfully", v6Pool.Name, nsName)
+					}
+					return nil
+				}).WithTimeout(time.Minute * 3).WithPolling(time.Second * 3).Should(BeNil())
+
+				podName := "pod" + tools.RandomName()
+				podYaml := common.GenerateExamplePodYaml(podName, nsName)
+				annoPodIPPoolValue := types.AnnoPodIPPoolValue{}
+				if frame.Info.IpV4Enabled {
+					annoPodIPPoolValue.IPv4Pools = []string{v4PoolObj.Name}
+				}
+				if frame.Info.IpV6Enabled {
+					annoPodIPPoolValue.IPv6Pools = []string{v6PoolObj.Name}
+				}
+				annoPodIPPoolValueMarshal, err := json.Marshal(annoPodIPPoolValue)
+				Expect(err).NotTo(HaveOccurred())
+				podYaml.SetAnnotations(map[string]string{
+					constant.AnnoPodIPPool: string(annoPodIPPoolValueMarshal),
+				})
+				GinkgoWriter.Printf("try to create Pod with namespaceName '%s' IPPool: %s \n", nsName, podYaml.String())
+				Expect(frame.CreatePod(podYaml)).To(Succeed())
+				ctx, cancel := context.WithTimeout(context.Background(), time.Minute*1)
 				defer cancel()
-				checkGatewayCommand := fmt.Sprintf("ip r | grep 'default via %s'", v4Gateway)
-				checkRouteCommand := fmt.Sprintf("ip r | grep '%s via %s'", v4Dst, v4Via)
-				output1, err1 := frame.ExecCommandInPod(k, nsName, checkGatewayCommand, ctx)
-				output2, err2 := frame.ExecCommandInPod(k, nsName, checkRouteCommand, ctx)
-				if k == podName1 {
-					Expect(output1).NotTo(BeEmpty())
-					Expect(err1).NotTo(HaveOccurred())
-				}
-				if k == podName2 {
-					Expect(output1).To(BeEmpty())
-					Expect(err1).To(HaveOccurred(), "cleanGateway=true, will not be used as the default route:%v \n", err1)
-				}
-				Expect(err2).NotTo(HaveOccurred())
-				Expect(output2).NotTo(BeEmpty())
-			}
-		}
-		if frame.Info.IpV6Enabled {
-			for k := range podNameCleanGatewayMap {
-				ctx, cancel := context.WithTimeout(context.Background(), common.ExecCommandTimeout)
-				defer cancel()
-				checkGatewayCommand := "ip -6 r show table main | grep -v veth0 | grep 'default via' | awk '{print $3}'"
-				checkRouteDstCommand := fmt.Sprintf("ip -6 r show table main | grep -v veth0 | grep 'via' | grep -w '%s' | grep -v 'default' | awk '{print $1}'", common.NIC1)
-				checkRouteViaCommand := fmt.Sprintf("ip -6 r show table main | grep -v veth0 | grep 'via' | grep -w '%s' | grep -v 'default' | awk '{print $3}'", common.NIC1)
-				effectiveIpv6Gw, err1 := frame.ExecCommandInPod(k, nsName, checkGatewayCommand, ctx)
-				effectiveIpv6Dst, err2 := frame.ExecCommandInPod(k, nsName, checkRouteDstCommand, ctx)
-				effectiveIpv6Via, err3 := frame.ExecCommandInPod(k, nsName, checkRouteViaCommand, ctx)
-				if k == podName1 {
-					Expect(common.ContrastIpv6ToIntValues(strings.TrimSpace(string(effectiveIpv6Gw)), v6Gateway)).NotTo(HaveOccurred())
-					Expect(err1).NotTo(HaveOccurred(), "failed execute command %v,error:%v", checkGatewayCommand, err1)
-				}
-				if k == podName2 {
-					Expect(effectiveIpv6Gw).To(BeEmpty())
-				}
-				Expect(common.ContrastIpv6ToIntValues(strings.TrimSpace(string(effectiveIpv6Dst)), v6Dst)).NotTo(HaveOccurred())
-				Expect(common.ContrastIpv6ToIntValues(strings.TrimSpace(string(effectiveIpv6Via)), v6Via)).NotTo(HaveOccurred())
-				Expect(err2).NotTo(HaveOccurred(), "failed execute command %v,error:%v", checkRouteDstCommand, err2)
-				Expect(err3).NotTo(HaveOccurred(), "failed execute command %v,error:%v", checkRouteViaCommand, err3)
-			}
-		}
+				GinkgoWriter.Printf("wait for one minute that pod %v/%v should be ready. \n", nsName, podName)
+				_, err = frame.WaitPodStarted(podName, nsName, ctx)
+				Expect(err).NotTo(HaveOccurred())
+			})
 
-		// delete pod
-		Expect(frame.DeletePod(podName1, nsName)).To(Succeed())
-		Expect(frame.DeletePod(podName2, nsName)).To(Succeed())
+			It("The namespace where the pod resides does not match the namespaceName, and the IP cannot be assigned ", Label("D00015"), func() {
+				systemNS := "kube-system"
+
+				Eventually(func() error {
+					if frame.Info.IpV4Enabled {
+						v4Pool, err := common.GetIppoolByName(frame, v4PoolObj.Name)
+						if nil != err {
+							return err
+						}
+						v4Pool.Spec.NamespaceName = []string{systemNS}
+						err = frame.UpdateResource(v4Pool)
+						if nil != err {
+							return err
+						}
+						GinkgoWriter.Printf("update IPPool %s with NamespaceName %s successfully", v4Pool.Name, systemNS)
+					}
+					if frame.Info.IpV6Enabled {
+						v6Pool, err := common.GetIppoolByName(frame, v6PoolObj.Name)
+						if nil != err {
+							return err
+						}
+						v6Pool.Spec.NamespaceName = []string{systemNS}
+						err = frame.UpdateResource(v6Pool)
+						if nil != err {
+							return err
+						}
+						GinkgoWriter.Printf("update IPPool %s with NamespaceName %s successfully", v6Pool.Name, systemNS)
+					}
+					return nil
+				}).WithTimeout(time.Minute * 3).WithPolling(time.Second * 3).Should(BeNil())
+
+				podName := "pod" + tools.RandomName()
+				podYaml := common.GenerateExamplePodYaml(podName, nsName)
+				annoPodIPPoolValue := types.AnnoPodIPPoolValue{}
+				if frame.Info.IpV4Enabled {
+					annoPodIPPoolValue.IPv4Pools = []string{v4PoolObj.Name}
+				}
+				if frame.Info.IpV6Enabled {
+					annoPodIPPoolValue.IPv6Pools = []string{v6PoolObj.Name}
+				}
+				annoPodIPPoolValueMarshal, err := json.Marshal(annoPodIPPoolValue)
+				Expect(err).NotTo(HaveOccurred())
+				podYaml.SetAnnotations(map[string]string{
+					constant.AnnoPodIPPool: string(annoPodIPPoolValueMarshal),
+				})
+				GinkgoWriter.Printf("try to create Pod with namespaceName '%s' IPPool: %s \n", systemNS, podYaml.String())
+				Expect(frame.CreatePod(podYaml)).To(Succeed())
+				ctx, cancel := context.WithTimeout(context.Background(), time.Minute*1)
+				defer cancel()
+				GinkgoWriter.Printf("wait for one minute that pod %v/%v would not ready. \n", nsName, podName)
+				_, err = frame.WaitPodStarted(podName, nsName, ctx)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
 	})
 
 	It("create and delete batch of ippool and check time cost", Label("D00006"), func() {
@@ -796,59 +907,18 @@ var _ = Describe("test ippool CR", Label("ippoolCR"), func() {
 			Skip("SpiderSubnet feature is disabled, just skip this case")
 		}
 
-		fn := func(crName string, ipVersion types.IPVersion, subnet, ips, gateway string, route spiderpoolv2beta1.Route) {
-			demoSpiderSubnet := &spiderpoolv2beta1.SpiderSubnet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: fmt.Sprintf("%s-%d-subnet", crName, ipVersion),
-				},
-				Spec: spiderpoolv2beta1.SubnetSpec{
-					IPVersion: pointer.Int64(ipVersion),
-					Subnet:    subnet,
-					IPs:       []string{ips},
-					Gateway:   pointer.String(gateway),
-					Routes:    []spiderpoolv2beta1.Route{route},
-				},
-			}
-			GinkgoWriter.Printf("Generate SpiderSubnet %s, try to create it\n", demoSpiderSubnet.String())
-			err := frame.CreateResource(demoSpiderSubnet)
-			if nil != err {
-				if strings.Contains(err.Error(), "overlaps") {
-					Skip(fmt.Sprintf("the SpiderSubnet %v overlaps: %v", demoSpiderSubnet.String(), err.Error()))
-				}
-				Fail(fmt.Sprintf("failed to create SpiderSubnet, error: %s", err))
-			}
-
-			demoSpiderIPPool := &spiderpoolv2beta1.SpiderIPPool{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: fmt.Sprintf("%s-%d-ippool", crName, ipVersion),
-				},
-				Spec: spiderpoolv2beta1.IPPoolSpec{
-					IPVersion: pointer.Int64(ipVersion),
-					Subnet:    subnet,
-					IPs:       []string{ips},
-				},
-			}
-			GinkgoWriter.Printf("Generate SpiderIPPool %s, try to create it\n", demoSpiderIPPool.String())
-			err = frame.CreateResource(demoSpiderIPPool)
-			Expect(err).NotTo(HaveOccurred())
-
-			GinkgoWriter.Println("check whether the IPPool inherits the Subnet properties")
-			Expect(demoSpiderIPPool.Spec.Gateway).To(Equal(demoSpiderSubnet.Spec.Gateway))
-			Expect(demoSpiderIPPool.Spec.Routes).To(Equal(demoSpiderSubnet.Spec.Routes))
-
-			GinkgoWriter.Println("clean up Subnet")
-			err = frame.DeleteResource(demoSpiderSubnet)
-			Expect(err).NotTo(HaveOccurred())
-		}
-
 		crName := "demo"
 		wg := sync.WaitGroup{}
+
+		// for IPv4, create IPPool first and create Subnet later
 		if frame.Info.IpV4Enabled {
 			wg.Add(1)
 			go func() {
 				defer GinkgoRecover()
 				defer wg.Done()
 
+				poolName := fmt.Sprintf("%s-%d-ippool", crName, constant.IPv4)
+				subnetName := fmt.Sprintf("%s-%d-subnet", crName, constant.IPv4)
 				subnet := "172.16.0.0/16"
 				ips := "172.16.0.2"
 				gateway := "172.16.0.1"
@@ -856,15 +926,73 @@ var _ = Describe("test ippool CR", Label("ippoolCR"), func() {
 					Dst: "172.17.0.0/16",
 					Gw:  "172.16.41.1",
 				}
-				fn(crName, constant.IPv4, subnet, ips, gateway, route)
+
+				demoSpiderIPPool := &spiderpoolv2beta1.SpiderIPPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: poolName,
+					},
+					Spec: spiderpoolv2beta1.IPPoolSpec{
+						IPVersion: pointer.Int64(constant.IPv4),
+						Subnet:    subnet,
+						IPs:       []string{ips},
+					},
+				}
+				GinkgoWriter.Printf("Generate SpiderIPPool %s, try to create it\n", demoSpiderIPPool.String())
+				err := frame.CreateResource(demoSpiderIPPool)
+				Expect(err).NotTo(HaveOccurred())
+
+				demoSpiderSubnet := &spiderpoolv2beta1.SpiderSubnet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: subnetName,
+					},
+					Spec: spiderpoolv2beta1.SubnetSpec{
+						IPVersion: pointer.Int64(constant.IPv4),
+						Subnet:    subnet,
+						IPs:       []string{ips},
+						Gateway:   pointer.String(gateway),
+						Routes:    []spiderpoolv2beta1.Route{route},
+					},
+				}
+				GinkgoWriter.Printf("Generate SpiderSubnet %s, try to create it\n", demoSpiderSubnet.String())
+				err = frame.CreateResource(demoSpiderSubnet)
+				if nil != err {
+					if strings.Contains(err.Error(), "overlaps") {
+						Skip(fmt.Sprintf("the SpiderSubnet %v overlaps: %v", demoSpiderSubnet.String(), err.Error()))
+					}
+					Fail(fmt.Sprintf("failed to create SpiderSubnet, error: %s", err))
+				}
+
+				Eventually(func() error {
+					demoSpiderIPPool, err = common.GetIppoolByName(frame, poolName)
+					if nil != err {
+						return err
+					}
+					_, ok := demoSpiderIPPool.Labels[constant.LabelIPPoolOwnerSpiderSubnet]
+					if !ok {
+						return fmt.Errorf("IPPool %s is not controlled by subnet, wait for Subnet's reconcile to take in", poolName)
+					}
+					return nil
+				}).WithTimeout(time.Minute * 3).WithPolling(time.Second * 5).Should(BeNil())
+
+				GinkgoWriter.Println("check whether the IPPool inherits the Subnet properties")
+				Expect(demoSpiderIPPool.Spec.Gateway).To(Equal(demoSpiderSubnet.Spec.Gateway))
+				Expect(demoSpiderIPPool.Spec.Routes).To(Equal(demoSpiderSubnet.Spec.Routes))
+
+				GinkgoWriter.Println("clean up Subnet")
+				err = frame.DeleteResource(demoSpiderSubnet)
+				Expect(err).NotTo(HaveOccurred())
 			}()
 		}
+
+		// for IPv4, create Subnet first and create IPPool later
 		if frame.Info.IpV6Enabled {
 			wg.Add(1)
 			go func() {
 				defer GinkgoRecover()
 				defer wg.Done()
 
+				poolName := fmt.Sprintf("%s-%d-ippool", crName, constant.IPv6)
+				subnetName := fmt.Sprintf("%s-%d-subnet", crName, constant.IPv6)
 				subnet := "fd00:172:16::/64"
 				ips := "fd00:172:16::2"
 				gateway := "fd00:172:16::1"
@@ -872,118 +1000,64 @@ var _ = Describe("test ippool CR", Label("ippoolCR"), func() {
 					Dst: "fd00:172:17::/64",
 					Gw:  "fd00:172:16::100",
 				}
-				fn(crName, constant.IPv6, subnet, ips, gateway, route)
+
+				demoSpiderSubnet := &spiderpoolv2beta1.SpiderSubnet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: subnetName,
+					},
+					Spec: spiderpoolv2beta1.SubnetSpec{
+						IPVersion: pointer.Int64(constant.IPv6),
+						Subnet:    subnet,
+						IPs:       []string{ips},
+						Gateway:   pointer.String(gateway),
+						Routes:    []spiderpoolv2beta1.Route{route},
+					},
+				}
+				GinkgoWriter.Printf("Generate SpiderSubnet %s, try to create it\n", demoSpiderSubnet.String())
+				err := frame.CreateResource(demoSpiderSubnet)
+				if nil != err {
+					if strings.Contains(err.Error(), "overlaps") {
+						Skip(fmt.Sprintf("the SpiderSubnet %v overlaps: %v", demoSpiderSubnet.String(), err.Error()))
+					}
+					Fail(fmt.Sprintf("failed to create SpiderSubnet, error: %s", err))
+				}
+
+				demoSpiderIPPool := &spiderpoolv2beta1.SpiderIPPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: poolName,
+					},
+					Spec: spiderpoolv2beta1.IPPoolSpec{
+						IPVersion: pointer.Int64(constant.IPv6),
+						Subnet:    subnet,
+						IPs:       []string{ips},
+					},
+				}
+				GinkgoWriter.Printf("Generate SpiderIPPool %s, try to create it\n", demoSpiderIPPool.String())
+				err = frame.CreateResource(demoSpiderIPPool)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(func() error {
+					demoSpiderIPPool, err = common.GetIppoolByName(frame, poolName)
+					if nil != err {
+						return err
+					}
+					_, ok := demoSpiderIPPool.Labels[constant.LabelIPPoolOwnerSpiderSubnet]
+					if !ok {
+						return fmt.Errorf("IPPool %s is not controlled by subnet, wait for Subnet's reconcile to take in", poolName)
+					}
+					return nil
+				}).WithTimeout(time.Minute * 3).WithPolling(time.Second * 5).Should(BeNil())
+
+				GinkgoWriter.Println("check whether the IPPool inherits the Subnet properties")
+				Expect(demoSpiderIPPool.Spec.Gateway).To(Equal(demoSpiderSubnet.Spec.Gateway))
+				Expect(demoSpiderIPPool.Spec.Routes).To(Equal(demoSpiderSubnet.Spec.Routes))
+
+				GinkgoWriter.Println("clean up Subnet")
+				err = frame.DeleteResource(demoSpiderSubnet)
+				Expect(err).NotTo(HaveOccurred())
 			}()
 		}
 		wg.Wait()
-
 	})
 
-	Context("Test IPPool namespace Affinity", Label("namespaceName"), func() {
-		It("The namespace where the pod is located matches the namespaceName, and the IP can be assigned", Label("D00014"), func() {
-			Eventually(func() error {
-				if frame.Info.IpV4Enabled {
-					v4Pool, err := common.GetIppoolByName(frame, v4PoolObj.Name)
-					if nil != err {
-						return err
-					}
-					v4Pool.Spec.NamespaceName = []string{nsName}
-					err = frame.UpdateResource(v4Pool)
-					if nil != err {
-						return err
-					}
-					GinkgoWriter.Printf("update IPPool %s with NamespaceName %s successfully", v4Pool.Name, nsName)
-				}
-				if frame.Info.IpV6Enabled {
-					v6Pool, err := common.GetIppoolByName(frame, v6PoolObj.Name)
-					if nil != err {
-						return err
-					}
-					v6Pool.Spec.NamespaceName = []string{nsName}
-					err = frame.UpdateResource(v6Pool)
-					if nil != err {
-						return err
-					}
-					GinkgoWriter.Printf("update IPPool %s with NamespaceName %s successfully", v6Pool.Name, nsName)
-				}
-				return nil
-			}).WithTimeout(time.Minute * 3).WithPolling(time.Second * 3).Should(BeNil())
-
-			podName := "pod" + tools.RandomName()
-			podYaml := common.GenerateExamplePodYaml(podName, nsName)
-			annoPodIPPoolValue := types.AnnoPodIPPoolValue{}
-			if frame.Info.IpV4Enabled {
-				annoPodIPPoolValue.IPv4Pools = []string{v4PoolObj.Name}
-			}
-			if frame.Info.IpV6Enabled {
-				annoPodIPPoolValue.IPv6Pools = []string{v6PoolObj.Name}
-			}
-			annoPodIPPoolValueMarshal, err := json.Marshal(annoPodIPPoolValue)
-			Expect(err).NotTo(HaveOccurred())
-			podYaml.SetAnnotations(map[string]string{
-				constant.AnnoPodIPPool: string(annoPodIPPoolValueMarshal),
-			})
-			GinkgoWriter.Printf("try to create Pod with namespaceName '%s' IPPool: %s \n", nsName, podYaml.String())
-			Expect(frame.CreatePod(podYaml)).To(Succeed())
-			ctx, cancel := context.WithTimeout(context.Background(), time.Minute*1)
-			defer cancel()
-			GinkgoWriter.Printf("wait for one minute that pod %v/%v should be ready. \n", nsName, podName)
-			_, err = frame.WaitPodStarted(podName, nsName, ctx)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("The namespace where the pod resides does not match the namespaceName, and the IP cannot be assigned ", Label("D00015"), func() {
-			systemNS := "kube-system"
-
-			Eventually(func() error {
-				if frame.Info.IpV4Enabled {
-					v4Pool, err := common.GetIppoolByName(frame, v4PoolObj.Name)
-					if nil != err {
-						return err
-					}
-					v4Pool.Spec.NamespaceName = []string{systemNS}
-					err = frame.UpdateResource(v4Pool)
-					if nil != err {
-						return err
-					}
-					GinkgoWriter.Printf("update IPPool %s with NamespaceName %s successfully", v4Pool.Name, systemNS)
-				}
-				if frame.Info.IpV6Enabled {
-					v6Pool, err := common.GetIppoolByName(frame, v6PoolObj.Name)
-					if nil != err {
-						return err
-					}
-					v6Pool.Spec.NamespaceName = []string{systemNS}
-					err = frame.UpdateResource(v6Pool)
-					if nil != err {
-						return err
-					}
-					GinkgoWriter.Printf("update IPPool %s with NamespaceName %s successfully", v6Pool.Name, systemNS)
-				}
-				return nil
-			}).WithTimeout(time.Minute * 3).WithPolling(time.Second * 3).Should(BeNil())
-
-			podName := "pod" + tools.RandomName()
-			podYaml := common.GenerateExamplePodYaml(podName, nsName)
-			annoPodIPPoolValue := types.AnnoPodIPPoolValue{}
-			if frame.Info.IpV4Enabled {
-				annoPodIPPoolValue.IPv4Pools = []string{v4PoolObj.Name}
-			}
-			if frame.Info.IpV6Enabled {
-				annoPodIPPoolValue.IPv6Pools = []string{v6PoolObj.Name}
-			}
-			annoPodIPPoolValueMarshal, err := json.Marshal(annoPodIPPoolValue)
-			Expect(err).NotTo(HaveOccurred())
-			podYaml.SetAnnotations(map[string]string{
-				constant.AnnoPodIPPool: string(annoPodIPPoolValueMarshal),
-			})
-			GinkgoWriter.Printf("try to create Pod with namespaceName '%s' IPPool: %s \n", systemNS, podYaml.String())
-			Expect(frame.CreatePod(podYaml)).To(Succeed())
-			ctx, cancel := context.WithTimeout(context.Background(), time.Minute*1)
-			defer cancel()
-			GinkgoWriter.Printf("wait for one minute that pod %v/%v would not ready. \n", nsName, podName)
-			_, err = frame.WaitPodStarted(podName, nsName, ctx)
-			Expect(err).To(HaveOccurred())
-		})
-	})
 })

--- a/test/e2e/ippoolcr/ippoolcr_test.go
+++ b/test/e2e/ippoolcr/ippoolcr_test.go
@@ -846,6 +846,7 @@ var _ = Describe("test ippool CR", Label("ippoolCR"), func() {
 		if frame.Info.IpV4Enabled {
 			wg.Add(1)
 			go func() {
+				defer GinkgoRecover()
 				defer wg.Done()
 
 				subnet := "172.16.0.0/16"
@@ -861,6 +862,7 @@ var _ = Describe("test ippool CR", Label("ippoolCR"), func() {
 		if frame.Info.IpV6Enabled {
 			wg.Add(1)
 			go func() {
+				defer GinkgoRecover()
 				defer wg.Done()
 
 				subnet := "fd00:172:16::/64"


### PR DESCRIPTION
In the past versions, if you create a SpiderSubnet resource first and create a corresponding subnet SpiderIPPool resource later, the SpiderIPPool would inherit the SpiderSubnet `gateway, routes`. But if you create an orphan SpiderIPPool first, then the SpiderIPPool resources wouldn't inherit the SpiderSubnet properites.

And in this PR, I supplement a e2e case which validate 2 situations:
  1. create SpiderSubnet first, and create the corresponding SpiderIPPool later.
  2. create SpiderIPPool first, and create the corresponding SpiderSubnet later. 


Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)

#### What type of PR is this?
**What this PR does / why we need it**:
fix bug


**Which issue(s) this PR fixes**:
close #3009 
