### PR TITLE
add kubernetes serviceCIDR APIResource register validation

### DIFF
--- a/cmd/spiderpool-controller/cmd/daemon.go
+++ b/cmd/spiderpool-controller/cmd/daemon.go
@@ -186,7 +186,7 @@ func DaemonMain() {
 	// disturbed by an abnormal webhook.
 	checkWebhookReady()
 
-	setupInformers()
+	setupInformers(controllerContext.ClientSet)
 
 	monitorMetrics(controllerContext.InnerCtx)
 
@@ -447,20 +447,16 @@ func initDynamicClient() (*dynamic.DynamicClient, error) {
 
 // setupInformers will run IPPool,Subnet... informers,
 // because these informers count on webhook
-func setupInformers() {
+func setupInformers(k8sClient *kubernetes.Clientset) {
 	// start SpiderIPPool informer
 	crdClient, err := crdclientset.NewForConfig(ctrl.GetConfigOrDie())
 	if err != nil {
 		logger.Fatal(err.Error())
 	}
 
-	k8sClient, err := initK8sClientSet()
-	if nil != err {
-		logger.Fatal(err.Error())
-	}
-
 	logger.Info("Begin to set up Coordinator informer")
 	if err := (&coordinatormanager.CoordinatorController{
+		K8sClient:           controllerContext.ClientSet,
 		Manager:             controllerContext.CRDManager,
 		Client:              controllerContext.CRDManager.GetClient(),
 		APIReader:           controllerContext.CRDManager.GetAPIReader(),

--- a/pkg/constant/k8s.go
+++ b/pkg/constant/k8s.go
@@ -33,6 +33,7 @@ const (
 	KindCronJob     = "CronJob"
 	KindKubevirtVM  = "VirtualMachine"
 	KindKubevirtVMI = "VirtualMachineInstance"
+	KindServiceCIDR = "ServiceCIDR"
 )
 
 var K8sKinds = []string{KindPod, KindDeployment, KindReplicaSet, KindDaemonSet, KindStatefulSet, KindJob, KindCronJob}

--- a/pkg/coordinatormanager/service_cidr_informer.go
+++ b/pkg/coordinatormanager/service_cidr_informer.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 
 	"go.uber.org/zap"
-	networkingv1 "k8s.io/api/networking/v1alpha1"
+	networkingv1alpha1 "k8s.io/api/networking/v1alpha1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,7 +39,7 @@ func NewServiceCIDRController(mgr ctrl.Manager, logger *zap.Logger, coordinatorN
 	if err != nil {
 		return nil, err
 	}
-	if err := c.Watch(source.Kind(mgr.GetCache(), &networkingv1.ServiceCIDR{}), &handler.EnqueueRequestForObject{}); err != nil {
+	if err := c.Watch(source.Kind(mgr.GetCache(), &networkingv1alpha1.ServiceCIDR{}), &handler.EnqueueRequestForObject{}); err != nil {
 		return nil, err
 	}
 
@@ -53,7 +53,7 @@ type serviceCIDRReconciler struct {
 }
 
 func (r *serviceCIDRReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	var svcPoolList networkingv1.ServiceCIDRList
+	var svcPoolList networkingv1alpha1.ServiceCIDRList
 	if err := r.client.List(ctx, &svcPoolList); err != nil {
 		return ctrl.Result{Requeue: true}, err
 	}


### PR DESCRIPTION
Before fetch the kubernetes `ServiceCIDR` resource, we need to check whether the current kubernetes registered the `networking v1alpha1 ServiceCIDR` API resources.

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)