### PR TITLE
fix: Missing GLIBC dynamic dependency makes ovs binary unavailable

### DIFF
--- a/charts/spiderpool/README.md
+++ b/charts/spiderpool/README.md
@@ -234,7 +234,7 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 | `plugins.image.repository`       | the image repository of plugins                            | `spidernet-io/spiderpool/spiderpool-plugins` |
 | `plugins.image.pullPolicy`       | the image pullPolicy of plugins                            | `IfNotPresent`                               |
 | `plugins.image.digest`           | the image digest of plugins                                | `""`                                         |
-| `plugins.image.tag`              | the image tag of plugins                                   | `f0e6ae94a758cf3a1cd2bc9892e5948f4811d32c`   |
+| `plugins.image.tag`              | the image tag of plugins                                   | `82659d90cae0d6a5169eac2869e47c989932d775`   |
 | `plugins.image.imagePullSecrets` | the image imagePullSecrets of plugins                      | `[]`                                         |
 
 ### clusterDefaultPool parameters

--- a/charts/spiderpool/values.yaml
+++ b/charts/spiderpool/values.yaml
@@ -314,7 +314,7 @@ plugins:
     digest: ""
 
     ## @param plugins.image.tag the image tag of plugins
-    tag: f0e6ae94a758cf3a1cd2bc9892e5948f4811d32c
+    tag: 82659d90cae0d6a5169eac2869e47c989932d775
 
     ## @param plugins.image.imagePullSecrets the image imagePullSecrets of plugins
     imagePullSecrets: []

--- a/images/spiderpool-plugins/Dockerfile
+++ b/images/spiderpool-plugins/Dockerfile
@@ -47,13 +47,13 @@ RUN git checkout ${RDMA_VERSION}  && make TARGET_ARCH=${TARGETARCH}   \
           TARGET_OS=${TARGETOS} build
 
 WORKDIR /src/ovs-cni
-RUN mkdir -p build && GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -tags no_openssl -mod vendor -o build/ovs ./cmd/plugin
+RUN mkdir -p build && GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 go build -v -ldflags="-s -w" -tags no_openssl -mod vendor -o build/ovs ./cmd/plugin
 
 WORKDIR /src/ib-sriov-cni
-RUN git checkout ${IB_SRIOV_VERSION} && go mod vendor && mkdir -p build && GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 go build -tags no_openssl -mod vendor -o build/ib-sriov ./cmd/ib-sriov-cni
+RUN git checkout ${IB_SRIOV_VERSION} && go mod vendor && mkdir -p build && GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 go build -v -ldflags="-s -w" -tags no_openssl -mod vendor -o build/ib-sriov ./cmd/ib-sriov-cni
 
 WORKDIR /src/sriov-cni
-RUN git checkout ${SRIOV_VERSION} && go mod vendor && mkdir -p build && GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 go build -tags no_openssl -mod vendor -o build/sriov ./cmd/sriov
+RUN git checkout ${SRIOV_VERSION} && go mod vendor && mkdir -p build && GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 go build -v -ldflags="-s -w" -tags no_openssl -mod vendor -o build/sriov ./cmd/sriov
 
 WORKDIR /src/ipoib-cni
 RUN git checkout ${IPOIB_VERSION} &&  make build && [ -f "build/ipoib" ]


### PR DESCRIPTION
## Thanks for contributing!

<!--Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>-->

#### What type of PR is this?

<!--
Add one of the following kinds:

Required labels:

- release/none 
- release/bug 
- release/feature

Optional labels:

- kind/bug
- kind/feature
- kind/ci-bug
- kind/doc
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3741

**Special notes for your reviewer**:
