### PR TITLE
coordinator: ensure hijickRoute's gw is from hostIPRouteForPod

### DIFF
--- a/cmd/coordinator/cmd/command_add.go
+++ b/cmd/coordinator/cmd/command_add.go
@@ -126,6 +126,30 @@ func CmdAdd(args *skel.CmdArgs) (err error) {
 		return err
 	}
 
+	// get all ip of pod
+	var allPodIp []netlink.Addr
+	err = c.netns.Do(func(netNS ns.NetNS) error {
+		allPodIp, err = networking.GetAllIPAddress(ipFamily, []string{`^lo$`})
+		if err != nil {
+			logger.Error("failed to GetAllIPAddress in pod", zap.Error(err))
+			return fmt.Errorf("failed to GetAllIPAddress in pod: %v", err)
+		}
+		return nil
+	})
+	if err != nil {
+		logger.Error("failed to all ip of pod", zap.Error(err))
+		return err
+	}
+	logger.Debug(fmt.Sprintf("all pod ip: %+v", allPodIp))
+
+	// get ip addresses of the node
+	c.hostIPRouteForPod, err = GetAllHostIPRouteForPod(c, ipFamily, allPodIp)
+	if err != nil {
+		logger.Error("failed to get IPAddressOnNode", zap.Error(err))
+		return fmt.Errorf("failed to get IPAddressOnNode: %v", err)
+	}
+	logger.Debug(fmt.Sprintf("host IP for route to Pod: %+v", c.hostIPRouteForPod))
+
 	// get basic info
 	switch c.tuneMode {
 	case ModeUnderlay:
@@ -238,32 +262,6 @@ func CmdAdd(args *skel.CmdArgs) (err error) {
 
 	// =================================
 
-	// get all ip of pod
-	var allPodIp []netlink.Addr
-	err = c.netns.Do(func(netNS ns.NetNS) error {
-		allPodIp, err = networking.GetAllIPAddress(ipFamily, []string{`^lo$`})
-		if err != nil {
-			logger.Error("failed to GetAllIPAddress in pod", zap.Error(err))
-			return fmt.Errorf("failed to GetAllIPAddress in pod: %v", err)
-		}
-		return nil
-	})
-	if err != nil {
-		logger.Error("failed to all ip of pod", zap.Error(err))
-		return err
-	}
-	logger.Debug(fmt.Sprintf("all pod ip: %+v", allPodIp))
-
-	// get ip addresses of the node
-	c.hostIPRouteForPod, err = GetAllHostIPRouteForPod(c, ipFamily, allPodIp)
-	if err != nil {
-		logger.Error("failed to get IPAddressOnNode", zap.Error(err))
-		return fmt.Errorf("failed to get IPAddressOnNode: %v", err)
-	}
-	logger.Debug(fmt.Sprintf("host IP for route to Pod: %+v", c.hostIPRouteForPod))
-
-	// =================================
-
 	// get ips of this interface(preInterfaceName) from, including ipv4 and ipv6
 	c.currentAddress, err = networking.IPAddressByName(c.netns, args.IfName, ipFamily)
 	if err != nil {
@@ -326,6 +324,22 @@ func CmdAdd(args *skel.CmdArgs) (err error) {
 	if err = c.setupHostRoutes(logger); err != nil {
 		logger.Error(err.Error())
 		return err
+	}
+
+	// get v4 and v6 gw for hijick route'gw
+	for _, gw := range c.hostIPRouteForPod {
+		copy := gw
+		if copy.To4() != nil {
+			if c.v4HijackRouteGw == nil && c.ipFamily != netlink.FAMILY_V6 {
+				c.v4HijackRouteGw = copy
+				logger.Debug("Get v4HijackRouteGw", zap.String("v4HijackRouteGw", c.v4HijackRouteGw.String()))
+			}
+		} else {
+			if c.v6HijackRouteGw == nil && c.ipFamily != netlink.FAMILY_V4 {
+				c.v6HijackRouteGw = copy
+				logger.Debug("Get v6HijackRouteGw", zap.String("v6HijackRouteGw", c.v6HijackRouteGw.String()))
+			}
+		}
 	}
 
 	if err = c.setupHijackRoutes(logger, c.currentRuleTable); err != nil {


### PR DESCRIPTION
## Thanks for contributing!

<!--Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>-->

#### What type of PR is this?

<!--
Add one of the following kinds:

Required labels:

- release/none 
- release/bug 
- release/feature

Optional labels:

- kind/bug
- kind/feature
- kind/ci-bug
- kind/doc
-->

- release/bug 

**What this PR does / why we need it**:

Avoiding the GW properly comes from the nodelocaldns's IP when coordinator creates the hijack routes in the pod. 

![企业微信截图_17131629598028](https://github.com/spidernet-io/spiderpool/assets/59680092/aa78a107-ff04-41ba-81c7-21f0b61e9d91)

There are some os where `ip r get` may return src as the address of the node's nodelocaldns, which should be avoided.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/spidernet-io/spiderpool/issues/3359

**Special notes for your reviewer**:
