### PR TITLE
use helm charts value control coordinator components startup

### DIFF
--- a/charts/spiderpool/templates/deployment.yaml
+++ b/charts/spiderpool/templates/deployment.yaml
@@ -173,6 +173,8 @@ spec:
           value: {{ .Values.multus.enableMultusConfig | quote }}
         - name: SPIDERPOOL_CNI_CONFIG_DIR
           value: {{ .Values.global.cniConfHostPath | quote }}
+        - name: SPIDERPOOL_COORDINATOR_ENABLED
+          value: {{ .Values.coordinator.enabled | quote }}
         - name: SPIDERPOOL_CILIUM_CONFIGMAP_NAMESPACE_NAME
           value: {{ .Values.global.ciliumConfigMap | quote }}
         - name: SPIDERPOOL_POD_NAME

--- a/charts/spiderpool/templates/tls.yaml
+++ b/charts/spiderpool/templates/tls.yaml
@@ -116,6 +116,7 @@ webhooks:
     resources:
     - spiderreservedips
   sideEffects: None
+{{- if .Values.coordinator.enabled }}
 - admissionReviewVersions:
   - v1
   clientConfig:
@@ -142,6 +143,7 @@ webhooks:
     resources:
     - spidercoordinators
   sideEffects: None
+{{- end }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -231,6 +233,7 @@ webhooks:
     resources:
     - spiderreservedips
   sideEffects: None
+{{- if .Values.coordinator.enabled }}
 - admissionReviewVersions:
   - v1
   clientConfig:
@@ -257,6 +260,7 @@ webhooks:
     resources:
     - spidercoordinators
   sideEffects: None
+{{- end }}
 {{- if .Values.multus.enableMultusConfig }}
 - admissionReviewVersions:
     - v1

--- a/cmd/spiderpool-controller/cmd/config.go
+++ b/cmd/spiderpool-controller/cmd/config.go
@@ -89,6 +89,7 @@ var envInfo = []envConf{
 	{"SPIDERPOOL_SUBNET_INFORMER_MAX_WORKQUEUE_LENGTH", "10000", false, nil, nil, &controllerContext.Cfg.SubnetInformerMaxWorkqueueLength},
 	{"SPIDERPOOL_SUBNET_APPLICATION_CONTROLLER_WORKERS", "5", true, nil, nil, &controllerContext.Cfg.SubnetAppControllerWorkers},
 
+	{"SPIDERPOOL_COORDINATOR_ENABLED", "false", false, nil, &controllerContext.Cfg.EnableCoordinator, nil},
 	{"SPIDERPOOL_COORDINATOR_INFORMER_RESYNC_PERIOD", "60", false, nil, nil, &controllerContext.Cfg.CoordinatorInformerResyncPeriod},
 	{"SPIDERPOOL_CNI_CONFIG_DIR", "/etc/cni/net.d", false, &controllerContext.Cfg.DefaultCniConfDir, nil, nil},
 
@@ -153,6 +154,8 @@ type Config struct {
 
 	EnableMultusConfig               bool
 	MultusConfigInformerResyncPeriod int
+
+	EnableCoordinator bool
 
 	// configmap
 	EnableIPv4                        bool `yaml:"enableIPv4"`


### PR DESCRIPTION
Do not register the coordinator `webhook` and do not set up coordinator `informer` when using the helm charts to install spiderpool with `--coordinator.enbaled=false`

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)

**What this PR does / why we need it**:
fix bug

**Which issue(s) this PR fixes**:
close #3181 

