### PR TITLE
Optimize clean scripts

### DIFF
--- a/docs/usage/install/uninstall-zh_CN.md
+++ b/docs/usage/install/uninstall-zh_CN.md
@@ -26,9 +26,9 @@
 
     将 `<spiderpool-name>` 替换为要卸载的 Spiderpool 的名称，将 `<spiderpool-namespace>` 替换为 Spiderpool 所在的命名空间。
 
-### v0.10.0 以上版本
+### v1.0.0 以上版本
 
-在 v0.10.0 之后引入了自动清理 Spiderpool 资源的功能，它通过 `spiderpoolController.cleanup.enabled` 配置项来启用，该值默认为 `true`，您可以通过如下方式验证与 Spiderpool 相关的资源数量是否自动被清理。
+在 v1.0.0 之后引入了自动清理 Spiderpool 资源的功能，它通过 `spiderpoolController.cleanup.enabled` 配置项来启用，该值默认为 `true`，您可以通过如下方式验证与 Spiderpool 相关的资源数量是否自动被清理。
 
 ```bash
 kubectl get spidersubnets.spiderpool.spidernet.io -o name | wc -l 
@@ -39,9 +39,18 @@ kubectl get spiderendpoints.spiderpool.spidernet.io -o name | wc -l
 kubectl get spidercoordinators.spiderpool.spidernet.io -o name | wc -l
 ```
 
-### v0.10.0 以下版本
+### v1.0.0 以下版本
 
-在低于 v0.10.0 的版本中，由于 Spiderpool 的某些 CR 资源中存在 [finalizers](https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/) ，导致 `helm uninstall` 命令无法清理干净，您需要手动清理。可获取如下清理脚本来完成清理，以确保下次部署 Spiderpool 时不会出现意外错误。
+在低于 v1.0.0 的版本中，由于 Spiderpool 的某些 CR 资源中存在 [finalizers](https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/) ，导致 `helm uninstall` 命令无法清理干净，您需要手动清理。可获取如下清理脚本来完成清理，以确保下次部署 Spiderpool 时不会出现意外错误。
+
+```bash
+wget https://raw.githubusercontent.com/spidernet-io/spiderpool/main/tools/scripts/cleanCRD.sh
+chmod +x cleanCRD.sh && ./cleanCRD.sh
+```
+
+## FAQ
+
+删除 Spiderpool 未使用 `helm uninstall` 方式，而是通过 `kubectl delete <spiderpool 部署的 namespace>`，导致出现资源卸载残留，从而影响新的安装。您需要手动清理。可获取如下清理脚本来完成清理，以确保下次部署 Spiderpool 时不会出现意外错误。
 
 ```bash
 wget https://raw.githubusercontent.com/spidernet-io/spiderpool/main/tools/scripts/cleanCRD.sh

--- a/docs/usage/install/uninstall.md
+++ b/docs/usage/install/uninstall.md
@@ -26,9 +26,9 @@ Understand the running application and understand the impact that uninstalling S
 
      Replace `<spiderpool-name>` with the name of the Spiderpool you want to uninstall and `<spiderpool-namespace>` with the namespace of the Spiderpool.
 
-### Above v0.10.0
+### Above v1.0.0
 
-The function of automatically cleaning Spiderpool resources was introduced after v0.10.0. It is enabled through the `spiderpoolController.cleanup.enabled` configuration item. The value defaults to `true`. You can verify whether the number of resources related to Spiderpool is automatically cleared as follows.
+The function of automatically cleaning Spiderpool resources was introduced after v1.0.0. It is enabled through the `spiderpoolController.cleanup.enabled` configuration item. The value defaults to `true`. You can verify whether the number of resources related to Spiderpool is automatically cleared as follows.
 
 ```bash
 kubectl get spidersubnets.spiderpool.spidernet.io -o name | wc -l
@@ -39,9 +39,18 @@ kubectl get spiderendpoints.spiderpool.spidernet.io -o name | wc -l
 kubectl get spidercoordinators.spiderpool.spidernet.io -o name | wc -l
 ```
 
-### Below v0.10.0
+### Below v1.0.0
 
-In versions lower than v0.10.0, Some CR resources having [finalizers](https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/) prevents complete cleanup via `helm uninstall`. You can download the cleaning script below to perform the necessary cleanup and avoid any unexpected errors during future deployments of Spiderpool.
+In versions lower than v1.0.0, Some CR resources having [finalizers](https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/) prevents complete cleanup via `helm uninstall`. You can download the cleaning script below to perform the necessary cleanup and avoid any unexpected errors during future deployments of Spiderpool.
+
+```bash
+wget https://raw.githubusercontent.com/spidernet-io/spiderpool/main/tools/scripts/cleanCRD.sh
+chmod +x cleanCRD.sh && ./cleanCRD.sh
+```
+
+## FAQ
+
+Spiderpool was not deleted using the `helm uninstall` method, but through `kubectl delete <spiderpool deployed namespace>`, which resulted in resource uninstallation residues, thus affecting the new installation. You need to clean it up manually. You can get the following cleanup script to complete the cleanup to ensure that there will be no unexpected errors when you deploy Spiderpool next time.
 
 ```bash
 wget https://raw.githubusercontent.com/spidernet-io/spiderpool/main/tools/scripts/cleanCRD.sh

--- a/tools/scripts/cleanCRD.sh
+++ b/tools/scripts/cleanCRD.sh
@@ -3,6 +3,10 @@
 # Copyright 2022 Authors of spidernet-io
 # SPDX-License-Identifier: Apache-2.0
 
+kubectl get MutatingWebhookConfiguration | sed '1 d' | awk '{print $1}' | grep spiderpool-controller |  xargs -n 1 -i kubectl delete MutatingWebhookConfiguration {}
+
+kubectl get ValidatingWebhookConfiguration | sed '1 d' | awk '{print $1}' | grep spiderpool-controller | xargs -n 1 -i kubectl delete ValidatingWebhookConfiguration {}
+
 kubectl get spiderippools | sed '1 d' | awk '{print $1}' | xargs -n 1 -i kubectl patch spiderippools {} --patch '{"metadata": {"finalizers": null}}' --type=merge
 
 kubectl get spidersubnets | sed '1 d' | awk '{print $1}' | xargs -n 1 -i kubectl patch spidersubnets {} --patch '{"metadata": {"finalizers": null}}' --type=merge


### PR DESCRIPTION
## Thanks for contributing!

<!--Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>-->

#### What type of PR is this?

<!--
Add one of the following kinds:

Required labels:

- release/none 
- release/bug 
- release/feature

Optional labels:

- kind/bug
- kind/feature
- kind/ci-bug
- kind/doc
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3696 

**Special notes for your reviewer**:

```
➜  spiderpool git:(fix/3696) kubectl delete ns spiderpool-ns              
namespace "spiderpool-ns" deleted
➜  spiderpool git:(fix/3696) kubectl get MutatingWebhookConfiguration -A
NAME                    WEBHOOKS   AGE
spiderpool-controller   5          76s
➜  spiderpool git:(fix/3696) bash ./tools/scripts/cleanCRD.sh
mutatingwebhookconfiguration.admissionregistration.k8s.io "spiderpool-controller" deleted
validatingwebhookconfiguration.admissionregistration.k8s.io "spiderpool-controller" deleted
spiderippool.spiderpool.spidernet.io/ippool-test patched
No resources found
spidercoordinator.spiderpool.spidernet.io/default patched
No resources found
customresourcedefinition.apiextensions.k8s.io "spiderendpoints.spiderpool.spidernet.io" deleted
customresourcedefinition.apiextensions.k8s.io "spiderippools.spiderpool.spidernet.io" deleted
customresourcedefinition.apiextensions.k8s.io "spiderreservedips.spiderpool.spidernet.io" deleted
customresourcedefinition.apiextensions.k8s.io "spidersubnets.spiderpool.spidernet.io" deleted
customresourcedefinition.apiextensions.k8s.io "spidercoordinators.spiderpool.spidernet.io" deleted
customresourcedefinition.apiextensions.k8s.io "spidermultusconfigs.spiderpool.spidernet.io" deleted
```