### PR TITLE
Fix panic in spidercoordinator informer

### DIFF
--- a/pkg/coordinatormanager/coordinator_informer.go
+++ b/pkg/coordinatormanager/coordinator_informer.go
@@ -86,14 +86,18 @@ type CoordinatorController struct {
 	Client    client.Client
 	APIReader client.Reader
 
-	CoordinatorLister  spiderlisters.SpiderCoordinatorLister
-	ConfigmapLister    corelister.ConfigMapLister
-	ServiceCIDRLister  networkingLister.ServiceCIDRLister
+	CoordinatorLister spiderlisters.SpiderCoordinatorLister
+	ConfigmapLister   corelister.ConfigMapLister
+	// only not to nil if the k8s serviceCIDR is enabled
+	ServiceCIDRLister networkingLister.ServiceCIDRLister
+	// only not to nil if the cilium multu-pool is enabled
 	CiliumIPPoolLister ciliumLister.CiliumPodIPPoolLister
 
-	CoordinatorSynced   cache.InformerSynced
-	ConfigmapSynced     cache.InformerSynced
-	ServiceCIDRSynced   cache.InformerSynced
+	CoordinatorSynced cache.InformerSynced
+	ConfigmapSynced   cache.InformerSynced
+	// only not nil if the k8s serviceCIDR is enabled
+	ServiceCIDRSynced cache.InformerSynced
+	// only not to nil if the cilium multu-pool is enabled
 	CiliumIPPoolsSynced cache.InformerSynced
 
 	Workqueue workqueue.RateLimitingInterface
@@ -505,7 +509,7 @@ func (cc *CoordinatorController) updatePodAndServerCIDR(ctx context.Context, log
 	}
 
 	if err = cc.updateServiceCIDR(logger, coordCopy); err != nil {
-		logger.Sugar().Warn("failed to list the serviceCIDR resources: %v, update service cidr from cluster service cidr", err)
+		logger.Sugar().Infof("unable to list the serviceCIDR resources: %v, update service cidr from cluster service cidr", err)
 		coordCopy.Status.ServiceCIDR = k8sServiceCIDR
 	}
 
@@ -706,6 +710,11 @@ func (cc *CoordinatorController) fetchCiliumIPPools(coordinator *spiderpoolv2bet
 
 func (cc *CoordinatorController) updateServiceCIDR(logger *zap.Logger, coordCopy *spiderpoolv2beta1.SpiderCoordinator) error {
 	// fetch kubernetes ServiceCIDR
+	if cc.ServiceCIDRLister == nil {
+		// serviceCIDR feature is disable if ServiceCIDRLister is nil
+		return fmt.Errorf("the kubernetes serviceCIDR is disabled")
+	}
+
 	svcPoolList, err := cc.ServiceCIDRLister.List(labels.NewSelector())
 	if err != nil {
 		return err


### PR DESCRIPTION
## Thanks for contributing!

<!--Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>-->

#### What type of PR is this?

<!--
Add one of the following kinds:

Required labels:

- release/none 
- release/bug 
- release/feature

Optional labels:

- kind/bug
- kind/feature
- kind/ci-bug
- kind/doc
-->

**What this PR does / why we need it**:

Fix panic in spidercoordinator informer: if the serviceCIDR resource can't be list, the serviceCIDRLister should be nil, in the case, we update the service cidr of the spidercoordinator.status from k8s service cidr.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/spidernet-io/spiderpool/issues/3263

**Special notes for your reviewer**:
