### PR TITLE
CI: make k8s 1.29 to default

### DIFF
--- a/.github/workflows/e2e-init.yaml
+++ b/.github/workflows/e2e-init.yaml
@@ -135,7 +135,7 @@ jobs:
             MINIMAL_VERSION=1.24.3
             K8S_VERSION=$(echo ${{ inputs.k8s_version }} | grep -Eo "([0-9]+\.[0-9]+)")
             if [ -z ${K8S_VERSION} ]; then
-              K8S_VERSION=1.27.1
+              K8S_VERSION=1.29.0
             fi
             if [[ "${K8S_VERSION}" < "${MINIMAL_VERSION}" ]]; then
               echo "The current kubernetes version is ${{ inputs.k8s_version }} , ignore to install openvswitch due to Kind base image outdated"


### PR DESCRIPTION
## Thanks for contributing!

<!--Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>-->

#### What type of PR is this?

<!--
Add one of the following kinds:

Required labels:

- release/none 
- release/bug 
- release/feature

Optional labels:

- kind/bug
- kind/feature
- kind/ci-bug
- kind/doc
-->

**What this PR does / why we need it**:

CI: make k8s 1.29 to default, we need to test the serviceCIDR resource.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
