### PR TITLE
Change the type of cilium bpf.vlanBypass to list

### DIFF
--- a/docs/usage/install/overlay/get-started-cilium-zh_cn.md
+++ b/docs/usage/install/overlay/get-started-cilium-zh_cn.md
@@ -18,9 +18,11 @@
 - 准备好一个 Kubernetes 集群
 - 安装 Cilium 作为集群的缺省 CNI。如果未安装，可参考 [官方文档](https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/) 或使用以下命令安装:
 
+    > Cilium 在运行时会扫描可用的 VLAN 设备和标签，并将过滤所有未知流量。在一些跨 VLAN 场景下访问时，可能会出现通讯问题，请在安装时使用 `--set bpf.vlanBypass={0}` 允许所有的 VLAN 标记通过，更多细节参考 [Cilium VLAN 802.1q 支持](https://docs.cilium.io/en/stable/configuration/vlan-802.1q/#vlan-802-1q)。
+
     ```shell
     ~# helm repo add cilium https://helm.cilium.io/
-    ~# helm install cilium cilium/cilium -namespace kube-system
+    ~# helm install cilium cilium/cilium -namespace kube-system --set bpf.vlanBypass={0}
     ~# kubectl wait --for=condition=ready -l k8s-app=cilium pod -n kube-system
     ```
 

--- a/docs/usage/install/overlay/get-started-cilium.md
+++ b/docs/usage/install/overlay/get-started-cilium.md
@@ -18,9 +18,11 @@ This page showcases the utilization of `Spiderpool`, a comprehensive Underlay ne
 - A ready Kubernetes cluster.
 - Cilium has been already installed as the default CNI for your cluster. If it is not installed, please refer to [the official documentation](https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/) or follow the commands below for installation:
 
+    > Cilium will scan available VLAN devices and tags when running, and will filter all unknown traffic. In some cross-VLAN scenarios,there may be communication problems. Please use `--set bpf.vlanBypass={0}` during installation to allow all VLAN tags to pass. For more details, refer to [Cilium VLAN 802.1q support](https://docs.cilium.io/en/stable/configuration/vlan-802.1q/#vlan-802-1q).
+
     ```shell
     ~# helm repo add cilium https://helm.cilium.io/
-    ~# helm install cilium cilium/cilium -namespace kube-system
+    ~# helm install cilium cilium/cilium -namespace kube-system --set bpf.vlanBypass={0}
     ~# kubectl wait --for=condition=ready -l k8s-app=cilium pod -n kube-system
     ```
 

--- a/test/scripts/install-default-cni.sh
+++ b/test/scripts/install-default-cni.sh
@@ -172,15 +172,15 @@ function install_cilium() {
       # k8sServiceHost api-server address
       # k8sServicePort api-service port
       # bpf.vlanBypass allow vlan traffic to pass
-      KUBE_PROXY_REPLACEMENT=disabled
+      KUBE_PROXY_REPLACEMENT=false
       if [ "$DISABLE_KUBE_PROXY" = "true" ]; then
-        KUBE_PROXY_REPLACEMENT=strict
+        KUBE_PROXY_REPLACEMENT=true
       fi
       CILIUM_HELM_OPTIONS=" --set cni.exclusive=false \
                             --set kubeProxyReplacement=${KUBE_PROXY_REPLACEMENT} \
                             --set k8sServiceHost=${E2E_CLUSTER_NAME}-control-plane \
                             --set k8sServicePort=6443 \
-                            --set bpf.vlanBypass=0 "
+                            --set bpf.vlanBypass={0} "
       case ${E2E_IP_FAMILY} in
         ipv4)
             CILIUM_HELM_OPTIONS+=" --set ipam.operator.clusterPoolIPv4PodCIDRList=${CILIUM_CLUSTER_POD_SUBNET_V4} \


### PR DESCRIPTION
## Thanks for contributing!

<!--Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>-->

#### What type of PR is this?

<!--
Add one of the following kinds:

Required labels:

- release/none 
- release/bug 
- release/feature

Optional labels:

- kind/bug
- kind/feature
- kind/ci-bug
- kind/doc
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3760 

**Special notes for your reviewer**:

cilium released a new version, and the type of bpf.vlanBypass was changed to list.

```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
cilium:
- bpf.vlanBypass: Invalid type. Expected: [null,array], given: integer
```