### PR TITLE
fix coordinator controller goroutines leak

### DIFF
--- a/pkg/coordinatormanager/coordinator_informer.go
+++ b/pkg/coordinatormanager/coordinator_informer.go
@@ -324,8 +324,16 @@ func (cc *CoordinatorController) syncHandler(ctx context.Context, coordinatorNam
 		logger.Sugar().Errorf("failed to handle spidercoordinator: %v", err)
 	}
 
+	if !reflect.DeepEqual(coordCopy.Spec, coord.Spec) {
+		logger.Sugar().Infof("try to patch coordinator's spec from %v to %v", coord.Spec, coordCopy.Spec)
+		err := cc.Client.Patch(ctx, coordCopy, client.MergeFrom(coord))
+		if nil != err {
+			return err
+		}
+	}
+
 	if !reflect.DeepEqual(coordCopy.Status, coord.Status) {
-		logger.Sugar().Infof(" Try to patch coordinator's status from %v to %v", coord.Status, coordCopy.Status)
+		logger.Sugar().Infof("Try to patch coordinator's status from %v to %v", coord.Status, coordCopy.Status)
 		if err = cc.Client.Status().Patch(ctx, coordCopy, client.MergeFrom(coord)); err != nil {
 			logger.Sugar().Errorf("failed to patch spidercoordinator phase: %v", err.Error())
 			return err

--- a/test/e2e/spidercoordinator/spidercoordinator_test.go
+++ b/test/e2e/spidercoordinator/spidercoordinator_test.go
@@ -99,6 +99,12 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 					Expect(err).NotTo(HaveOccurred(), "Failed to execute mv command on the node %s ; error is %v", pod.Spec.NodeName, err)
 				}
 
+				coord, err := GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
+				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator,error is %v", err)
+				coord.Spec.PodCIDRType = ptr.To(common.PodCIDRTypeAuto)
+				err = frame.KClient.Update(context.TODO(), coord)
+				Expect(err).NotTo(HaveOccurred())
+
 				Eventually(func() bool {
 					spc, err := GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
 					Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
@@ -123,11 +129,16 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 						}
 					}
 					return true
-				}, common.ExecCommandTimeout, common.ForcedWaitingTime).Should(BeTrue())
+				}, common.ExecCommandTimeout, common.ForcedWaitingTime*3).Should(BeTrue())
 			})
 		})
 
 		It("Switch podCIDRType to `auto` but no cni files in /etc/cni/net.d, Viewing should be consistent with `none`.", Label("V00002"), func() {
+			coord, err := GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
+			Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator,error is %v", err)
+			coord.Spec.PodCIDRType = ptr.To(common.PodCIDRTypeAuto)
+			err = frame.KClient.Update(context.TODO(), coord)
+			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func() bool {
 				By("Get the default spidercoodinator.")


### PR DESCRIPTION
In the coordinator reconcile operation, it changed the SpiderCoordinator default resource's spec but use the `Status()` API, in which the update procession failed. And it would start a goroutine to watch calico resource in every update procession. 

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)

**What this PR does / why we need it**:
fix bug

**Which issue(s) this PR fixes**:
close https://github.com/spidernet-io/spiderpool/issues/3225
