### PR TITLE
 pod launched by unexpected CNI when the health checking of the agent fails and multus.conf is lost

### DIFF
--- a/charts/spiderpool/templates/daemonset.yaml
+++ b/charts/spiderpool/templates/daemonset.yaml
@@ -106,36 +106,6 @@ spec:
             - name: cni-bin-path
               mountPath: /host/opt/cni/bin
         {{- end }}
-        {{- if .Values.multus.multusCNI.install }}
-        - name: multus-cni
-          imagePullPolicy: {{ .Values.multus.multusCNI.image.pullPolicy }}
-          image: {{ include "spiderpool.multus.image" . | quote }}
-          command:
-            - "/bin/sh"
-            - "-c"
-            - |
-              ITEM="multus"
-              rm -f /host/opt/cni/bin/${ITEM}.old || true
-              ( [ -f "/host/opt/cni/bin/${ITEM}" ] && mv /host/opt/cni/bin/${ITEM} /host/opt/cni/bin/${ITEM}.old ) || true
-              cp /usr/src/multus-cni/bin/${ITEM} /host/opt/cni/bin/${ITEM}
-              rm -f /host/opt/cni/bin/${ITEM}.old &>/dev/null  || true
-              sed -i 's/sleep infinity/echo \"exit...\"/g'  entrypoint.sh
-              ./entrypoint.sh --multus-conf-file=/tmp/multus-conf/00-multus.conf \
-                --cni-version=0.3.1
-          securityContext:
-            privileged: true
-          volumeMounts:
-            - name: cni
-              mountPath: /host/etc/cni/net.d
-            - name: cni-bin-path
-              mountPath: /host/opt/cni/bin
-              mountPropagation: Bidirectional
-            - name: multus-cfg
-              mountPath: /tmp/multus-conf
-            {{- if .Values.multus.multusCNI.extraVolumes }}
-            {{- include "tplvalues.render" ( dict "value" .Values.multus.multusCNI.extraVolumeMounts "context" $ ) | nindent 12 }}
-            {{- end }}
-        {{- end }}
       containers:
       - name: {{ .Values.spiderpoolAgent.name | trunc 63 | trimSuffix "-" }}
         image: {{ include "spiderpool.spiderpoolAgent.image" . | quote }}
@@ -205,18 +175,6 @@ spec:
                 	cp /usr/bin/${ITEM} /host/opt/cni/bin/${ITEM}
                 	rm -f /host/opt/cni/bin/${ITEM}.old &>/dev/null  || true
                 done
-          preStop:
-            exec:
-              command:
-              - "/bin/sh"
-              - "-c"
-              - | 
-                {{- if .Values.multus.multusCNI.uninstall }}
-                rm -f /host/opt/cni/bin/multus || true
-                rm -rf /host/etc/cni/net.d/multus.d || true
-                rm -f /host/etc/cni/net.d/00-multus.conf || true
-                {{- end }}
-                {{ .Values.spiderpoolAgent.binName }} shutdown
         env:
         - name: SPIDERPOOL_POD_NAME
           valueFrom:
@@ -282,6 +240,47 @@ spec:
         {{- if .Values.spiderpoolAgent.extraVolumes }}
         {{- include "tplvalues.render" ( dict "value" .Values.spiderpoolAgent.extraVolumeMounts "context" $ ) | nindent 8 }}
         {{- end }}
+     {{- if .Values.multus.multusCNI.install }}
+      - name: multus-cni
+        imagePullPolicy: {{ .Values.multus.multusCNI.image.pullPolicy }}
+        image: {{ include "spiderpool.multus.image" . | quote }}
+        command:
+          - "/bin/sh"
+          - "-c"
+          - |
+            ITEM="multus"
+            rm -f /host/opt/cni/bin/${ITEM}.old || true
+            ( [ -f "/host/opt/cni/bin/${ITEM}" ] && mv /host/opt/cni/bin/${ITEM} /host/opt/cni/bin/${ITEM}.old ) || true
+            cp /usr/src/multus-cni/bin/${ITEM} /host/opt/cni/bin/${ITEM}
+            rm -f /host/opt/cni/bin/${ITEM}.old &>/dev/null  || true
+            ./entrypoint.sh --multus-conf-file=/tmp/multus-conf/00-multus.conf \
+              --cni-version=0.3.1
+        securityContext:
+          privileged: true
+        {{- if .Values.multus.multusCNI.uninstall }}        
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - "/bin/sh"
+              - "-c"
+              - | 
+                rm -f /host/opt/cni/bin/multus || true
+                rm -rf /host/etc/cni/net.d/multus.d || true
+                rm -f /host/etc/cni/net.d/00-multus.conf || true
+        {{- end }}
+        volumeMounts:
+          - name: cni
+            mountPath: /host/etc/cni/net.d
+          - name: cni-bin-path
+            mountPath: /host/opt/cni/bin
+            mountPropagation: Bidirectional
+          - name: multus-cfg
+            mountPath: /tmp/multus-conf
+          {{- if .Values.multus.multusCNI.extraVolumes }}
+          {{- include "tplvalues.render" ( dict "value" .Values.multus.multusCNI.extraVolumeMounts "context" $ ) | nindent 12 }}
+          {{- end }}
+      {{- end }}
       volumes:
         # To read the configuration from the config map
       - name: config-path

--- a/test/Makefile
+++ b/test/Makefile
@@ -259,6 +259,7 @@ setup_spiderpool:
 			HELM_OPTION+=" --set dra.hostDevicePath=$(E2E_SPIDERPOOL_DRA_SOLIBRARY_PATH) " ; \
 		fi ; \
 		HELM_OPTION+=" --set multus.multusCNI.install=true " ; \
+		HELM_OPTION+=" --set multus.multusCNI.uninstall=true " ; \
 		HELM_OPTION+=" --set multus.multusCNI.image.registry= " ; \
 		HELM_OPTION+=" --set multus.multusCNI.image.repository=$(E2E_MULTUS_IMAGE_NAME) " ; \
 		if [ "$(INSTALL_OVERLAY_CNI)" == "true" ]; then \
@@ -399,6 +400,7 @@ uninstall_spiderpool:
 	@echo -e "\033[35m [helm uninstall spiderpool] \033[0m"
 	helm uninstall $(RELEASE_NAME) --wait --debug -n $(RELEASE_NAMESPACE) \
 	     --kubeconfig $(E2E_KUBECONFIG)  || { KIND_CLUSTER_NAME=$(E2E_CLUSTER_NAME) ./scripts/debugEnv.sh $(E2E_KUBECONFIG) "detail"   ; exit 1 ; } ; \
+	echo "Multus config has been cleanup successfully." ; \
 	for ((i=0; i<100; i++)); do \
     	if ! kubectl --kubeconfig=$(E2E_KUBECONFIG) get all --all-namespaces | grep -q "spiderpool" ; then \
 			echo "All resources successfully cleared." ; \

--- a/test/e2e/coordinator/macvlan-overlay-one/macvlan_overlay_one_test.go
+++ b/test/e2e/coordinator/macvlan-overlay-one/macvlan_overlay_one_test.go
@@ -886,7 +886,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 			const SPIDERPOOL_ENABLED_RELEASE_CONFLICT_IPS = "SPIDERPOOL_ENABLED_RELEASE_CONFLICT_IPS"
 			spiderpoolAgentDS, err := frame.GetDaemonSet(constant.SpiderpoolAgent, "kube-system")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(spiderpoolAgentDS.Spec.Template.Spec.Containers).To(HaveLen(1))
+			Expect(spiderpoolAgentDS.Spec.Template.Spec.Containers).To(HaveLen(2))
 
 			// the release conflicted IPs feature is default to be true if we do not set the ENV
 			isReleaseConflictIPs := true


### PR DESCRIPTION
## Thanks for contributing!

<!--Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>-->

#### What type of PR is this?

- release/bug 

<!--
Add one of the following kinds:

Required labels:

- release/none 
- release/bug 
- release/feature

Optional labels:

- kind/bug
- kind/feature
- kind/ci-bug
- kind/doc
-->

**What this PR does / why we need it**:

the prestop of the agent's container would clean up the multus cni config(00-multus.conf), If the container restart but not pod restarts, the config file wouldn't be re-generated, which can cause the multus doesn't work.

the pr moves the multus-cni from init-container to container, and choose the it as the first containers.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/spidernet-io/spiderpool/issues/3755

**Special notes for your reviewer**:

1. restart the multus-cni container, the 00-multus.conf would be re-generated.

```
root@spider-worker:/# crictl ps
CONTAINER           IMAGE               CREATED              STATE               NAME                     ATTEMPT             POD ID              POD
a4d9d4af2fe69       d958cfbb222dd       About a minute ago   Running             spiderpool-agent         1                   4ee679bf58463       spiderpool-agent-tzv5j
d831dc97340f0       c0e8690ae66a1       2 minutes ago        Running             multus-cni               2                   4ee679bf58463       spiderpool-agent-tzv5j
8d75c8c8afcc8       0cdd32d9ecad4       6 minutes ago        Running             spiderpool-controller    0                   63e231c0e00a4       spiderpool-controller-6c96859774-xfk8k
1cb443c9e2275       ded66453eb630       24 hours ago         Running             calico-node              0                   07b5a657f52d2       calico-node-99ns6
c6b519fbbc373       ce18e076e9d4b       24 hours ago         Running             local-path-provisioner   0                   84e082ef2ce9e       local-path-provisioner-6f8956fb48-rrjxj
de187f755a123       cbb01a7bd410d       24 hours ago         Running             coredns                  0                   5ccf34350d4d2       coredns-76f75df574-vrvvw
c3bd1ec34ff92       cbb01a7bd410d       24 hours ago         Running             coredns                  0                   0d54dd25c240c       coredns-76f75df574-qxjwr
70065ffc12219       fa4dee78049db       24 hours ago         Running             kube-proxy               0                   d2acd3475056d       kube-proxy-tzcfr
root@spider-worker:/# ls -l /etc/cni/net.d/
total 16
-rw-r--r-- 1 root root  461 Jul 25 08:11 00-multus.conf
-rw-r--r-- 1 root root  752 Jul 24 07:58 10-calico.conflist
-rw------- 1 root root 2737 Jul 25 01:42 calico-kubeconfig
drwxr-xr-x 2 root root 4096 Jul 25 08:11 multus.d
root@spider-worker:/# crictl stop d831dc97340f0
d831dc97340f0
root@spider-worker:/# ls -l /etc/cni/net.d/
total 16
-rw-r--r-- 1 root root  461 Jul 25 08:14 00-multus.conf
-rw-r--r-- 1 root root  752 Jul 24 07:58 10-calico.conflist
-rw------- 1 root root 2737 Jul 25 01:42 calico-kubeconfig
drwxr-xr-x 2 root root 4096 Jul 25 08:14 multus.d
```

2. restart the agent's container, the 00-multus.conf has no changes.
