### PR TITLE
fix: CI failed to download the file

### DIFF
--- a/.github/workflows/auto-upgrade-ci.yaml
+++ b/.github/workflows/auto-upgrade-ci.yaml
@@ -227,14 +227,14 @@ jobs:
 
       - name: Download old spiderpool-agent image with tag ${{ needs.call_build_old_ci_image.outputs.imageTag }}
         if: ${{ needs.get_ref.outputs.build_old_image_tag == 'true' }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: old-image-tar-spiderpool-agent
           path: test/.download
 
       - name: Download old spiderpool-controller image with tag ${{ needs.call_build_old_ci_image.outputs.imageTag }}
         if: ${{ needs.get_ref.outputs.build_old_image_tag == 'true' }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: old-image-tar-spiderpool-controller
           path: test/.download
@@ -308,13 +308,13 @@ jobs:
           cp -r /tmp/config ${{ env.KUBECONFIG_PATH }}/${{ env.E2E_CLUSTER_NAME }}/.kube/config
 
       - name: Download new spiderpool-agent image with tag ${{ needs.call_build_new_ci_image.outputs.imageTag }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: new-image-tar-spiderpool-agent
           path: test/.download
 
       - name: Download new spiderpool-controller image with tag ${{ needs.call_build_new_ci_image.outputs.imageTag }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: new-image-tar-spiderpool-controller
           path: test/.download

--- a/.github/workflows/auto-version-release.yaml
+++ b/.github/workflows/auto-version-release.yaml
@@ -137,13 +137,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Chart Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ needs.release-chart.outputs.artifact }}
           path: chart-package/
 
       - name: Download Changelog Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ needs.release-changelog.outputs.artifact }}
           path: changelog-result/

--- a/.github/workflows/build-image-base.yaml
+++ b/.github/workflows/build-image-base.yaml
@@ -148,7 +148,7 @@ jobs:
           mkdir -p image-digest/
 
       - name: Download digests of all images built
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: image-digest/
 

--- a/.github/workflows/build-image-ci.yaml
+++ b/.github/workflows/build-image-ci.yaml
@@ -301,13 +301,13 @@ jobs:
           mkdir -p image-digest/
 
       - name: Download digests of all images built
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: image-digest/
           name: image-digest-spiderpool-agent
 
       - name: Download digests of all images built
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: image-digest/
           name: image-digest-spiderpool-controller

--- a/.github/workflows/build-image-plugins.yaml
+++ b/.github/workflows/build-image-plugins.yaml
@@ -237,7 +237,7 @@ jobs:
           mkdir -p image-digest/
 
       - name: Download digests of all images built
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: image-digest/
 

--- a/.github/workflows/call-release-changelog.yaml
+++ b/.github/workflows/call-release-changelog.yaml
@@ -126,7 +126,7 @@ jobs:
           ref: ${{ env.DEST_BRANCH }}
 
       - name: Download Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: changelog_artifact
           path: ${{ env.DEST_DIRECTORY }}

--- a/.github/workflows/call-release-chart.yaml
+++ b/.github/workflows/call-release-chart.yaml
@@ -115,7 +115,7 @@ jobs:
           persist-credentials: "true"
 
       - name: Download Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: chart_package_artifact
           path: charts/

--- a/.github/workflows/call-release-doc.yaml
+++ b/.github/workflows/call-release-doc.yaml
@@ -152,7 +152,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: website_package_artifact
 

--- a/.github/workflows/call-update-githubpages.yaml
+++ b/.github/workflows/call-update-githubpages.yaml
@@ -45,13 +45,13 @@ jobs:
           mkdir ${{ env.DEST_DIRECTORY }}/charts
 
       - name: Download Website Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.site_artifact_name }}
           path: ${{ env.DEST_DIRECTORY }}
 
       - name: Download Chart Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.chart_artifact_name }}
           path: ${{ env.DEST_DIRECTORY }}/charts

--- a/.github/workflows/e2e-init.yaml
+++ b/.github/workflows/e2e-init.yaml
@@ -110,13 +110,13 @@ jobs:
           bash ./test/scripts/install-tools.sh
 
       - name: Download spiderpool-agent image
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: image-tar-spiderpool-agent
           path: test/.download
 
       - name: Download spiderpool-controller image
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: image-tar-spiderpool-controller
           path: test/.download

--- a/.github/workflows/trivy-scan-image.yaml
+++ b/.github/workflows/trivy-scan-image.yaml
@@ -24,13 +24,13 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Download spiderpool-agent image
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: image-tar-spiderpool-agent
           path: test/.download
 
       - name: Download spiderpool-controller image
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: image-tar-spiderpool-controller
           path: test/.download


### PR DESCRIPTION
## Thanks for contributing!

<!--Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>-->

#### What type of PR is this?

<!--
Add one of the following kinds:

Required labels:

- release/none 
- release/bug 
- release/feature

Optional labels:

- kind/bug
- kind/feature
- kind/ci-bug
- kind/doc
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3676

**Special notes for your reviewer**:
Because pr https://github.com/spidernet-io/spiderpool/pull/3426 updated actions/upload-artifact, but actions/download-artifact lagged behind it by a large version, which caused CI to fail