### PR TITLE
fix: confirm that the SpiderSubnet AutoPool feature is really disabled

### DIFF
--- a/test/scripts/debugEnv.sh
+++ b/test/scripts/debugEnv.sh
@@ -184,6 +184,10 @@ elif [ "$TYPE"x == "detail"x ] ; then
     kubectl get network-attachment-definitions.k8s.cni.cncf.io -o json --kubeconfig ${E2E_KUBECONFIG}
 
     echo ""
+    echo "--------- kubectl get configmaps -n kube-system spiderpool-conf -ojson"
+    kubectl get configmaps -n kube-system spiderpool-conf -ojson --kubeconfig ${E2E_KUBECONFIG}
+
+    echo ""
     echo "=============== IPAM log  ============== "
     KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-"spider"}
     KIND_NODES=$(  kind get  nodes --name ${KIND_CLUSTER_NAME} )


### PR DESCRIPTION
## Thanks for contributing!

<!--Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>-->

#### What type of PR is this?

<!--
Add one of the following kinds:

Required labels:

- release/none 
- release/bug 
- release/feature

Optional labels:

- kind/bug
- kind/feature
- kind/ci-bug
- kind/doc
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3353 

**Special notes for your reviewer**:
With the same code, some jobs can run and others cannot. It is speculated that enableAutoPoolForApplication has been modified, but it has not yet taken effect, so the e2e probability fails, and a new loop check enableAutoPoolForApplication parameter is added.