### PR TITLE
fix(charts): Remove unnecessary sensitive permissions for DaemonSet agent and Pod init

### DIFF
--- a/charts/spiderpool/templates/role.yaml
+++ b/charts/spiderpool/templates/role.yaml
@@ -2,7 +2,166 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: spiderpool-admin
+  name: {{ .Values.spiderpoolAgent.name | trunc 63 | trimSuffix "-" }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - namespaces
+  - pods/status
+  verbs:
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - k8s.cni.cncf.io
+  resources:
+  - network-attachment-definitions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachineinstances
+  - virtualmachines
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - resource.k8s.io
+  resources:
+  - podschedulingcontexts
+  - podschedulingcontexts/status
+  - resourceclaims
+  - resourceclaims/status
+  - resourceclaimtemplates
+  - resourceclasses
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - spiderpool.spidernet.io
+  resources:
+  - spiderclaimparameters
+  - spidercoordinators
+  - spiderendpoints
+  - spiderippools
+  - spidermultusconfigs
+  - spiderreservedips
+  - spidersubnets
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - spiderpool.spidernet.io
+  resources:
+  - spidercoordinators/status
+  - spiderippools/status
+  - spidersubnets/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.spiderpoolController.name | trunc 63 | trimSuffix "-" }}
 rules:
 - apiGroups:
   - ""
@@ -112,12 +271,6 @@ rules:
   - kubevirt.io
   resources:
   - virtualmachineinstances
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - kubevirt.io
-  resources:
   - virtualmachines
   verbs:
   - get
@@ -141,50 +294,12 @@ rules:
   - spiderpool.spidernet.io
   resources:
   - spiderclaimparameters
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - spiderpool.spidernet.io
-  resources:
   - spidercoordinators
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - spiderpool.spidernet.io
-  resources:
-  - spidercoordinators/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - spiderpool.spidernet.io
-  resources:
   - spiderendpoints
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - spiderpool.spidernet.io
-  resources:
   - spiderippools
+  - spidermultusconfigs
+  - spiderreservedips
+  - spidersubnets
   verbs:
   - create
   - delete
@@ -197,52 +312,181 @@ rules:
 - apiGroups:
   - spiderpool.spidernet.io
   resources:
+  - spidercoordinators/status
   - spiderippools/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - spiderpool.spidernet.io
-  resources:
-  - spidermultusconfigs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - spiderpool.spidernet.io
-  resources:
-  - spiderreservedips
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - spiderpool.spidernet.io
-  resources:
-  - spidersubnets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - spiderpool.spidernet.io
-  resources:
   - spidersubnets/status
   verbs:
   - get
   - patch
   - update
+---
+{{- if or .Values.ipam.enableIPv4 .Values.ipam.enableIPv6 }}
+{{- if or .Values.clusterDefaultPool.installIPv4IPPool .Values.clusterDefaultPool.installIPv6IPPool .Values.coordinator.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.spiderpoolInit.name | trunc 63 | trimSuffix "-" }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - namespaces
+  - pods
+  - pods/status
+  verbs:
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - k8s.cni.cncf.io
+  resources:
+  - network-attachment-definitions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachineinstances
+  - virtualmachines
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - resource.k8s.io
+  resources:
+  - podschedulingcontexts
+  - podschedulingcontexts/status
+  - resourceclaims
+  - resourceclaims/status
+  - resourceclaimtemplates
+  - resourceclasses
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - spiderpool.spidernet.io
+  resources:
+  - spiderclaimparameters
+  - spidercoordinators
+  - spiderendpoints
+  - spiderippools
+  - spidermultusconfigs
+  - spiderreservedips
+  - spidersubnets
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - spiderpool.spidernet.io
+  resources:
+  - spidercoordinators/status
+  - spiderippools/status
+  - spidersubnets/status
+  verbs:
+  - get
+  - patch
+  - update
+{{- end }}
+{{- end }}

--- a/charts/spiderpool/templates/role_binding.yaml
+++ b/charts/spiderpool/templates/role_binding.yaml
@@ -1,20 +1,40 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: spiderpool-admin
+  name: {{ .Values.spiderpoolAgent.name | trunc 63 | trimSuffix "-" }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: spiderpool-admin
+  name: {{ .Values.spiderpoolAgent.name | trunc 63 | trimSuffix "-" }}
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.spiderpoolAgent.name | trunc 63 | trimSuffix "-" }}
   namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.spiderpoolController.name | trunc 63 | trimSuffix "-" }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.spiderpoolController.name | trunc 63 | trimSuffix "-" }}
+subjects:
 - kind: ServiceAccount
   name: {{ .Values.spiderpoolController.name | trunc 63 | trimSuffix "-" }}
   namespace: {{ .Release.Namespace }}
+---
 {{- if or .Values.ipam.enableIPv4 .Values.ipam.enableIPv6 }}
 {{- if or .Values.clusterDefaultPool.installIPv4IPPool .Values.clusterDefaultPool.installIPv6IPPool .Values.coordinator.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.spiderpoolInit.name | trunc 63 | trimSuffix "-" }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.spiderpoolInit.name | trunc 63 | trimSuffix "-" }}
+subjects:
 - kind: ServiceAccount
   name: {{ .Values.spiderpoolInit.name | trunc 63 | trimSuffix "-" }}
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:

Required labels:

- release/none 
- release/bug 
- release/feature

Optional labels:

- kind/bug
- kind/feature
- kind/ci-bug
- kind/doc
-->

- release/bug

**What this PR does / why we need it**:

This PR removes unnecessary RBAC permissions for the DaemonSet agent and Pod init to avoid potential security risks. Technically, this PR does:

1. Create a separate `ClusterRole` for each workload
2. Remove some unnecessary permissions applied by the DaemonSet agent and Pod init

This PR minimizes the deletion of permissions to avoid affecting the normal function of the APP. However, there should still be some unnecessary RBAC permissions (such as for the Deployment controller).

Also, this PR DOES NOT include changing the kubebuilder annotation in: `pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/rbac.go`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3420
Fixes #3361

**Special notes for your reviewer**:

The removed permission from the permission rules are as follows:

- DaemonSet agent
    - `delete/deletecollection/patch/update` verb of `nodes/pods`
        - As suggested in #3420
    - `update` verb of `daemonsets/deployments/replicasets/statefulsets`
        - As suggested in #3420
    - `update` verb of `cronjobs/jobs`
        - As suggested in #3420
    - `get/list/watch` verb of `*`
        - As suggested in #3361, in order to remove `get/list` verb of `secrets`
        - **This change needs to be carefully review since it contains a wildcard.**
        - This change only deletes this rule, the `get/list/watch` permissions applied in other rules will not be affected.

- Pod init
    - `delete/deletecollection/patch/update` verb of `nodes`
    - `update` verb of `daemonsets/deployments/replicasets/statefulsets`
    - `update` verb of `cronjobs/jobs`

I am more aggressive in deleting the permissions of DaemonSet agent, mainly because DaemonSet will be deployed to any worker node in the cluster, so attackers have more opportunities to obtain the ServiceAccount token of DaemonSet agent.