### PR TITLE
Revert build(deps): bump actions/download-artifact and actions/upload-artifact from 3 to 4

### DIFF
--- a/.github/workflows/auto-upgrade-ci.yaml
+++ b/.github/workflows/auto-upgrade-ci.yaml
@@ -227,14 +227,14 @@ jobs:
 
       - name: Download old spiderpool-agent image with tag ${{ needs.call_build_old_ci_image.outputs.imageTag }}
         if: ${{ needs.get_ref.outputs.build_old_image_tag == 'true' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: old-image-tar-spiderpool-agent
           path: test/.download
 
       - name: Download old spiderpool-controller image with tag ${{ needs.call_build_old_ci_image.outputs.imageTag }}
         if: ${{ needs.get_ref.outputs.build_old_image_tag == 'true' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: old-image-tar-spiderpool-controller
           path: test/.download
@@ -308,13 +308,13 @@ jobs:
           cp -r /tmp/config ${{ env.KUBECONFIG_PATH }}/${{ env.E2E_CLUSTER_NAME }}/.kube/config
 
       - name: Download new spiderpool-agent image with tag ${{ needs.call_build_new_ci_image.outputs.imageTag }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: new-image-tar-spiderpool-agent
           path: test/.download
 
       - name: Download new spiderpool-controller image with tag ${{ needs.call_build_new_ci_image.outputs.imageTag }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: new-image-tar-spiderpool-controller
           path: test/.download
@@ -367,7 +367,7 @@ jobs:
 
       - name: Upload e2e log
         if: ${{ needs.get_ref.outputs.e2e_enabled == 'true' }}
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: ${{ needs.get_ref.outputs.old_version }}-to-${{ needs.get_ref.outputs.new_version }}-debuglog.txt
           path: test/e2edebugLog.txt
@@ -375,7 +375,7 @@ jobs:
 
       - name: Upload e2e report
         if: ${{ env.UPLOAD_E2E_REPORT == 'true' }}
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: ${{ needs.get_ref.outputs.old_version }}-to-${{ needs.get_ref.outputs.new_version }}-e2ereport.json
           path: e2ereport.json

--- a/.github/workflows/auto-version-release.yaml
+++ b/.github/workflows/auto-version-release.yaml
@@ -137,13 +137,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Chart Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: ${{ needs.release-chart.outputs.artifact }}
           path: chart-package/
 
       - name: Download Changelog Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: ${{ needs.release-changelog.outputs.artifact }}
           path: changelog-result/

--- a/.github/workflows/build-image-base.yaml
+++ b/.github/workflows/build-image-base.yaml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Upload artifact digests
         if: ${{ env.exists == 'false' }}
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: image-digest ${{ env.IMAGE_NAME }}
           path: image-digest
@@ -148,7 +148,7 @@ jobs:
           mkdir -p image-digest/
 
       - name: Download digests of all images built
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           path: image-digest/
 

--- a/.github/workflows/build-image-ci.yaml
+++ b/.github/workflows/build-image-ci.yaml
@@ -250,7 +250,7 @@ jobs:
 
       # Upload artifact digests
       - name: Upload artifact digests
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: image-digest-${{ matrix.name }}
           path: image-digest
@@ -258,7 +258,7 @@ jobs:
 
       # Upload artifact race images tar
       - name: Upload artifact race image tar
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: ${{ inputs.imageTarName }}-${{ matrix.name }}
           path: /tmp/${{ matrix.name }}-race.tar
@@ -301,13 +301,13 @@ jobs:
           mkdir -p image-digest/
 
       - name: Download digests of all images built
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           path: image-digest/
           name: image-digest-spiderpool-agent
 
       - name: Download digests of all images built
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           path: image-digest/
           name: image-digest-spiderpool-controller

--- a/.github/workflows/build-image-plugins.yaml
+++ b/.github/workflows/build-image-plugins.yaml
@@ -220,7 +220,7 @@ jobs:
 
       - name: Upload artifact digests
         if: ${{ env == 'false' }}
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: image-digest ${{ env.IMAGE_NAME }}
           path: image-digest
@@ -237,7 +237,7 @@ jobs:
           mkdir -p image-digest/
 
       - name: Download digests of all images built
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           path: image-digest/
 

--- a/.github/workflows/call-release-changelog.yaml
+++ b/.github/workflows/call-release-changelog.yaml
@@ -109,7 +109,7 @@ jobs:
           cat ${FILE_PATH}
 
       - name: Upload Changelog
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: changelog_artifact
           path: ${{ env.FILE_PATH }}
@@ -126,7 +126,7 @@ jobs:
           ref: ${{ env.DEST_BRANCH }}
 
       - name: Download Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: changelog_artifact
           path: ${{ env.DEST_DIRECTORY }}

--- a/.github/workflows/call-release-chart.yaml
+++ b/.github/workflows/call-release-chart.yaml
@@ -87,7 +87,7 @@ jobs:
           mv charts/*.tgz tmp
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: chart_package_artifact
           path: tmp/*
@@ -115,7 +115,7 @@ jobs:
           persist-credentials: "true"
 
       - name: Download Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: chart_package_artifact
           path: charts/

--- a/.github/workflows/call-release-doc.yaml
+++ b/.github/workflows/call-release-doc.yaml
@@ -133,7 +133,7 @@ jobs:
           echo "Push a doc version: ${{ env.DOCS_TAG }} from branch: ${{ env.REF }}, update it to latest: ${{ env.SET_LATEST }} "
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: website_package_artifact
           path: site.tar.gz
@@ -152,7 +152,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: website_package_artifact
 

--- a/.github/workflows/call-release-image.yaml
+++ b/.github/workflows/call-release-image.yaml
@@ -177,14 +177,14 @@ jobs:
           cd ..
 
       - name: Upload artifact digests
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: image-digest-artifact-${{ env.imagetag }}
           path: image-digest-output.txt
           retention-days: 1
 
       - name: Upload artifact digests
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: makefile-digest-artifact-${{ env.imagetag }}
           path: Makefile.digests

--- a/.github/workflows/call-update-githubpages.yaml
+++ b/.github/workflows/call-update-githubpages.yaml
@@ -45,13 +45,13 @@ jobs:
           mkdir ${{ env.DEST_DIRECTORY }}/charts
 
       - name: Download Website Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.site_artifact_name }}
           path: ${{ env.DEST_DIRECTORY }}
 
       - name: Download Chart Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.chart_artifact_name }}
           path: ${{ env.DEST_DIRECTORY }}/charts

--- a/.github/workflows/e2e-init.yaml
+++ b/.github/workflows/e2e-init.yaml
@@ -110,13 +110,13 @@ jobs:
           bash ./test/scripts/install-tools.sh
 
       - name: Download spiderpool-agent image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: image-tar-spiderpool-agent
           path: test/.download
 
       - name: Download spiderpool-controller image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: image-tar-spiderpool-controller
           path: test/.download
@@ -197,7 +197,7 @@ jobs:
 
       - name: Upload e2e log
         if: ${{ inputs.run_e2e == 'true' }}
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: ${{ inputs.os }}-${{ inputs.ip_family }}-${{ matrix.e2e_test_mode }}-${{ inputs.k8s_version }}-debuglog.txt
           path: test/e2edebugLog.txt
@@ -205,7 +205,7 @@ jobs:
 
       - name: Upload e2e report
         if: ${{ env.UPLOAD_E2E_REPORT == 'true' }}
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: ${{ inputs.os }}-${{ inputs.ip_family }}-${{ matrix.e2e_test_mode }}-${{ inputs.k8s_version }}-e2ereport.json
           path: e2ereport.json

--- a/.github/workflows/lint-golang.yaml
+++ b/.github/workflows/lint-golang.yaml
@@ -214,7 +214,7 @@ jobs:
 
       - name: Upload Coverage Artifact
         if: ${{ steps.unittest.outcome == 'failure' }}
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: coverage.out
           path: coverage.out
@@ -222,7 +222,7 @@ jobs:
 
       - name: Upload Report Artifact
         if: ${{ steps.unittest.outcome == 'failure' }}
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: unittestreport.json
           path: unittestreport.json

--- a/.github/workflows/lint-yaml.yaml
+++ b/.github/workflows/lint-yaml.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload artifact digests
         if: ${{ steps.yaml-lint.outcome == 'failure' }}
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: log
           path: ${{ steps.yaml-lint.outputs.logfile }}

--- a/.github/workflows/trivy-scan-image.yaml
+++ b/.github/workflows/trivy-scan-image.yaml
@@ -24,13 +24,13 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Download spiderpool-agent image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: image-tar-spiderpool-agent
           path: test/.download
 
       - name: Download spiderpool-controller image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: image-tar-spiderpool-controller
           path: test/.download

--- a/.github/workflows/update-chart-readme.yml
+++ b/.github/workflows/update-chart-readme.yml
@@ -52,7 +52,7 @@ jobs:
           echo "-----------------------------"
 
       - name: Upload artifact digests
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: README.md
           path: thisProject/charts/spiderpool/README.md


### PR DESCRIPTION
## Thanks for contributing!

<!--Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>-->

#### What type of PR is this?

<!--
Add one of the following kinds:

Required labels:

- release/none 
- release/bug 
- release/feature

Optional labels:

- kind/bug
- kind/feature
- kind/ci-bug
- kind/doc
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

The dependency checker robot updated actions/upload-artifact for us, which was great, but it introduced some new issues. We had to roll it back.

```
##[debug]Body: {
##[debug]  "code": "already_exists",
##[debug]  "msg": "an artifact with this name already exists on the workflow run"
##[debug]}
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

refer to: https://github.com/marketplace/actions/upload-a-build-artifact
```
Breaking Changes
On self hosted runners, additional [firewall rules](https://github.com/actions/toolkit/tree/main/packages/artifact#breaking-changes) may be required.

- Uploading to the same named Artifact multiple times.

- Due to how Artifacts are created in this new version, it is no longer possible to upload to the same named Artifact multiple times. You must either split the uploads into multiple Artifacts with different names, or only upload once. Otherwise you will encounter an error.

- Limit of Artifacts for an individual job. Each job in a workflow run now has a limit of 500 artifacts.

```
