### PR TITLE
add link-local IP to veth0 for istio

### DIFF
--- a/cmd/coordinator/cmd/utils.go
+++ b/cmd/coordinator/cmd/utils.go
@@ -170,6 +170,21 @@ func (c *coordinator) setupVeth(logger *zap.Logger, containerID string) error {
 		if err := netlink.LinkSetUp(link); err != nil {
 			return fmt.Errorf("failed to set %q UP: %v", containerInterface.Name, err)
 		}
+
+		if c.ipFamily == netlink.FAMILY_V6 {
+			// set an address to veth to fix work with istio
+			// set only when not ipv6 only
+			return nil
+		}
+
+		if err = netlink.AddrAdd(link, &netlink.Addr{
+			IPNet: &net.IPNet{
+				IP:   net.ParseIP("169.254.200.1"),
+				Mask: net.CIDRMask(32, 32),
+			},
+		}); err != nil {
+			return fmt.Errorf("failed to add ip address to veth0: %v", err)
+		}
 		return nil
 	})
 


### PR DESCRIPTION
## Thanks for contributing!

<!--Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>-->

#### What type of PR is this?

- release/bug 

<!--
Add one of the following kinds:

Required labels:

- release/none 
- release/bug 
- release/feature

Optional labels:

- kind/bug
- kind/feature
- kind/ci-bug
- kind/doc
-->

**What this PR does / why we need it**:

The iptables redirect module uses the IP address of the incoming interface as the dst to modify the packet, but if the interface is not configured with an IP address, the packet will be dropped. 

NOTE: this is for istio sidecar

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/spidernet-io/spiderpool/issues/3568

**Special notes for your reviewer**:
