### PR TITLE
Spidercoordinator: It able to get CIDR from kubeadm-config

### DIFF
--- a/docs/usage/install/overlay/get-started-calico.md
+++ b/docs/usage/install/overlay/get-started-calico.md
@@ -84,9 +84,30 @@ status:
   - 10.233.0.0/18
 ```
 
-> 1.If the phase is not synced, the pod will be prevented from being created.
->
-> 2.If the overlayPodCIDR does not meet expectations, it may cause pod communication issue.
+> At present, Spiderpool prioritizes obtaining the cluster's Pod and Service subnets by querying the kube-system/kubeadm-config ConfigMap. If the kubeadm-config does not exist, causing the failure to obtain the cluster subnet, Spiderpool will attempt to retrieve the cluster Pod and Service subnets from the kube-controller-manager Pod. If the kube-controller-manager component in your cluster runs in systemd mode instead of as a static Pod, Spiderpool still cannot retrieve the cluster's subnet information.
+
+If both of the above methods fail, Spiderpool will synchronize the status.phase as NotReady, preventing Pod creation. To address such abnormal situations, we can take either of the following approaches:
+
+- Manually create the kubeadm-config ConfigMap and correctly configure the cluster's subnet information:
+
+```shell
+export POD_SUBNET=<YOUR_POD_SUBNET>
+export SERVICE_SUBNET=<YOUR_SERVICE_SUBNET>
+cat << EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubeadm-config
+  namespace: kube-system
+data:
+  ClusterConfiguration: 
+    networking:
+      podSubnet: ${POD_SUBNET}
+      serviceSubnet: ${SERVICE_SUBNET}
+EOF
+```
+
+Once created, Spiderpool will automatically synchronize its status.
 
 ### Create SpiderIPPool
 

--- a/docs/usage/install/overlay/get-started-cilium-zh_cn.md
+++ b/docs/usage/install/overlay/get-started-cilium-zh_cn.md
@@ -85,9 +85,30 @@ status:
   - 10.233.0.0/18
 ```
 
-> 1.如果 phase 不为 Synced, 那么将会阻止 Pod 被创建
->
-> 2.如果 overlayPodCIDR 不正常, 可能会导致通信问题
+> 目前 Spiderpool 优先通过查询 `kube-system/kubeadm-config` ConfigMap 获取集群的 Pod 和 Service 子网。 如果 kubeadm-config 不存在导致无法获取集群子网，那么 Spiderpool 会从 Kube-controller-manager Pod 中获取集群 Pod 和 Service 的子网。 如果您集群的 Kube-controller-manager 组件以 `systemd` 方式而不是以静态 Pod 运行。那么 Spiderpool 仍然无法获取集群的子网信息。
+
+如果上面两种方式都失败，Spiderpool 会同步 status.phase 为 NotReady, 这将会阻止 Pod 被创建。我们可以通过下面的方式解决异常情况:
+
+- 手动创建 kubeadm-config ConfigMap, 并正确配置集群的子网信息:
+
+```shell
+export POD_SUBNET=<YOUR_POD_SUBNET>
+export SERVICE_SUBNET=<YOUR_SERVICE_SUBNET>
+cat << EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubeadm-config
+  namespace: kube-system
+data:
+  ClusterConfiguration: |
+  networking:
+    podSubnet: ${POD_SUBNET}
+    serviceSubnet: ${SERVICE_SUBNET}
+EOF
+```
+
+一旦创建完成，Spiderpool 将会自动同步其状态。
 
 ### 创建 SpiderIPPool
 

--- a/docs/usage/install/overlay/get-started-cilium.md
+++ b/docs/usage/install/overlay/get-started-cilium.md
@@ -85,9 +85,30 @@ status:
   - 10.233.0.0/18
 ```
 
-> 1.If the phase is not synced, the pod will be prevented from being created.
->
-> 2.If the overlayPodCIDR does not meet expectations, it may cause pod communication issue.
+> At present, Spiderpool prioritizes obtaining the cluster's Pod and Service subnets by querying the kube-system/kubeadm-config ConfigMap. If the kubeadm-config does not exist, causing the failure to obtain the cluster subnet, Spiderpool will attempt to retrieve the cluster Pod and Service subnets from the kube-controller-manager Pod. If the kube-controller-manager component in your cluster runs in systemd mode instead of as a static Pod, Spiderpool still cannot retrieve the cluster's subnet information.
+
+If both of the above methods fail, Spiderpool will synchronize the status.phase as NotReady, preventing Pod creation. To address such abnormal situations, we can take either of the following approaches:
+
+- Manually create the kubeadm-config ConfigMap and correctly configure the cluster's subnet information:
+
+```shell
+export POD_SUBNET=<YOUR_POD_SUBNET>
+export SERVICE_SUBNET=<YOUR_SERVICE_SUBNET>
+cat << EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubeadm-config
+  namespace: kube-system
+data:
+  ClusterConfiguration: 
+  networking:
+    podSubnet: ${POD_SUBNET}
+    serviceSubnet: ${SERVICE_SUBNET}
+EOF
+```
+
+Once created, Spiderpool will automatically synchronize its status.
 
 ### Create SpiderIPPool
 

--- a/test/doc/spidercoodinator.md
+++ b/test/doc/spidercoodinator.md
@@ -10,3 +10,4 @@
 | V00006  | status.phase is not-ready, expect the cidr of status to be empty                                          | p3       |       |  done  |       |
 | V00007  | spidercoordinator has the lowest priority                                                                 | p3       |       |  done  |       |
 | V00008  | status.phase is not-ready, pods will fail to run                                                          | p3       |       |  done  |       |
+| V00009 | it can get the clusterCIDR from kubeadmConfig or kube-controller-manager pod | p3 |  | done|


### PR DESCRIPTION
If the kube-controller-manager Pod is running as systemd precess rather than Pod, In this case, We can't get the CIDR from the KCM Pod. We can get the CIDR from the kubeadm-config configMap.

## Thanks for contributing!

<!--Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>-->

#### What type of PR is this?

<!--
Add one of the following kinds:

Required labels:

- release/none 
- release/bug 
- release/feature

Optional labels:

- kind/bug
- kind/feature
- kind/ci-bug
- kind/doc
-->

**What this PR does / why we need it**:



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/spidernet-io/spiderpool/issues/3126

**Special notes for your reviewer**:
