### PR TITLE
fix e2e cilium installation failure with IPv6

### DIFF
--- a/test/scripts/install-default-cni.sh
+++ b/test/scripts/install-default-cni.sh
@@ -133,7 +133,8 @@ function install_cilium() {
                                    --set tunnel=disabled \
                                    --set ipv6NativeRoutingCIDR=${CILIUM_CLUSTER_POD_SUBNET_V6} \
                                    --set autoDirectNodeRoutes=true \
-                                   --set enableIPv6Masquerade=true "
+                                   --set enableIPv6Masquerade=true \
+                                   --set routingMode=native "
           ;;
         dual)
             CILIUM_HELM_OPTIONS+=" --set ipam.operator.clusterPoolIPv4PodCIDRList=${CILIUM_CLUSTER_POD_SUBNET_V4} \


### PR DESCRIPTION
Failed to install cilium in the kind.
Reference: https://github.com/spidernet-io/spiderpool/pull/3168#issuecomment-1925300944