### PR TITLE
supplement pyroscope profile types

### DIFF
--- a/cmd/spiderpool-agent/cmd/daemon.go
+++ b/cmd/spiderpool-agent/cmd/daemon.go
@@ -94,6 +94,10 @@ func DaemonMain() {
 		if e != nil || len(node) == 0 {
 			logger.Sugar().Fatalf("Failed to get hostname: %v", e)
 		}
+
+		// These 2 lines are only required if you're using mutex or block profiling
+		runtime.SetMutexProfileFraction(5)
+		runtime.SetBlockProfileRate(5)
 		_, e = pyroscope.Start(pyroscope.Config{
 			ApplicationName: binNameAgent,
 			ServerAddress:   agentContext.Cfg.PyroscopeAddress,
@@ -105,6 +109,12 @@ func DaemonMain() {
 				pyroscope.ProfileAllocSpace,
 				pyroscope.ProfileInuseObjects,
 				pyroscope.ProfileInuseSpace,
+				// additional
+				pyroscope.ProfileGoroutines,
+				pyroscope.ProfileMutexCount,
+				pyroscope.ProfileMutexDuration,
+				pyroscope.ProfileBlockCount,
+				pyroscope.ProfileBlockDuration,
 			},
 		})
 		if e != nil {

--- a/cmd/spiderpool-controller/cmd/daemon.go
+++ b/cmd/spiderpool-controller/cmd/daemon.go
@@ -98,6 +98,10 @@ func DaemonMain() {
 		if e != nil || len(node) == 0 {
 			logger.Sugar().Fatalf("Failed to get hostname: %v", e)
 		}
+
+		// These 2 lines are only required if you're using mutex or block profiling
+		runtime.SetMutexProfileFraction(5)
+		runtime.SetBlockProfileRate(5)
 		_, e = pyroscope.Start(pyroscope.Config{
 			ApplicationName: binNameController,
 			ServerAddress:   controllerContext.Cfg.PyroscopeAddress,
@@ -109,6 +113,12 @@ func DaemonMain() {
 				pyroscope.ProfileAllocSpace,
 				pyroscope.ProfileInuseObjects,
 				pyroscope.ProfileInuseSpace,
+				// additional
+				pyroscope.ProfileGoroutines,
+				pyroscope.ProfileMutexCount,
+				pyroscope.ProfileMutexDuration,
+				pyroscope.ProfileBlockCount,
+				pyroscope.ProfileBlockDuration,
 			},
 		})
 		if e != nil {

--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -93,9 +93,9 @@ endif
 USE_TLS_METHOD := auto
 
 ifeq ($(E2E_CHINA_IMAGE_REGISTRY),true)
-    IMAGE_PYROSCOPE_NAME ?= docker.m.daocloud.io/pyroscope/pyroscope:latest
+    IMAGE_PYROSCOPE_NAME ?= docker.m.daocloud.io/grafana/pyroscope:latest
 else
-    IMAGE_PYROSCOPE_NAME ?= docker.io/pyroscope/pyroscope:latest
+    IMAGE_PYROSCOPE_NAME ?= docker.io/grafana/pyroscope:latest
 endif
 
 


### PR DESCRIPTION
1. supplement pyroscope profile types in go code
2. change pyroscope image from `pyroscope/pyroscope` to `grafana/pyroscope`

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)