### PR TITLE
Spidercoordinator: It able to get CIDR from kubeadm-config

### DIFF
--- a/docs/usage/install/overlay/get-started-calico-zh_cn.md
+++ b/docs/usage/install/overlay/get-started-calico-zh_cn.md
@@ -88,10 +88,31 @@ status:
   serviceCIDR:
   - 10.233.0.0/18
 ```
+ 
+> 目前 Spiderpool 优先通过查询 `kube-system/kubeadm-config` ConfigMap 获取集群的 Pod 和 Service 子网。 如果 kubeadm-config 不存在导致无法获取集群子网，那么 Spiderpool 会从 Kube-controller-manager Pod 中获取集群 Pod 和 Service 的子网。 如果您集群的 Kube-controller-manager 组件以 `systemd` 方式而不是以静态 Pod 运行。那么 Spiderpool 仍然无法获取集群的子网信息。
 
-> 1. 如果 phase 不为 Synced, 那么将会阻止 Pod 被创建
->
-> 2. 如果 overlayPodCIDR 不正常, 可能会导致通信问题
+如果上面两种方式都失败，Spiderpool 会同步 status.phase 为 NotReady, 这将会阻止 Pod 被创建。我们可以通过下面解决异常情况:
+
+- 手动创建 kubeadm-config ConfigMap, 并正确配置集群的子网信息:
+
+```shell
+export POD_SUBNET=<YOUR_POD_SUBNET>
+export SERVICE_SUBNET=<YOUR_SERVICE_SUBNET>
+cat << EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubeadm-config
+  namespace: kube-system
+data:
+  ClusterConfiguration: 
+    networking:
+      podSubnet: ${POD_SUBNET}
+      serviceSubnet: ${SERVICE_SUBNET}
+EOF
+```
+
+一旦创建完成，Spiderpool 将会自动同步其状态。
 
 ### 创建 SpiderIPPool
 

--- a/docs/usage/install/overlay/get-started-calico.md
+++ b/docs/usage/install/overlay/get-started-calico.md
@@ -84,9 +84,30 @@ status:
   - 10.233.0.0/18
 ```
 
-> 1. If the phase is not synced, the pod will be prevented from being created.
->
-> 2. If the overlayPodCIDR does not meet expectations, it may cause pod communication issue.
+> At present, Spiderpool prioritizes obtaining the cluster's Pod and Service subnets by querying the kube-system/kubeadm-config ConfigMap. If the kubeadm-config does not exist, causing the failure to obtain the cluster subnet, Spiderpool will attempt to retrieve the cluster Pod and Service subnets from the kube-controller-manager Pod. If the kube-controller-manager component in your cluster runs in systemd mode instead of as a static Pod, Spiderpool still cannot retrieve the cluster's subnet information.
+
+If both of the above methods fail, Spiderpool will synchronize the status.phase as NotReady, preventing Pod creation. To address such abnormal situations, we can take either of the following approaches:
+
+- Manually create the kubeadm-config ConfigMap and correctly configure the cluster's subnet information:
+
+```shell
+export POD_SUBNET=<YOUR_POD_SUBNET>
+export SERVICE_SUBNET=<YOUR_SERVICE_SUBNET>
+cat << EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubeadm-config
+  namespace: kube-system
+data:
+  ClusterConfiguration: 
+    networking:
+      podSubnet: ${POD_SUBNET}
+      serviceSubnet: ${SERVICE_SUBNET}
+EOF
+```
+
+Once created, Spiderpool will automatically synchronize its status.
 
 ### Create SpiderIPPool
 

--- a/docs/usage/install/overlay/get-started-cilium-zh_cn.md
+++ b/docs/usage/install/overlay/get-started-cilium-zh_cn.md
@@ -85,9 +85,30 @@ status:
   - 10.233.0.0/18
 ```
 
-> 1. 如果 phase 不为 Synced, 那么将会阻止 Pod 被创建
->
-> 2. 如果 overlayPodCIDR 不正常, 可能会导致通信问题
+> 目前 Spiderpool 优先通过查询 `kube-system/kubeadm-config` ConfigMap 获取集群的 Pod 和 Service 子网。 如果 kubeadm-config 不存在导致无法获取集群子网，那么 Spiderpool 会从 Kube-controller-manager Pod 中获取集群 Pod 和 Service 的子网。 如果您集群的 Kube-controller-manager 组件以 `systemd` 方式而不是以静态 Pod 运行。那么 Spiderpool 仍然无法获取集群的子网信息。
+
+如果上面两种方式都失败，Spiderpool 会同步 status.phase 为 NotReady, 这将会阻止 Pod 被创建。我们可以通过下面的方式解决异常情况:
+
+- 手动创建 kubeadm-config ConfigMap, 并正确配置集群的子网信息:
+
+```shell
+export POD_SUBNET=<YOUR_POD_SUBNET>
+export SERVICE_SUBNET=<YOUR_SERVICE_SUBNET>
+cat << EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubeadm-config
+  namespace: kube-system
+data:
+  ClusterConfiguration: |
+  networking:
+    podSubnet: ${POD_SUBNET}
+    serviceSubnet: ${SERVICE_SUBNET}
+EOF
+```
+
+一旦创建完成，Spiderpool 将会自动同步其状态。
 
 ### 创建 SpiderIPPool
 

--- a/docs/usage/install/overlay/get-started-cilium.md
+++ b/docs/usage/install/overlay/get-started-cilium.md
@@ -85,9 +85,30 @@ status:
   - 10.233.0.0/18
 ```
 
-> 1. If the phase is not synced, the pod will be prevented from being created.
->
-> 2. If the overlayPodCIDR does not meet expectations, it may cause pod communication issue.
+> At present, Spiderpool prioritizes obtaining the cluster's Pod and Service subnets by querying the kube-system/kubeadm-config ConfigMap. If the kubeadm-config does not exist, causing the failure to obtain the cluster subnet, Spiderpool will attempt to retrieve the cluster Pod and Service subnets from the kube-controller-manager Pod. If the kube-controller-manager component in your cluster runs in systemd mode instead of as a static Pod, Spiderpool still cannot retrieve the cluster's subnet information.
+
+If both of the above methods fail, Spiderpool will synchronize the status.phase as NotReady, preventing Pod creation. To address such abnormal situations, we can take either of the following approaches:
+
+- Manually create the kubeadm-config ConfigMap and correctly configure the cluster's subnet information:
+
+```shell
+export POD_SUBNET=<YOUR_POD_SUBNET>
+export SERVICE_SUBNET=<YOUR_SERVICE_SUBNET>
+cat << EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubeadm-config
+  namespace: kube-system
+data:
+  ClusterConfiguration: 
+  networking:
+    podSubnet: ${POD_SUBNET}
+    serviceSubnet: ${SERVICE_SUBNET}
+EOF
+```
+
+Once created, Spiderpool will automatically synchronize its status.
 
 ### Create SpiderIPPool
 

--- a/test/doc/spidercoodinator.md
+++ b/test/doc/spidercoodinator.md
@@ -10,3 +10,4 @@
 | V00006  | status.phase is not-ready, expect the cidr of status to be empty                                          | p3       |       |  done  |       |
 | V00007  | spidercoordinator has the lowest priority                                                                 | p3       |       |  done  |       |
 | V00008  | status.phase is not-ready, pods will fail to run                                                          | p3       |       |  done  |       |
+| V00009 | it can get the clusterCIDR from kubeadmConfig or kube-controller-manager pod | p3 |  | done|

--- a/test/e2e/spidercoordinator/spidercoordinator_test.go
+++ b/test/e2e/spidercoordinator/spidercoordinator_test.go
@@ -5,14 +5,18 @@ package spidercoordinator_suite_test
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spidernet-io/spiderpool/pkg/constant"
 	"github.com/spidernet-io/spiderpool/pkg/coordinatormanager"
 	"github.com/spidernet-io/spiderpool/pkg/ip"
+	spiderpoolv2beta1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1"
 	"github.com/spidernet-io/spiderpool/test/e2e/common"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Serial, func() {
@@ -94,21 +98,25 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 				}
 
 				Eventually(func() bool {
-					By("Get the default spidercoodinator.")
 					spc, err := GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
 					Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+					GinkgoWriter.Printf("Display the default spider coordinator information: %+v \n", spc)
 
-					By("After restoring the cni configuration under /etc/cni/net.d, the environment returns to normal.")
 					if spc.Status.OverlayPodCIDR == nil || spc.Status.Phase != coordinatormanager.Synced {
 						GinkgoWriter.Printf("status.overlayPodCIDR status is still synchronizing, status %+v \n", spc.Status.OverlayPodCIDR)
 						return false
 					}
+
 					for _, cidr := range spc.Status.OverlayPodCIDR {
 						if ip.IsIPv4CIDR(cidr) {
-							Expect(cidr).To(Equal(v4PodCIDRString))
+							if cidr != v4PodCIDRString {
+								return false
+							}
 							GinkgoWriter.Printf("ipv4 podCIDR is as expected, value %v=%v \n", cidr, v4PodCIDRString)
 						} else {
-							Expect(cidr).To(Equal(v6PodCIDRString))
+							if cidr != v6PodCIDRString {
+								return false
+							}
 							GinkgoWriter.Printf("ipv6 podCIDR is as expected, value %v=%v \n", cidr, v6PodCIDRString)
 						}
 					}
@@ -181,17 +189,23 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 				Eventually(func() bool {
 					spc, err := GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
 					Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+					GinkgoWriter.Printf("Display the default spider coordinator information: %+v \n", spc)
 
 					if spc.Status.OverlayPodCIDR == nil || spc.Status.Phase != coordinatormanager.Synced {
 						GinkgoWriter.Printf("status.overlayPodCIDR status is still synchronizing, status %+v \n", spc.Status.OverlayPodCIDR)
 						return false
 					}
+
 					for _, cidr := range spc.Status.OverlayPodCIDR {
 						if ip.IsIPv4CIDR(cidr) {
-							Expect(cidr).To(Equal(v4PodCIDRString))
+							if cidr != v4PodCIDRString {
+								return false
+							}
 							GinkgoWriter.Printf("ipv4 podCIDR is as expected, value %v=%v \n", cidr, v4PodCIDRString)
 						} else {
-							Expect(cidr).To(Equal(v6PodCIDRString))
+							if cidr != v6PodCIDRString {
+								return false
+							}
 							GinkgoWriter.Printf("ipv6 podCIDR is as expected, value %v=%v \n", cidr, v6PodCIDRString)
 						}
 					}
@@ -264,21 +278,23 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 			Eventually(func() bool {
 				spc, err := GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
 				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+				GinkgoWriter.Printf("Display the default spider coordinator information: %+v \n", spc)
 
-				if spc.Status.Phase != coordinatormanager.Synced {
-					GinkgoWriter.Printf("status.Phase status is still synchronizing, status %+v \n", spc.Status.Phase)
-					return false
-				}
-				if spc.Status.OverlayPodCIDR == nil {
+				if spc.Status.OverlayPodCIDR == nil || spc.Status.Phase != coordinatormanager.Synced {
 					GinkgoWriter.Printf("status.overlayPodCIDR status is still synchronizing, status %+v \n", spc.Status.OverlayPodCIDR)
 					return false
 				}
+
 				for _, cidr := range spc.Status.OverlayPodCIDR {
 					if ip.IsIPv4CIDR(cidr) {
-						Expect(cidr).To(Equal(v4PodCIDRString))
+						if cidr != v4PodCIDRString {
+							return false
+						}
 						GinkgoWriter.Printf("ipv4 podCIDR is as expected, value %v=%v \n", cidr, v4PodCIDRString)
 					} else {
-						Expect(cidr).To(Equal(v6PodCIDRString))
+						if cidr != v6PodCIDRString {
+							return false
+						}
 						GinkgoWriter.Printf("ipv6 podCIDR is as expected, value %v=%v \n", cidr, v6PodCIDRString)
 					}
 				}
@@ -313,6 +329,129 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 
 				GinkgoWriter.Println("status.overlayPodCIDR is nil, as expected.")
 				return true
+			}, common.ExecCommandTimeout, common.ForcedWaitingTime).Should(BeTrue())
+		})
+	})
+
+	Context("It can get the clusterCIDR from kubeadmConfig and kube-controller-manager pod", func() {
+
+		var spc *spiderpoolv2beta1.SpiderCoordinator
+		var cm *corev1.ConfigMap
+		var err error
+		BeforeEach(func() {
+			if !common.CheckRunOverlayCNI() {
+				GinkgoWriter.Println("This environment is in underlay mode.")
+				Skip("Not applicable to underlay mode")
+			}
+
+			if !common.CheckCalicoFeatureOn() {
+				GinkgoWriter.Println("The CNI isn't calico.")
+				Skip("This case only run in calico")
+			}
+
+			cm, err = frame.GetConfigmap("kubeadm-config", "kube-system")
+			Expect(err).NotTo(HaveOccurred())
+
+			spc, err = GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
+			Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+
+			// Switch podCIDRType to `cluster`.
+			spcCopy := spc.DeepCopy()
+			spcCopy.Spec.PodCIDRType = pointer.String(common.PodCIDRTypeCluster)
+			Expect(PatchSpiderCoordinator(spcCopy, spc)).NotTo(HaveOccurred())
+
+			DeferCleanup(func() {
+				spc, err := GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
+				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+				GinkgoWriter.Printf("Display the default spider coordinator information: %+v \n", spc)
+
+				// Switch podCIDRType to `auto`.
+				spcCopy := spc.DeepCopy()
+				spcCopy.Spec.PodCIDRType = pointer.String(common.PodCIDRTypeAuto)
+				Expect(PatchSpiderCoordinator(spcCopy, spc)).NotTo(HaveOccurred())
+
+				Eventually(func() bool {
+					spc, err := GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
+					Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+					GinkgoWriter.Printf("Display the default spider coordinator information: %+v \n", spc)
+
+					if spc.Status.OverlayPodCIDR == nil || spc.Status.Phase != coordinatormanager.Synced {
+						GinkgoWriter.Printf("status.overlayPodCIDR status is still synchronizing, status %+v \n", spc.Status.OverlayPodCIDR)
+						return false
+					}
+
+					for _, cidr := range spc.Status.OverlayPodCIDR {
+						if ip.IsIPv4CIDR(cidr) {
+							if cidr != v4PodCIDRString {
+								return false
+							}
+							GinkgoWriter.Printf("ipv4 podCIDR is as expected, value %v=%v \n", cidr, v4PodCIDRString)
+						} else {
+							if cidr != v6PodCIDRString {
+								return false
+							}
+							GinkgoWriter.Printf("ipv6 podCIDR is as expected, value %v=%v \n", cidr, v6PodCIDRString)
+						}
+					}
+					return true
+				}, common.ExecCommandTimeout, common.ForcedWaitingTime).Should(BeTrue())
+			})
+		})
+
+		It("Prioritize getting ClusterCIDR from kubeadm-config", func() {
+			GinkgoWriter.Printf("podCIDR and serviceCIDR from spidercoordinator: %v,%v\n", spc.Status.OverlayPodCIDR, spc.Status.ServiceCIDR)
+
+			podCIDR, serviceCIDr := coordinatormanager.ExtractK8sCIDRFromKubeadmConfigMap(cm)
+			GinkgoWriter.Printf("podCIDR and serviceCIDR from kubeadm-config : %v,%v\n", podCIDR, serviceCIDr)
+
+			Eventually(func() bool {
+				spc, err = GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
+				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+
+				if spc.Status.Phase != coordinatormanager.Synced {
+					return false
+				}
+
+				if reflect.DeepEqual(podCIDR, spc.Status.OverlayPodCIDR) && reflect.DeepEqual(serviceCIDr, spc.Status.ServiceCIDR) {
+					return true
+				}
+
+				return false
+			}, common.ExecCommandTimeout, common.ForcedWaitingTime).Should(BeTrue())
+		})
+
+		It("Getting clusterCIDR from kube-controller-manager Pod when kubeadm-config does not exist", func() {
+			// delete the kubeadm-config configMap
+			GinkgoWriter.Print("deleting kubeadm-config\n")
+			err = frame.DeleteConfigmap("kubeadm-config", "kube-system")
+			Expect(err).NotTo(HaveOccurred())
+
+			defer func() {
+				cm.ResourceVersion = ""
+				cm.Generation = 0
+				err = frame.CreateConfigmap(cm)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			allPods, err := frame.GetPodList(client.MatchingLabels{"component": "kube-controller-manager"})
+			Expect(err).NotTo(HaveOccurred())
+
+			kcmPodCIDR, kcmServiceCIDR := coordinatormanager.ExtractK8sCIDRFromKCMPod(&allPods.Items[0])
+			GinkgoWriter.Printf("podCIDR and serviceCIDR from kube-controller-manager pod : %v,%v\n", kcmPodCIDR, kcmServiceCIDR)
+
+			Eventually(func() bool {
+				spc, err = GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
+				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+
+				if spc.Status.Phase != coordinatormanager.Synced {
+					return false
+				}
+
+				if reflect.DeepEqual(kcmPodCIDR, spc.Status.OverlayPodCIDR) && reflect.DeepEqual(kcmServiceCIDR, spc.Status.ServiceCIDR) {
+					return true
+				}
+
+				return false
 			}, common.ExecCommandTimeout, common.ForcedWaitingTime).Should(BeTrue())
 		})
 	})


### PR DESCRIPTION
If the kube-controller-manager Pod is running as systemd process rather than Pod, In this case, We can't get the CIDR from the KCM Pod. We can get the CIDR from the kubeadm-config configMap.

## Thanks for contributing!

<!--Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>-->

#### What type of PR is this?

- release/bug 

<!--
Add one of the following kinds:

Required labels:

- release/none 
- release/bug 
- release/feature

Optional labels:

- kind/bug
- kind/feature
- kind/ci-bug
- kind/doc
-->

**What this PR does / why we need it**:

Kube-controller-pod is running as systemd process rather than a pod, We can't get the cluster CIDR in this case.

1. We get the clusterCIDR from kubeadm-config ConfigMap first.
2. If kubeadm-config ConfigMap does exist in cluster, we can get it from kube-controller-manager.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/spidernet-io/spiderpool/issues/3054

**Special notes for your reviewer**:
