### PR TITLE
fix the logic of obtaining kubeadm-config to avoid being unable to create Pods

### DIFF
--- a/test/scripts/install-default-cni.sh
+++ b/test/scripts/install-default-cni.sh
@@ -194,7 +194,8 @@ function install_cilium() {
                                    --set tunnel=disabled \
                                    --set ipv6NativeRoutingCIDR=${CILIUM_CLUSTER_POD_SUBNET_V6} \
                                    --set autoDirectNodeRoutes=true \
-                                   --set enableIPv6Masquerade=true "
+                                   --set enableIPv6Masquerade=true \
+                                   --set routingMode=native "
           ;;
         dual)
             CILIUM_HELM_OPTIONS+=" --set ipam.operator.clusterPoolIPv4PodCIDRList=${CILIUM_CLUSTER_POD_SUBNET_V4} \


### PR DESCRIPTION
## Thanks for contributing!

<!--Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>-->

#### What type of PR is this?

<!--
Add one of the following kinds:

Required labels:

- release/none 
- release/bug 
- release/feature

Optional labels:

- kind/bug
- kind/feature
- kind/ci-bug
- kind/doc
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3180 
Fixes #3210 

**Additional information**

1. In the original logic, the judgment of kubeadm-config was incorrect.
2. When kubeadm-config does not exist, obtain podCIDR and serviceCIDR from kube-controller-manager Pod. Due to different ways of deploying the cluster, there may be two types: Spec.Containers[0].Command and Spec.Containers[0].Args. Scenarios, such as the RKE2 cluster is Spec.Containers[0].Args and not Spec.Containers[0].Command, resulting in a judgment error and an empty serviceCIDR returned, resulting in the inability to create a Pod.
