### PR TITLE
feature: support wildcard match for IPPool

### DIFF
--- a/cmd/spiderpool-agent/cmd/crd_manager.go
+++ b/cmd/spiderpool-agent/cmd/crd_manager.go
@@ -16,6 +16,7 @@ import (
 	controllerruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	"github.com/spidernet-io/spiderpool/pkg/constant"
 	spiderpoolv2beta1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1"
 )
 
@@ -46,14 +47,21 @@ func newCRDManager() (ctrl.Manager, error) {
 		return nil, err
 	}
 
-	if err := mgr.GetFieldIndexer().IndexField(agentContext.InnerCtx, &spiderpoolv2beta1.SpiderIPPool{}, "spec.default", func(raw client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(agentContext.InnerCtx, &spiderpoolv2beta1.SpiderIPPool{}, constant.SpecDefaultField, func(raw client.Object) []string {
 		ipPool := raw.(*spiderpoolv2beta1.SpiderIPPool)
 		return []string{strconv.FormatBool(*ipPool.Spec.Default)}
 	}); err != nil {
 		return nil, err
 	}
 
-	if err := mgr.GetFieldIndexer().IndexField(agentContext.InnerCtx, &spiderpoolv2beta1.SpiderReservedIP{}, "spec.ipVersion", func(raw client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(agentContext.InnerCtx, &spiderpoolv2beta1.SpiderIPPool{}, constant.SpecIPVersionField, func(raw client.Object) []string {
+		ipPool := raw.(*spiderpoolv2beta1.SpiderIPPool)
+		return []string{strconv.FormatInt(*ipPool.Spec.IPVersion, 10)}
+	}); err != nil {
+		return nil, err
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(agentContext.InnerCtx, &spiderpoolv2beta1.SpiderReservedIP{}, constant.SpecIPVersionField, func(raw client.Object) []string {
 		reservedIP := raw.(*spiderpoolv2beta1.SpiderReservedIP)
 		return []string{strconv.FormatInt(*reservedIP.Spec.IPVersion, 10)}
 	}); err != nil {

--- a/cmd/spiderpool-controller/cmd/crd_manager.go
+++ b/cmd/spiderpool-controller/cmd/crd_manager.go
@@ -65,14 +65,14 @@ func newCRDManager() (ctrl.Manager, error) {
 		return nil, err
 	}
 
-	if err := mgr.GetFieldIndexer().IndexField(controllerContext.InnerCtx, &spiderpoolv2beta1.SpiderIPPool{}, "spec.default", func(raw client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(controllerContext.InnerCtx, &spiderpoolv2beta1.SpiderIPPool{}, constant.SpecDefaultField, func(raw client.Object) []string {
 		ipPool := raw.(*spiderpoolv2beta1.SpiderIPPool)
 		return []string{strconv.FormatBool(*ipPool.Spec.Default)}
 	}); err != nil {
 		return nil, err
 	}
 
-	if err := mgr.GetFieldIndexer().IndexField(controllerContext.InnerCtx, &spiderpoolv2beta1.SpiderReservedIP{}, "spec.ipVersion", func(raw client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(controllerContext.InnerCtx, &spiderpoolv2beta1.SpiderReservedIP{}, constant.SpecIPVersionField, func(raw client.Object) []string {
 		reservedIP := raw.(*spiderpoolv2beta1.SpiderReservedIP)
 		return []string{strconv.FormatInt(*reservedIP.Spec.IPVersion, 10)}
 	}); err != nil {

--- a/docs/concepts/coordinator.md
+++ b/docs/concepts/coordinator.md
@@ -155,7 +155,7 @@ spec:
 
 ## Automatically get the CIDR of a clustered Service
 
-Kubernetes 1.29 starts to support configuring the CIDR of a clustered Service as a ServiceCIDR resource, for more information refer to [KEP 1880](https://github.com/kubernetes/enhancements/blob/master/keps/ sig-network/1880-multiple-service-cidrs/README.md). If your cluster supports ServiceCIDR, the Spiderpool-controller component automatically listens for changes to the ServiceCIDR resource and automatically updates the Service subnet information it reads into the Status of the Spidercoordinator.
+Kubernetes 1.29 starts to support configuring the CIDR of a clustered Service as a ServiceCIDR resource, for more information refer to [KEP 1880](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/1880-multiple-service-cidrs/README.md). If your cluster supports ServiceCIDR, the Spiderpool-controller component automatically listens for changes to the ServiceCIDR resource and automatically updates the Service subnet information it reads into the Status of the Spidercoordinator.
 
 ```shell
 ~# kubectl get servicecidr kubernetes -o yaml

--- a/docs/usage/spider-ippool.md
+++ b/docs/usage/spider-ippool.md
@@ -55,7 +55,14 @@ spec:
 
 ### Specify IPPool to Allocate IP Addresses to Applications
 
-> For the priority rules when specifying the SpiderIPPool, refer to the [Candidate Pool Acquisition](../concepts/ipam-des.md#candidate-pool-acquisition).
+This feature owns 4 usage options including: `Use Pod Annotation to Specify IP Pool`, `Use Namespace Annotation to Specify IP Pool`, `Use CNI Configuration File to Specify IP Pool` and `Set Cluster Default Level for SpiderIPPool`.
+
+> For the priority rules when specifying the SpiderIPPool, refer to the [Candidate Pool Acquisition](../concepts/ipam-des.md#candidate-pool-acquisition).  
+> Additionally, with the following ways of specifying IPPools(Pod Annotation, Namespace Annotation, CNI configuration file) you can also use wildcards '*', '?' and '[]' to match the desired IPPools. For example: ipam.spidernet.io/ippool: '{"ipv4": ["demo-v4-ippool1", "backup-ipv4*"]}'
+>
+>   1. '*': Matches zero or more characters. For example, "ab" can match "ab", "abc", "abcd", and so on.
+>   2. '?': Matches a single character. For example, "a?c" can match "abc", "adc", "axc", and so on.
+>   3. '[]': Matches a specified range of characters. You can specify the choices of characters inside the brackets, or use a hyphen to specify a character range. For example, "[abc]" can match any one of the characters "a", "b", or "c".
 
 #### Use Pod Annotation to Specify IP Pool
 
@@ -64,8 +71,8 @@ You can use annotations like `ipam.spidernet.io/ippool` or `ipam.spidernet.io/ip
 ```yaml
 ipam.spidernet.io/ippool: |-
   {
-    "ipv4": ["demo-v4-ippool1", "backup-ipv4-ippool"],
-    "ipv6": ["demo-v6-ippool1", "backup-ipv6-ippool"]
+    "ipv4": ["demo-v4-ippool1", "backup-ipv4-ippool", "wildcard-v4?"],
+    "ipv6": ["demo-v6-ippool1", "backup-ipv6-ippool", "wildcard-v6*"]
   }
 ```
 
@@ -76,11 +83,11 @@ When using the annotation `ipam.spidernet.io/ippools` for specifying multiple ne
 ```yaml
 ipam.spidernet.io/ippools: |-
   [{
-      "ipv4": ["demo-v4-ippool1"],
-      "ipv6": ["demo-v6-ippool1"],
+      "ipv4": ["demo-v4-ippool1", "wildcard-v4-ippool[123]"],
+      "ipv6": ["demo-v6-ippool1", "wildcard-v6-ippool[123]"]
    },{
-      "ipv4": ["demo-v4-ippool2"],
-      "ipv6": ["demo-v6-ippool2"],
+      "ipv4": ["demo-v4-ippool2", "wildcard-v4-ippool[456]"],
+      "ipv6": ["demo-v6-ippool2", "wildcard-v6-ippool[456]"],
       "cleangateway": true
   }]
 ```
@@ -89,13 +96,13 @@ ipam.spidernet.io/ippools: |-
 ipam.spidernet.io/ippools: |-
   [{
       "interface": "eth0",
-      "ipv4": ["demo-v4-ippool1"],
-      "ipv6": ["demo-v6-ippool1"],
+      "ipv4": ["demo-v4-ippool1", "wildcard-v4-ippool[123]"],
+      "ipv6": ["demo-v6-ippool1", "wildcard-v6-ippool[123]"],
       "cleangateway": true
    },{
       "interface": "net1",
-      "ipv4": ["demo-v4-ippool2"],
-      "ipv6": ["demo-v6-ippool2"],
+      "ipv4": ["demo-v4-ippool2", "wildcard-v4-ippool[456]"],
+      "ipv6": ["demo-v6-ippool2", "wildcard-v6-ippool[456]"],
       "cleangateway": false
   }]
 ```
@@ -112,8 +119,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
-    ipam.spidernet.io/default-ipv4-ippool: '["ns-v4-ippool1","ns-v4-ippool2"]'
-    ipam.spidernet.io/default-ipv6-ippool: '["ns-v6-ippool1","ns-v6-ippool2"]'
+    ipam.spidernet.io/default-ipv4-ippool: '["ns-v4-ippool1", "ns-v4-ippool2", "wildcard-v4*"]'
+    ipam.spidernet.io/default-ipv6-ippool: '["ns-v6-ippool1", "ns-v6-ippool2", "wildcard-v6?"]'
   name: kube-system
 ...
 ```
@@ -131,8 +138,8 @@ You can specify the default IPv4 and IPv6 pools for an application in the CNI co
   "master": "eth0",
   "ipam": {
     "type": "spiderpool",
-    "default_ipv4_ippool":["default-v4-ippool","backup-ipv4-ippool"],
-    "default_ipv6_ippool":["default-v6-ippool","backup-ipv6-ippool"]
+    "default_ipv4_ippool":["default-v4-ippool", "backup-ipv4-ippool", "wildcard-v4-ippool[123]"],
+    "default_ipv6_ippool":["default-v6-ippool", "backup-ipv6-ippool", "wildcard-v6-ippool[456]"]
     }
 }
 ```

--- a/docs/usage/spider-subnet-zh_CN.md
+++ b/docs/usage/spider-subnet-zh_CN.md
@@ -166,7 +166,7 @@ subnet-7   4         10.7.0.0/16   0                    10
 
 以下的示例 Yaml 中， 会创建 2 个副本的 Deployment 应用 ，其中：
 
-- `ipam.spidernet.io/subnet`：用于指定 Spiderpool 的子网，Spiderpool 会自动在该子网中随机选择一些 IP 来创建固定 IP 池，与本应用绑定，实现 IP 固定的效果。在本示例中该注解会为 Pod 创建 1 个对应子网的固定 IP 池。
+- `ipam.spidernet.io/subnet`：用于指定 Spiderpool 的子网，Spiderpool 会自动在该子网中随机选择一些 IP 来创建固定 IP 池，与本应用绑定，实现 IP 固定的效果。在本示例中该注解会为 Pod 创建 1 个对应子网的固定 IP 池。(注意：不支持通配符的形式。)
 
 - `ipam.spidernet.io/ippool-ip-number`：用于指定创建 IP 池 中 的 IP 数量。该 annotation 的写法支持两种方式：一种是数字的方式指定 IP 池的固定数量，例如 `ipam.spidernet.io/ippool-ip-number：1`；另一种方式是使用加号和数字指定 IP 池的相对数量，例如`ipam.spidernet.io/ippool-ip-number：+1`，即表示 IP 池中的数量会自动实时保持在应用的副本数的基础上多 1 个 IP，以解决应用在弹性扩缩容的时有临时的 IP 可用。
 

--- a/docs/usage/spider-subnet.md
+++ b/docs/usage/spider-subnet.md
@@ -167,7 +167,7 @@ subnet-7   4         10.7.0.0/16   0                    10
 
 The following YAML example creates two replicas of a Deployment application:
 
-- `ipam.spidernet.io/subnet`: specifies the Spiderpool subnet. Spiderpool automatically selects IP addresses from this subnet to create a fixed IP pool associated with the application, ensuring fixed IP assignment.
+- `ipam.spidernet.io/subnet`: specifies the Spiderpool subnet. Spiderpool automatically selects IP addresses from this subnet to create a fixed IP pool associated with the application, ensuring fixed IP assignment. (Notice: this feature don't support wildcard.)
 
 - `ipam.spidernet.io/ippool-ip-number`: specifies the number of IP addresses in the IP pool. This annotation can be written in two ways: specifying a fixed quantity using a numeric value, such as `ipam.spidernet.io/ippool-ip-number：1`, or specifying a relative quantity using a plus and a number, such as `ipam.spidernet.io/ippool-ip-number：+1`. The latter means that the IP pool will dynamically maintain an additional IP address based on the number of replicas, ensuring temporary IPs are available during elastic scaling.
 

--- a/pkg/constant/k8s.go
+++ b/pkg/constant/k8s.go
@@ -160,3 +160,14 @@ const (
 )
 
 const WebhookMutateRoute = "/webhook-health-check"
+
+// CRD field
+const (
+	SpecIPVersionField = "spec.ipVersion"
+	SpecDefaultField   = "spec.default"
+)
+
+const (
+	Str4 = "4"
+	Str6 = "6"
+)

--- a/pkg/ipam/pool_selections.go
+++ b/pkg/ipam/pool_selections.go
@@ -41,12 +41,12 @@ func (i *ipam) getPoolCandidates(ctx context.Context, addArgs *models.IpamAddArg
 
 	// Select IPPool candidates through the Pod annotation "ipam.spidernet.io/ippools".
 	if anno, ok := pod.Annotations[constant.AnnoPodIPPools]; ok {
-		return getPoolFromPodAnnoPools(ctx, anno, *addArgs.IfName)
+		return i.getPoolFromPodAnnoPools(ctx, anno, *addArgs.IfName)
 	}
 
 	// Select IPPool candidates through the Pod annotation "ipam.spidernet.io/ippool".
 	if anno, ok := pod.Annotations[constant.AnnoPodIPPool]; ok {
-		t, err := getPoolFromPodAnnoPool(ctx, anno, *addArgs.IfName, addArgs.CleanGateway)
+		t, err := i.getPoolFromPodAnnoPool(ctx, anno, *addArgs.IfName, addArgs.CleanGateway)
 		if err != nil {
 			return nil, err
 		}
@@ -64,7 +64,11 @@ func (i *ipam) getPoolCandidates(ctx context.Context, addArgs *models.IpamAddArg
 	}
 
 	// Select IPPool candidates through CNI network configuration.
-	if t := getPoolFromNetConf(ctx, *addArgs.IfName, addArgs.DefaultIPV4IPPool, addArgs.DefaultIPV6IPPool, addArgs.CleanGateway); t != nil {
+	t, err = i.getPoolFromNetConf(ctx, *addArgs.IfName, addArgs.DefaultIPV4IPPool, addArgs.DefaultIPV6IPPool, addArgs.CleanGateway)
+	if nil != err {
+		return nil, err
+	}
+	if t != nil {
 		return ToBeAllocateds{t}, nil
 	}
 
@@ -73,7 +77,6 @@ func (i *ipam) getPoolCandidates(ctx context.Context, addArgs *models.IpamAddArg
 	if err != nil {
 		return nil, err
 	}
-
 	return ToBeAllocateds{t}, nil
 }
 
@@ -301,7 +304,7 @@ func (i *ipam) applyThirdControllerAutoPool(ctx context.Context, subnetName stri
 	return pool, nil
 }
 
-func getPoolFromPodAnnoPools(ctx context.Context, anno, currentNIC string) (ToBeAllocateds, error) {
+func (i *ipam) getPoolFromPodAnnoPools(ctx context.Context, anno, currentNIC string) (ToBeAllocateds, error) {
 	logger := logutils.FromContext(ctx)
 	logger.Sugar().Infof("Use IPPools from Pod annotation '%s'", constant.AnnoPodIPPools)
 
@@ -310,6 +313,27 @@ func getPoolFromPodAnnoPools(ctx context.Context, anno, currentNIC string) (ToBe
 	err := json.Unmarshal([]byte(anno), &annoPodIPPools)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", errPrefix, err)
+	}
+
+	for index := range annoPodIPPools {
+		if len(annoPodIPPools[index].IPv4Pools) != 0 {
+			newPoolNames, hasWildcard, err := i.ipPoolManager.ParseWildcardPoolNameList(ctx, annoPodIPPools[index].IPv4Pools, constant.IPv4)
+			if nil != err {
+				return nil, err
+			}
+			if hasWildcard {
+				annoPodIPPools[index].IPv4Pools = newPoolNames
+			}
+		}
+		if len(annoPodIPPools[index].IPv6Pools) != 0 {
+			newPoolNames, hasWildcard, err := i.ipPoolManager.ParseWildcardPoolNameList(ctx, annoPodIPPools[index].IPv6Pools, constant.IPv6)
+			if nil != err {
+				return nil, err
+			}
+			if hasWildcard {
+				annoPodIPPools[index].IPv6Pools = newPoolNames
+			}
+		}
 	}
 
 	// validate and mutate the IPPools annotation value
@@ -342,7 +366,7 @@ func getPoolFromPodAnnoPools(ctx context.Context, anno, currentNIC string) (ToBe
 	return tt, nil
 }
 
-func getPoolFromPodAnnoPool(ctx context.Context, anno, nic string, cleanGateway bool) (*ToBeAllocated, error) {
+func (i *ipam) getPoolFromPodAnnoPool(ctx context.Context, anno, nic string, cleanGateway bool) (*ToBeAllocated, error) {
 	logger := logutils.FromContext(ctx)
 	logger.Sugar().Infof("Use IPPools from Pod annotation '%s'", constant.AnnoPodIPPool)
 
@@ -350,6 +374,29 @@ func getPoolFromPodAnnoPool(ctx context.Context, anno, nic string, cleanGateway 
 	errPrefix := fmt.Errorf("%w, invalid format of Pod annotation '%s'", constant.ErrWrongInput, constant.AnnoPodIPPool)
 	if err := json.Unmarshal([]byte(anno), &annoPodIPPool); err != nil {
 		return nil, fmt.Errorf("%w: %v", errPrefix, err)
+	}
+
+	// check IPv4 PoolName wildcard
+	if len(annoPodIPPool.IPv4Pools) != 0 {
+		newPoolNames, hasWildcard, err := i.ipPoolManager.ParseWildcardPoolNameList(ctx, annoPodIPPool.IPv4Pools, constant.IPv4)
+		if nil != err {
+			return nil, err
+		}
+		// overwrite the annoPodIPPool
+		if hasWildcard {
+			annoPodIPPool.IPv4Pools = newPoolNames
+		}
+	}
+	// check IPv6 PoolName wildcard
+	if len(annoPodIPPool.IPv6Pools) != 0 {
+		newPoolNames, hasWildcard, err := i.ipPoolManager.ParseWildcardPoolNameList(ctx, annoPodIPPool.IPv6Pools, constant.IPv6)
+		if nil != err {
+			return nil, err
+		}
+		// overwrite the annoPodIPPool
+		if hasWildcard {
+			annoPodIPPool.IPv6Pools = newPoolNames
+		}
 	}
 
 	t := &ToBeAllocated{
@@ -386,6 +433,25 @@ func (i *ipam) getPoolFromNS(ctx context.Context, namespace, nic string, cleanGa
 		return nil, nil
 	}
 
+	if len(nsDefaultV4Pools) != 0 {
+		newPoolNames, hasWildcard, err := i.ipPoolManager.ParseWildcardPoolNameList(ctx, nsDefaultV4Pools, constant.IPv4)
+		if nil != err {
+			return nil, err
+		}
+		if hasWildcard {
+			nsDefaultV4Pools = newPoolNames
+		}
+	}
+	if len(nsDefaultV6Pools) != 0 {
+		newPoolNames, hasWildcard, err := i.ipPoolManager.ParseWildcardPoolNameList(ctx, nsDefaultV6Pools, constant.IPv6)
+		if nil != err {
+			return nil, err
+		}
+		if hasWildcard {
+			nsDefaultV6Pools = newPoolNames
+		}
+	}
+
 	logger := logutils.FromContext(ctx)
 	logger.Sugar().Infof("Use IPPools from Namespace annotation '%s'", constant.AnnotationPre+"/default-ipv(4/6)-ippool")
 
@@ -409,9 +475,27 @@ func (i *ipam) getPoolFromNS(ctx context.Context, namespace, nic string, cleanGa
 	return t, nil
 }
 
-func getPoolFromNetConf(ctx context.Context, nic string, netConfV4Pool, netConfV6Pool []string, cleanGateway bool) *ToBeAllocated {
+func (i *ipam) getPoolFromNetConf(ctx context.Context, nic string, netConfV4Pool, netConfV6Pool []string, cleanGateway bool) (*ToBeAllocated, error) {
 	if len(netConfV4Pool) == 0 && len(netConfV6Pool) == 0 {
-		return nil
+		return nil, nil
+	}
+	if len(netConfV4Pool) != 0 {
+		newPoolNames, hasWildcard, err := i.ipPoolManager.ParseWildcardPoolNameList(ctx, netConfV4Pool, constant.IPv4)
+		if nil != err {
+			return nil, err
+		}
+		if hasWildcard {
+			netConfV4Pool = newPoolNames
+		}
+	}
+	if len(netConfV6Pool) != 0 {
+		newPoolNames, hasWildcard, err := i.ipPoolManager.ParseWildcardPoolNameList(ctx, netConfV6Pool, constant.IPv6)
+		if nil != err {
+			return nil, err
+		}
+		if hasWildcard {
+			netConfV6Pool = newPoolNames
+		}
 	}
 
 	logger := logutils.FromContext(ctx)
@@ -434,14 +518,14 @@ func getPoolFromNetConf(ctx context.Context, nic string, netConfV4Pool, netConfV
 		})
 	}
 
-	return t
+	return t, nil
 }
 
 func (i *ipam) getClusterDefaultPools(ctx context.Context, nic string, cleanGateway bool) (*ToBeAllocated, error) {
 	ipPoolList, err := i.ipPoolManager.ListIPPools(
 		ctx,
 		constant.UseCache,
-		client.MatchingFields{"spec.default": strconv.FormatBool(true)},
+		client.MatchingFields{constant.SpecDefaultField: strconv.FormatBool(true)},
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/ipam/utils.go
+++ b/pkg/ipam/utils.go
@@ -7,13 +7,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net"
-	"strconv"
-
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/strings/slices"
+	"net"
+	"strconv"
 
 	"github.com/spidernet-io/spiderpool/api/v1/agent/models"
 	subnetmanagercontrollers "github.com/spidernet-io/spiderpool/pkg/applicationcontroller/applicationinformers"

--- a/pkg/ippoolmanager/ippool_manager_suite_test.go
+++ b/pkg/ippoolmanager/ippool_manager_suite_test.go
@@ -61,9 +61,16 @@ var _ = BeforeSuite(func() {
 			ipPool := raw.(*spiderpoolv2beta1.SpiderIPPool)
 			return []string{ipPool.GetObjectMeta().GetName()}
 		}).
-		WithIndex(&spiderpoolv2beta1.SpiderIPPool{}, "spec.default", func(raw client.Object) []string {
+		WithIndex(&spiderpoolv2beta1.SpiderIPPool{}, constant.SpecDefaultField, func(raw client.Object) []string {
 			ipPool := raw.(*spiderpoolv2beta1.SpiderIPPool)
 			return []string{strconv.FormatBool(*ipPool.Spec.Default)}
+		}).
+		WithIndex(&spiderpoolv2beta1.SpiderIPPool{}, constant.SpecIPVersionField, func(raw client.Object) []string {
+			ipPool := raw.(*spiderpoolv2beta1.SpiderIPPool)
+			if ipPool.Spec.IPVersion != nil {
+				return []string{strconv.FormatInt(*ipPool.Spec.IPVersion, 10)}
+			}
+			return []string{}
 		}).
 		WithStatusSubresource(&spiderpoolv2beta1.SpiderIPPool{}).
 		Build()
@@ -76,7 +83,7 @@ var _ = BeforeSuite(func() {
 			ipPool := raw.(*spiderpoolv2beta1.SpiderIPPool)
 			return []string{ipPool.GetObjectMeta().GetName()}
 		}).
-		WithIndex(&spiderpoolv2beta1.SpiderIPPool{}, "spec.default", func(raw client.Object) []string {
+		WithIndex(&spiderpoolv2beta1.SpiderIPPool{}, constant.SpecDefaultField, func(raw client.Object) []string {
 			ipPool := raw.(*spiderpoolv2beta1.SpiderIPPool)
 			return []string{strconv.FormatBool(*ipPool.Spec.Default)}
 		}).

--- a/pkg/ippoolmanager/utils.go
+++ b/pkg/ippoolmanager/utils.go
@@ -136,3 +136,26 @@ func findAllocatedIPFromRecords(allocatedRecords spiderpoolv2beta1.PoolIPAllocat
 
 	return "", false
 }
+
+// HasWildcardInStr checks whether the wildcard '*', '?', '[]' exists in the given string variable
+func HasWildcardInStr(str string) bool {
+	switch {
+	case strings.Contains(str, "?"):
+		return true
+	case strings.Contains(str, "*"):
+		return true
+	case strings.Contains(str, "[") && strings.Contains(str, "]"):
+		return true
+	}
+
+	return false
+}
+
+func HasWildcardInSlice(arr []string) bool {
+	for _, str := range arr {
+		if HasWildcardInStr(str) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/ippoolmanager/utils_test.go
+++ b/pkg/ippoolmanager/utils_test.go
@@ -328,4 +328,28 @@ var _ = Describe("IPPoolManager-utils", Label("ippool_manager_utils"), func() {
 			Expect(hasFound).To(BeFalse())
 		})
 	})
+
+	Context("Test Wildcard", func() {
+		It("For single string variable", func() {
+			hasWildcardInStr := HasWildcardInStr("pool")
+			Expect(hasWildcardInStr).To(BeFalse())
+
+			hasWildcardInStr = HasWildcardInStr("pool?")
+			Expect(hasWildcardInStr).To(BeTrue())
+
+			hasWildcardInStr = HasWildcardInStr("pool*")
+			Expect(hasWildcardInStr).To(BeTrue())
+
+			hasWildcardInStr = HasWildcardInStr("pool[abc]")
+			Expect(hasWildcardInStr).To(BeTrue())
+		})
+
+		It("For string slice", func() {
+			hasWildcardInSlice := HasWildcardInSlice([]string{"pool1", "pool2", "pool3"})
+			Expect(hasWildcardInSlice).To(BeFalse())
+
+			hasWildcardInSlice = HasWildcardInSlice([]string{"pool1", "v4pool*", "pool2"})
+			Expect(hasWildcardInSlice).To(BeTrue())
+		})
+	})
 })

--- a/pkg/reservedipmanager/reservedip_manager.go
+++ b/pkg/reservedipmanager/reservedip_manager.go
@@ -76,7 +76,7 @@ func (rm *reservedIPManager) AssembleReservedIPs(ctx context.Context, version ty
 		return nil, err
 	}
 
-	rIPList, err := rm.ListReservedIPs(ctx, constant.UseCache, client.MatchingFields{"spec.ipVersion": strconv.FormatInt(version, 10)})
+	rIPList, err := rm.ListReservedIPs(ctx, constant.UseCache, client.MatchingFields{constant.SpecIPVersionField: strconv.FormatInt(version, 10)})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/reservedipmanager/reservedip_manager_suite_test.go
+++ b/pkg/reservedipmanager/reservedip_manager_suite_test.go
@@ -11,12 +11,12 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 	k8stesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/spidernet-io/spiderpool/pkg/constant"
 	spiderpoolv2beta1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1"
 	"github.com/spidernet-io/spiderpool/pkg/reservedipmanager"
 )
@@ -44,7 +44,7 @@ var _ = BeforeSuite(func() {
 			rIP := raw.(*spiderpoolv2beta1.SpiderReservedIP)
 			return []string{rIP.GetObjectMeta().GetName()}
 		}).
-		WithIndex(&spiderpoolv2beta1.SpiderReservedIP{}, "spec.ipVersion", func(raw client.Object) []string {
+		WithIndex(&spiderpoolv2beta1.SpiderReservedIP{}, constant.SpecIPVersionField, func(raw client.Object) []string {
 			rIP := raw.(*spiderpoolv2beta1.SpiderReservedIP)
 			return []string{strconv.FormatInt(*rIP.Spec.IPVersion, 10)}
 		}).
@@ -58,7 +58,7 @@ var _ = BeforeSuite(func() {
 			rIP := raw.(*spiderpoolv2beta1.SpiderReservedIP)
 			return []string{rIP.GetObjectMeta().GetName()}
 		}).
-		WithIndex(&spiderpoolv2beta1.SpiderReservedIP{}, "spec.ipVersion", func(raw client.Object) []string {
+		WithIndex(&spiderpoolv2beta1.SpiderReservedIP{}, constant.SpecIPVersionField, func(raw client.Object) []string {
 			rIP := raw.(*spiderpoolv2beta1.SpiderReservedIP)
 			return []string{strconv.FormatInt(*rIP.Spec.IPVersion, 10)}
 		}).

--- a/test/doc/annotation.md
+++ b/test/doc/annotation.md
@@ -8,6 +8,7 @@
 | A00004  | Take a test with the Priority: pod annotation > namespace annotation > specified in a CNI profile                           | p1       |       | done   |       |
 | A00005  | The "IPPools" annotation has the higher Priority over the "IPPool" annotation                                               | p1       |       | done   |       |
 | A00006  | The namespace annotation has precedence over global default IPPool                                                          | p1       | true  | done   |       |
+| A00007  | Use wildcard for namespace annotation to specify IPPools                                                                    | p1       | true  | done   |       |
 | A00008  | Successfully run an annotated multi-container pod                                                                           | p2       |       | done   |       |
 | A00009  | Modify the annotated IPPool for a specified Deployment pod<br />Modify the annotated IPPool for a specified StatefulSet pod | p2       |       | done   |       |
 | A00010  | Modify the annotated IPPool for a pod running on multiple NICs                                                              | p3       |       | done   |       |
@@ -15,3 +16,4 @@
 | A00012  | Specify the default route NIC through Pod annotation: `ipam.spidernet.io/default-route-nic`                                 | p2       |       | done   |       |
 | A00013  | It's invalid to specify one NIC corresponding IPPool in IPPools annotation with multiple NICs                               | p2       |       | done   |       |
 | A00014  | It's invalid to specify same NIC name for IPPools annotation with multiple NICs                                             | p2       |       | done   |       |
+| A00015  | Use wildcard for 'ipam.spidernet.io/ippools' annotation to specify IPPools                                                  | p2       |       | done   |       |


### PR DESCRIPTION
With the following ways of specifying IPPools(Pod Annotation, Namespace Annotation, CNI configuration file), you can also use wildcards `*`, `?` and `[]` to match the desired IPPools. 

For example: 
`ipam.spidernet.io/ippool: '{"ipv4": ["demo-v4-ippool1", "backup-ipv4*"]}'`

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)