### PR TITLE
e2e fix: skip About passt network core binding e2e

### DIFF
--- a/test/e2e/kubevirt/kubevirt_test.go
+++ b/test/e2e/kubevirt/kubevirt_test.go
@@ -57,7 +57,10 @@ var _ = Describe("test kubevirt", Label("kubevirt"), func() {
 		})
 	})
 
-	It("Succeed to keep static IP for kubevirt VM/VMI after restarting the VM/VMI pod", Label("F00001"), func() {
+	// TODO(ty-dc): Kubevirt removed support for passt network core binding in v1.3, see https://github.com/kubevirt/kubevirt/pull/11915
+	// The reason for removal is: "Network Core Binding has not yet reached GA level",
+	// but the feature has not been abandoned? Temporarily pending e2e, follow up later.
+	It("Succeed to keep static IP for kubevirt VM/VMI after restarting the VM/VMI pod", Label("F00001"), Pending, func() {
 		// VM crash with Passt network mode: https://github.com/kubevirt/kubevirt/issues/10583
 		// reference spiderpool CI issue: https://github.com/spidernet-io/spiderpool/issues/2460
 		if !frame.Info.IpV4Enabled && frame.Info.IpV6Enabled {


### PR DESCRIPTION
## Thanks for contributing!

<!--Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>-->

#### What type of PR is this?

<!--
Add one of the following kinds:

Required labels:

- release/none 
- release/bug 
- release/feature

Optional labels:

- kind/bug
- kind/feature
- kind/ci-bug
- kind/doc
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3740 

**Special notes for your reviewer**:
Kubevirt removed support for passt network core binding in v1.3, refer to https://kubevirt.io/user-guide/release_notes/#deprecation
The reason for removal is: "Network Core Binding has not yet reached GA level",
but the feature has not been abandoned? Temporarily pending e2e, follow up later.