### PR TITLE
optimize e2e kubelet restart case

### DIFF
--- a/cmd/spiderpool-controller/cmd/daemon.go
+++ b/cmd/spiderpool-controller/cmd/daemon.go
@@ -33,6 +33,7 @@ import (
 	"github.com/spidernet-io/spiderpool/pkg/multuscniconfig"
 	"github.com/spidernet-io/spiderpool/pkg/namespacemanager"
 	"github.com/spidernet-io/spiderpool/pkg/nodemanager"
+	"github.com/spidernet-io/spiderpool/pkg/openapi"
 	"github.com/spidernet-io/spiderpool/pkg/podmanager"
 	"github.com/spidernet-io/spiderpool/pkg/reservedipmanager"
 	"github.com/spidernet-io/spiderpool/pkg/statefulsetmanager"
@@ -178,7 +179,7 @@ func DaemonMain() {
 	initGCManager(controllerContext.InnerCtx)
 
 	logger.Info("Set spiderpool-controller Startup probe ready")
-	controllerContext.webhookClient = newWebhookHealthCheckClient()
+	controllerContext.webhookClient = openapi.NewWebhookHealthCheckClient()
 	controllerContext.IsStartupProbe.Store(true)
 
 	// The CRD webhook of Spiderpool must be started before informer, so that
@@ -553,7 +554,7 @@ func checkWebhookReady() {
 			logger.Fatal("out of the max wait duration for webhook ready in process starting phase")
 		}
 
-		err := WebhookHealthyCheck(controllerContext.webhookClient, controllerContext.Cfg.WebhookPort)
+		err := openapi.WebhookHealthyCheck(controllerContext.webhookClient, controllerContext.Cfg.WebhookPort, nil)
 		if nil != err {
 			logger.Error(err.Error())
 

--- a/cmd/spiderpool-controller/cmd/runtime_status.go
+++ b/cmd/spiderpool-controller/cmd/runtime_status.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 
 	"github.com/spidernet-io/spiderpool/api/v1/controller/server/restapi/runtime"
+	"github.com/spidernet-io/spiderpool/pkg/openapi"
 )
 
 // Singleton
@@ -35,7 +36,7 @@ type _httpGetControllerReadiness struct {
 
 // Handle handles GET requests for k8s readiness probe.
 func (g *_httpGetControllerReadiness) Handle(params runtime.GetRuntimeReadinessParams) middleware.Responder {
-	if err := WebhookHealthyCheck(g.webhookClient, g.Cfg.WebhookPort); err != nil {
+	if err := openapi.WebhookHealthyCheck(g.webhookClient, g.Cfg.WebhookPort, nil); err != nil {
 		logger.Sugar().Errorf("failed to check spiderpool-controller readiness probe, error: %v", err)
 		return runtime.NewGetRuntimeReadinessInternalServerError()
 	}
@@ -61,7 +62,7 @@ type _httpGetControllerLiveness struct {
 
 // Handle handles GET requests for k8s liveness probe.
 func (g *_httpGetControllerLiveness) Handle(params runtime.GetRuntimeLivenessParams) middleware.Responder {
-	if err := WebhookHealthyCheck(g.webhookClient, g.Cfg.WebhookPort); err != nil {
+	if err := openapi.WebhookHealthyCheck(g.webhookClient, g.Cfg.WebhookPort, nil); err != nil {
 		logger.Sugar().Errorf("failed to check spiderpool controller liveness probe, error: %v", err)
 		return runtime.NewGetRuntimeLivenessInternalServerError()
 	}

--- a/pkg/constant/k8s.go
+++ b/pkg/constant/k8s.go
@@ -158,3 +158,5 @@ const (
 	OvsCNI     = "ovs"
 	CustomCNI  = "custom"
 )
+
+const WebhookMutateRoute = "/webhook-health-check"

--- a/pkg/openapi/webhook_checker.go
+++ b/pkg/openapi/webhook_checker.go
@@ -1,0 +1,56 @@
+// Copyright 2024 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+
+package openapi
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+
+	"github.com/spidernet-io/spiderpool/pkg/constant"
+)
+
+// NewWebhookHealthCheckClient creates one http client which serves for webhook health check
+func NewWebhookHealthCheckClient() *http.Client {
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+			DisableKeepAlives: true,
+		},
+	}
+
+	return httpClient
+}
+
+// WebhookHealthyCheck servers for spiderpool controller readiness and liveness probe.
+// This is a Layer7 check.
+func WebhookHealthyCheck(httpClient *http.Client, webhookPort string, url *string) error {
+	var webhookMutateURL string
+	if url != nil {
+		webhookMutateURL = fmt.Sprintf("https://%s:%s%s", *url, webhookPort, constant.WebhookMutateRoute)
+	} else {
+		webhookMutateURL = fmt.Sprintf("https://localhost:%s%s", webhookPort, constant.WebhookMutateRoute)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, webhookMutateURL, nil)
+	if nil != err {
+		return fmt.Errorf("failed to new webhook https request, error: %v", err)
+	}
+
+	resp, err := httpClient.Do(req)
+	if nil != err {
+		return fmt.Errorf("webhook server is not reachable: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("webhook health check status code: %d", resp.StatusCode)
+	}
+
+	return nil
+}


### PR DESCRIPTION
There's a e2e case that we will restart kubelet, we need to keep the whole cluster back to ready after restart.
So, in this case we use the ginkgo `Defercleanup` to make sure the node ready, and the node's spiderpool-controller webhook server ready.

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)