### PR TITLE
supplement right AlreadyExist error return for IPPool/Subnet webhook

### DIFF
--- a/pkg/ippoolmanager/ippool_validate.go
+++ b/pkg/ippoolmanager/ippool_validate.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strconv"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/strings/slices"
@@ -199,8 +200,10 @@ func (iw *IPPoolWebhook) validateIPPoolCIDR(ctx context.Context, ipPool *spiderp
 
 	for _, pool := range ipPoolList.Items {
 		if *pool.Spec.IPVersion == *ipPool.Spec.IPVersion {
+			// since we met already exist IPPool resource, we just return the error to avoid the following taxing operations.
+			// the user can also use k8s 'errors.IsAlreadyExists' to get the right error type assertion.
 			if pool.Name == ipPool.Name {
-				return field.InternalError(subnetField, fmt.Errorf("IPPool %s already exists", ipPool.Name))
+				return field.InternalError(subnetField, fmt.Errorf("IPPool %s %s", ipPool.Name, metav1.StatusReasonAlreadyExists))
 			}
 
 			if pool.Spec.Subnet == ipPool.Spec.Subnet {

--- a/pkg/ippoolmanager/ippool_webhook_test.go
+++ b/pkg/ippoolmanager/ippool_webhook_test.go
@@ -680,7 +680,7 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					warns, err := ipPoolWebhook.ValidateCreate(ctx, ipPoolT)
-					Expect(apierrors.IsInvalid(err)).To(BeTrue())
+					Expect(apierrors.IsAlreadyExists(err)).To(BeTrue())
 					Expect(warns).To(BeNil())
 				})
 

--- a/pkg/subnetmanager/subnet_webhook_test.go
+++ b/pkg/subnetmanager/subnet_webhook_test.go
@@ -478,7 +478,7 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					warns, err := subnetWebhook.ValidateCreate(ctx, subnetT)
-					Expect(apierrors.IsInvalid(err)).To(BeTrue())
+					Expect(apierrors.IsAlreadyExists(err)).To(BeTrue())
 					Expect(warns).To(BeNil())
 				})
 


### PR DESCRIPTION
Refer to #3321 , the user get an `InternalError` type error after send a create IPPool/Subnet resource API request, which leads to wrong type assertion.

The reason why we keep returning the `AlreadyExist` by ourself is that considering the lots of taxing operations in the IPPool/Subnet Webhook. So, if we meet resource already first we just return it and ignore the other operations.


Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)

**What this PR does / why we need it**:
fix bug

**Which issue(s) this PR fixes**:
close #3321 
