### PR TITLE
e2e fix: the kube-controller-manager Pod runs successfully when the label is kube-controller-manager1.

### DIFF
--- a/test/e2e/spidercoordinator/spidercoordinator_test.go
+++ b/test/e2e/spidercoordinator/spidercoordinator_test.go
@@ -524,6 +524,15 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 			err = common.ExecCommandOnKindNode(context.TODO(), []string{masterNode}, command)
 			Expect(err).NotTo(HaveOccurred(), "failed to update kcm labels: %v\n", err)
 
+			// Delete it manually to speed up reconstruction.
+			podList, err := frame.GetPodList(client.MatchingLabels{
+				"component": "kube-controller-manager",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			if len(podList.Items) != 0 {
+				Expect(frame.DeletePodList(podList)).NotTo(HaveOccurred())
+			}
+
 			Eventually(func() bool {
 				podList, err := frame.GetPodList(client.MatchingLabels{
 					"component": "kube-controller-manager1",


### PR DESCRIPTION

## Thanks for contributing!

<!--Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>-->

#### What type of PR is this?

<!--
Add one of the following kinds:

Required labels:

- release/none 
- release/bug 
- release/feature

Optional labels:

- kind/bug
- kind/feature
- kind/ci-bug
- kind/doc
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3474
kube-controller-manager after changing tags, but not restarting as expected. So it failed.

**Special notes for your reviewer**:
