### PR TITLE
Support ipv6 subnet with CIDR mask bigger than 64

### DIFF
--- a/pkg/ip/subnet.go
+++ b/pkg/ip/subnet.go
@@ -1,0 +1,229 @@
+// Copyright 2024 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+
+package ip
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+	"net"
+	"strings"
+)
+
+type Range struct {
+	Raw        string
+	Start, End *big.Int
+}
+
+type CIDR struct {
+	base    net.IPNet           // base is the base subnet
+	isIPv4  bool                // isIPv4 is true if the base subnet is an IPv4 address
+	ranges  []Range             // ranges is available IP ranges
+	usedMap map[string]struct{} // usedMap is a map of used IP addresses
+}
+
+func NewCIDR(base string, ranges []string, exclude []string) (*CIDR, error) {
+	_, ipNet, err := net.ParseCIDR(base)
+	if err != nil {
+		return nil, err
+	}
+	subnet := &CIDR{base: *ipNet}
+	if ipNet.IP.To4() != nil {
+		subnet.isIPv4 = true
+	}
+
+	for _, item := range ranges {
+		s, e, err := subnet.parse(item)
+		if err != nil {
+			return nil, err
+		}
+		err = subnet.addIncludeRange(Range{Raw: item, Start: s, End: e})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	excludeRanges := make([]Range, 0)
+	for _, item := range exclude {
+		s, e, err := subnet.parse(item)
+		if err != nil {
+			return nil, err
+		}
+		r := Range{Raw: item, Start: s, End: e}
+		excludeRanges = append(excludeRanges, r)
+	}
+	subnet.ranges = removeExcludeIPRange(subnet.ranges, excludeRanges)
+	return subnet, nil
+}
+
+// AddUsedIP adds the IP addresses to the used store.
+func (c *CIDR) AddUsedIP(list ...string) error {
+	for _, value := range list {
+		c.usedMap[value] = struct{}{}
+	}
+	return nil
+}
+
+// TotalUsedIPInt returns the number of used IP addresses in the subnet.
+func (c *CIDR) TotalUsedIPInt() int {
+	return len(c.usedMap)
+}
+
+// TotalIP returns the number of IP addresses in the subnet.
+func (c *CIDR) TotalIP() *big.Int {
+	total := big.NewInt(0)
+	for _, r := range c.ranges {
+		total.Add(total, big.NewInt(1))
+		total.Add(total, new(big.Int).Sub(r.End, r.Start))
+	}
+	return total
+}
+
+// TotalIPInt returns the number of IP addresses in the subnet as an integer.
+func (c *CIDR) TotalIPInt() int {
+	totalInt64 := c.TotalIP().Int64()
+	if c.TotalIP().Cmp(big.NewInt(math.MaxInt64)) > 0 {
+		return math.MaxInt64
+	}
+	return int(totalInt64)
+}
+
+// addIncludeRange adds the range to the subnet.
+func (c *CIDR) addIncludeRange(r Range) error {
+	if r.Start == nil || r.End == nil {
+		return fmt.Errorf("nil range: %s", r.Raw)
+	}
+	// if start > end, start = end, end = start
+	if r.Start.Cmp(r.End) > 0 {
+		r.Start, r.End = r.End, r.Start
+	}
+	a := Range{Raw: r.Raw, Start: r.Start, End: r.End}
+	for _, b := range c.ranges {
+		// a.start in b
+		if a.Start.Cmp(b.Start) >= 0 && a.End.Cmp(b.End) <= 0 {
+			return fmt.Errorf("range %v is already covered by %v", a.Raw, b.Raw)
+		}
+		// a.end in b
+		if a.Start.Cmp(b.Start) <= 0 && a.End.Cmp(b.End) >= 0 {
+			return fmt.Errorf("range %v covers %v", a.Raw, b.Raw)
+		}
+		// b.start in a
+		if a.Start.Cmp(b.Start) >= 0 && a.Start.Cmp(b.End) <= 0 {
+			return fmt.Errorf("range %v overlaps with %v", a.Raw, b.Raw)
+		}
+		// b.end in a
+		if a.End.Cmp(b.Start) >= 0 && a.End.Cmp(b.End) <= 0 {
+			return fmt.Errorf("range %v overlaps with %v", a.Raw, b.Raw)
+		}
+	}
+	c.ranges = append(c.ranges, a)
+	return nil
+}
+
+// parse parses the range string and returns the start and end IP addresses.
+// case ipv4
+// - "10.6.0.1"
+// - "10.6.0.1-10.6.0.1"
+// - "10.6.0.1/24"
+// case ipv6
+// - "fd00:db8::1"
+// - "fd00:db8::1-fd00:db8::1"
+// - "fd00:db8::1/64"
+func (c *CIDR) parse(value string) (*big.Int, *big.Int, error) {
+	parts := strings.Split(value, "-")
+	if len(parts) > 2 {
+		return nil, nil, fmt.Errorf("invalid range: %v", value)
+	}
+	if len(parts) == 1 {
+		if strings.Contains(value, "/") {
+			return nil, nil, fmt.Errorf("invalid range: %v", value)
+		} else {
+			res, err := c.convertIPtoBigInt(value)
+			return res, res, err
+		}
+	}
+	start, err := c.convertIPtoBigInt(parts[0])
+	if err != nil {
+		return nil, nil, err
+	}
+	end, err := c.convertIPtoBigInt(parts[1])
+	if err != nil {
+		return nil, nil, err
+	}
+	return start, end, nil
+}
+
+// convertIPtoBigInt converts the IP address to big.Int.
+func (c *CIDR) convertIPtoBigInt(value string) (*big.Int, error) {
+	ip := net.ParseIP(value)
+	if ip == nil {
+		return nil, fmt.Errorf("invalid IP address: %v", value)
+	}
+	if !c.base.Contains(ip) {
+		return nil, fmt.Errorf("not match base subnet: %v", value)
+	}
+	if c.isIPv4 {
+		ipv4 := ip.To4()
+		if ipv4 == nil {
+			return nil, fmt.Errorf("not match base subnet IPv4 version: %v", value)
+		}
+		res := big.NewInt(0).SetBytes(ipv4)
+		return res, nil
+	} else {
+		ipv6 := ip.To16()
+		if ipv6 == nil {
+			return nil, fmt.Errorf("not match base subnet IPv6 version: %v", value)
+		}
+		res := big.NewInt(0).SetBytes(ipv6)
+		return res, nil
+	}
+}
+
+// IPRange returns the IP ranges in the subnet.
+func (c *CIDR) IPRange() []Range {
+	return c.ranges
+}
+
+// IsOverlapIPRanges checks if the subnet overlaps with the given ranges.
+func (c *CIDR) IsOverlapIPRanges(r []Range) ([]string, bool) {
+	overlaps := make([]string, 0)
+	for _, x := range c.ranges {
+		for _, y := range r {
+			if (x.Start.Cmp(y.Start) >= 0 && x.Start.Cmp(y.End) <= 0) ||
+				(x.End.Cmp(y.Start) >= 0 && x.End.Cmp(y.End) <= 0) ||
+				(y.Start.Cmp(x.Start) >= 0 && y.Start.Cmp(x.End) <= 0) ||
+				(y.End.Cmp(x.Start) >= 0 && y.End.Cmp(x.End) <= 0) {
+				overlaps = append(overlaps, y.Raw)
+			}
+		}
+	}
+	return overlaps, len(overlaps) > 0
+}
+
+func removeExcludeIPRange(base []Range, exclude []Range) []Range {
+	f := func(base []Range, toBeRemoved Range) (res []Range) {
+		x, y := toBeRemoved.Start, toBeRemoved.End
+		for _, e := range base {
+			a, b := e.Start, e.End
+			if a.Cmp(y) > 0 || b.Cmp(x) < 0 {
+				res = append(res, e)
+			} else {
+				if a.Cmp(x) < 0 {
+					newEnd := new(big.Int).Sub(x, big.NewInt(1))
+					res = append(res, Range{e.Raw, a, newEnd})
+				}
+				if b.Cmp(y) > 0 {
+					newStart := new(big.Int).Add(y, big.NewInt(1))
+					res = append(res, Range{e.Raw, newStart, b})
+				}
+			}
+		}
+		return
+	}
+	result := base
+	for _, e := range exclude {
+		result = f(result, e)
+	}
+	return result
+}

--- a/pkg/ip/subnet_test.go
+++ b/pkg/ip/subnet_test.go
@@ -1,0 +1,390 @@
+// Copyright 2024 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+
+package ip
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NewCIDR", Label("subnet_test"), func() {
+	testCases := []struct {
+		name            string
+		base            string
+		ranges          []string
+		exclude         []string
+		expErr          bool
+		expTotal        int
+		expRanges       []string
+		overlapIPRanges []string
+		expIsOverlap    bool
+	}{
+		{
+			name:     "empty ranges and exclude",
+			base:     "10.6.0.0/24",
+			ranges:   []string{},
+			exclude:  []string{},
+			expErr:   false,
+			expTotal: 0,
+		},
+		{
+			name:     "ipv4 subnet contain range",
+			base:     "10.6.0.0/24",
+			ranges:   []string{"10.6.0.1-10.6.0.2"},
+			exclude:  nil,
+			expErr:   false,
+			expTotal: 2,
+			expRanges: []string{
+				"10.6.0.1-10.6.0.2",
+			},
+		},
+		{
+			name: "ipv4 subnet contain multiple ranges",
+			base: "10.6.0.0/24",
+			ranges: []string{
+				"10.6.0.1-10.6.0.2",
+				"10.6.0.4-10.6.0.6",
+			},
+			exclude:  nil,
+			expErr:   false,
+			expTotal: 5,
+			expRanges: []string{
+				"10.6.0.1-10.6.0.2",
+				"10.6.0.4-10.6.0.6",
+			},
+		},
+		{
+			name: "fully overlapping ranges",
+			base: "10.6.0.0/24",
+			ranges: []string{
+				"10.6.0.1-10.6.0.10",
+				"10.6.0.1-10.6.0.10",
+			},
+			exclude: nil,
+			expErr:  true,
+		},
+		{
+			name:      "ipv4 subnet contain ip",
+			base:      "10.6.0.0/24",
+			ranges:    []string{"10.6.0.1"},
+			exclude:   nil,
+			expErr:    false,
+			expTotal:  1,
+			expRanges: []string{"10.6.0.1"},
+		},
+		{
+			name: "ipv4 subnet not contain ip",
+			base: "10.6.0.0/24",
+			ranges: []string{
+				"10.5.0.1",
+			},
+			exclude:  nil,
+			expErr:   true,
+			expTotal: 0,
+		},
+		{
+			name: "ipv4 subnet not contain range",
+			base: "10.6.0.0/24",
+			ranges: []string{
+				"10.5.0.1-10.6.0.10",
+			},
+			exclude: nil,
+			expErr:  true,
+		},
+		{
+			name: "ipv4 subnet range overlap range case1",
+			base: "10.6.0.0/24",
+			ranges: []string{
+				"10.6.0.1-10.6.0.10",
+				"10.6.0.10-10.6.0.20",
+			},
+			exclude: nil,
+			expErr:  true,
+		},
+		{
+			name: "ipv4 subnet range overlap range case2",
+			base: "10.6.0.0/24",
+			ranges: []string{
+				"10.6.0.1-10.6.0.10",
+				"10.6.0.3-10.6.0.5",
+			},
+			exclude: nil,
+			expErr:  true,
+		},
+		{
+			name: "ipv4 subnet range overlap ip",
+			base: "10.6.0.0/24",
+			ranges: []string{
+				"10.6.0.1-10.6.0.10",
+				"10.6.0.3",
+			},
+			exclude: nil,
+			expErr:  true,
+		},
+		{
+			name: "ipv4 subnet invalid range",
+			base: "10.6.0.0/24",
+			ranges: []string{
+				"10.6.0.1-",
+			},
+			exclude: nil,
+			expErr:  true,
+		},
+		{
+			name: "ipv4 subnet invalid range",
+			base: "10.6.0.0/24",
+			ranges: []string{
+				"10.6.0.1-fd:00::1",
+			},
+			exclude: nil,
+			expErr:  true,
+		},
+		{
+			name: "ipv4 subnet invalid range",
+			base: "10.6.0.0/24",
+			ranges: []string{
+				"10.6.0.1-fd:00::1",
+			},
+			exclude: nil,
+			expErr:  true,
+		},
+		{
+			name: "invalid IP address format",
+			base: "10.6.0.0/24",
+			ranges: []string{
+				"10.6.0.1-10.6.0.300",
+			},
+			exclude: nil,
+			expErr:  true,
+		},
+		{
+			name: "invalid CIDR format",
+			base: "10.6.0.0/33",
+			ranges: []string{
+				"10.6.0.1-10.6.0.10",
+			},
+			exclude: nil,
+			expErr:  true,
+		},
+		{
+			name:      "case signal exclude",
+			base:      "10.6.0.0/24",
+			ranges:    []string{"10.6.0.1-10.6.0.10"},
+			exclude:   []string{"10.6.0.1-10.6.0.2"},
+			expErr:    false,
+			expTotal:  8,
+			expRanges: []string{"10.6.0.3-10.6.0.10"},
+		},
+		{
+			name: "case multi exclude",
+			base: "10.6.0.0/24",
+			ranges: []string{
+				"10.6.0.1-10.6.0.10",
+			},
+			exclude: []string{
+				"10.6.0.1-10.6.0.2",
+				"10.6.0.8-10.6.0.10",
+			},
+			expErr:   false,
+			expTotal: 5,
+			expRanges: []string{
+				"10.6.0.3-10.6.0.7",
+			},
+		},
+		{
+			name: "case multi exclude",
+			base: "10.6.0.0/24",
+			ranges: []string{
+				"10.6.0.1-10.6.0.10",
+				"10.6.0.11-10.6.0.20",
+				"10.6.0.21-10.6.0.30",
+			},
+			exclude: []string{
+				"10.6.0.1-10.6.0.2",
+				"10.6.0.8-10.6.0.22",
+			},
+			expErr:   false,
+			expTotal: 13,
+			expRanges: []string{
+				"10.6.0.3-10.6.0.7",
+				"10.6.0.23-10.6.0.30",
+			},
+		},
+
+		{
+			name:     "ipv6 subnet contain range",
+			base:     "fd00::/64",
+			ranges:   []string{"fd00::1-fd00::2"},
+			exclude:  nil,
+			expErr:   false,
+			expTotal: 2,
+			expRanges: []string{
+				"fd00::1-fd00::2",
+			},
+		},
+
+		{
+			name: "ipv6 subnet contain multiple ranges",
+			base: "fd00::/64",
+			ranges: []string{
+				"fd00::1-fd00::2",
+				"fd00::4-fd00::6",
+			},
+			exclude:  nil,
+			expErr:   false,
+			expTotal: 5,
+			expRanges: []string{
+				"fd00::1-fd00::2",
+				"fd00::4-fd00::6",
+			},
+		},
+
+		{
+			name: "ipv6 subnet contain multiple ranges",
+			base: "fd00::/64",
+			ranges: []string{
+				"fd00::1-fd00::2",
+				"fd00::4-fd00::6",
+			},
+			exclude:  nil,
+			expErr:   false,
+			expTotal: 5,
+			expRanges: []string{
+				"fd00::1-fd00::2",
+				"fd00::4-fd00::6",
+			},
+		},
+		{
+			name: "ipv6 subnet invalid range",
+			base: "fd00::/64",
+			ranges: []string{
+				"fd00::1-",
+			},
+			exclude: nil,
+			expErr:  true,
+		},
+		{
+			name: "ipv6 subnet invalid range",
+			base: "fd00::/64",
+			ranges: []string{
+				"fd00::1-10.6.0.1",
+			},
+			exclude: nil,
+			expErr:  true,
+		},
+		{
+			name: "invalid IPv6 address format",
+			base: "fd00::/64",
+			ranges: []string{
+				"fd00::1-fd00::zzzz",
+			},
+			exclude: nil,
+			expErr:  true,
+		},
+		{
+			name:      "case signal exclude",
+			base:      "fd00::/64",
+			ranges:    []string{"fd00::1-fd00::10"},
+			exclude:   []string{"fd00::1-fd00::2"},
+			expErr:    false,
+			expTotal:  14,
+			expRanges: []string{"fd00::3-fd00::10"},
+		},
+		{
+			name: "case multi exclude",
+			base: "fd00::/64",
+			ranges: []string{
+				"fd00::1-fd00::10",
+				"fd00::11-fd00::20",
+				"fd00::21-fd00::30",
+			},
+			exclude: []string{
+				"fd00::1-fd00::2",
+				"fd00::8-fd00::22",
+			},
+			expErr:   false,
+			expTotal: 19,
+			expRanges: []string{
+				"fd00::3-fd00::7",
+				"fd00::23-fd00::30",
+			},
+		},
+		{
+			name: "case for overlap ranges",
+			base: "fd12:3456:789a:baba::/64",
+			ranges: []string{
+				"fd12:3456:789a:baba::1-fd12:3456:789a:baba:ffff:ffff:ffff:ffff",
+			},
+			exclude: []string{
+				"fd12:3456:789a:baba::1-fd12:3456:789a:baba::10",
+			},
+			expErr:   false,
+			expTotal: 9223372036854775807,
+			expRanges: []string{
+				"fd12:3456:789a:baba::11-fd12:3456:789a:baba:ffff:ffff:ffff:ffff",
+			},
+			overlapIPRanges: []string{"fd12:3456:789a:baba::11-fd12:3456:789a:baba::12"},
+			expIsOverlap:    true,
+		},
+	}
+
+	for _, c := range testCases {
+		c := c // capture range variable
+		It(c.name, func() {
+			subnet, err := NewCIDR(c.base, c.ranges, c.exclude)
+			if c.expErr {
+				Expect(err).To(HaveOccurred())
+				return
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			Expect(subnet.TotalIPInt()).To(Equal(c.expTotal))
+
+			var expRanges []Range
+			for _, raw := range c.expRanges {
+				start, end, err := subnet.parse(raw)
+				Expect(err).NotTo(HaveOccurred())
+				expRanges = append(expRanges, Range{Raw: raw, Start: start, End: end})
+			}
+
+			Expect(compareRanges(subnet.IPRange(), expRanges)).To(BeTrue())
+
+			var overlapIPRanges []Range
+			for _, raw := range c.overlapIPRanges {
+				start, end, err := subnet.parse(raw)
+				Expect(err).NotTo(HaveOccurred(), "case - %v, error parsing range %v: %v", c.name, raw, err)
+				overlapIPRanges = append(overlapIPRanges, Range{Raw: raw, Start: start, End: end})
+			}
+
+			_, isOverlap := subnet.IsOverlapIPRanges(overlapIPRanges)
+			Expect(isOverlap).To(Equal(c.expIsOverlap), "case - %v, expected overlap %v but got %v", c.name, c.expIsOverlap, isOverlap)
+		})
+	}
+})
+
+func compareRanges(a, b []Range) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	mapA := make(map[string]Range)
+	mapB := make(map[string]Range)
+
+	for _, r := range a {
+		mapA[r.Start.String()+"-"+r.End.String()] = r
+	}
+	for _, r := range b {
+		mapB[r.Start.String()+"-"+r.End.String()] = r
+	}
+
+	for key, rangeA := range mapA {
+		rangeB, exists := mapB[key]
+		if !exists || rangeA.Start.Cmp(rangeB.Start) != 0 || rangeA.End.Cmp(rangeB.End) != 0 {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/ippoolmanager/ippool_informer.go
+++ b/pkg/ippoolmanager/ippool_informer.go
@@ -317,14 +317,14 @@ func (ic *IPPoolController) syncHandler(ctx context.Context, pool *spiderpoolv2b
 		informerLogger.Sugar().Infof("initial SpiderIPPool '%s' status AllocatedIPCount to 0", pool.Name)
 	}
 
-	totalIPs, err := spiderpoolip.AssembleTotalIPs(*pool.Spec.IPVersion, pool.Spec.IPs, pool.Spec.ExcludeIPs)
-	if nil != err {
+	subnet, err := spiderpoolip.NewCIDR(pool.Spec.Subnet, pool.Spec.IPs, pool.Spec.ExcludeIPs)
+	if err != nil {
 		return fmt.Errorf("%w: failed to calculate SpiderIPPool '%s' total IP count, error: %v", constant.ErrWrongInput, pool.Name, err)
 	}
-
-	if pool.Status.TotalIPCount == nil || *pool.Status.TotalIPCount != int64(len(totalIPs)) {
+	total := subnet.TotalIPInt()
+	if pool.Status.TotalIPCount == nil || *pool.Status.TotalIPCount != int64(total) {
 		needUpdate = true
-		pool.Status.TotalIPCount = ptr.To(int64(len(totalIPs)))
+		pool.Status.TotalIPCount = ptr.To(int64(total))
 	}
 
 	if needUpdate {

--- a/pkg/ippoolmanager/ippool_validate.go
+++ b/pkg/ippoolmanager/ippool_validate.go
@@ -25,7 +25,6 @@ var (
 	ipVersionField   *field.Path = field.NewPath("spec").Child("ipVersion")
 	subnetField      *field.Path = field.NewPath("spec").Child("subnet")
 	ipsField         *field.Path = field.NewPath("spec").Child("ips")
-	excludeIPsField  *field.Path = field.NewPath("spec").Child("excludeIPs")
 	gatewayField     *field.Path = field.NewPath("spec").Child("gateway")
 	routesField      *field.Path = field.NewPath("spec").Child("routes")
 	podAffinityField *field.Path = field.NewPath("spec").Child("podAffinity")
@@ -229,19 +228,9 @@ func (iw *IPPoolWebhook) validateIPPoolCIDR(ctx context.Context, ipPool *spiderp
 }
 
 func (iw *IPPoolWebhook) validateIPPoolAvailableIPs(ctx context.Context, ipPool *spiderpoolv2beta1.SpiderIPPool) *field.Error {
-	if err := iw.validateIPPoolIPs(*ipPool.Spec.IPVersion, ipPool.Spec.Subnet, ipPool.Spec.IPs); err != nil {
-		return err
-	}
-	if err := validateIPPoolExcludeIPs(*ipPool.Spec.IPVersion, ipPool.Spec.Subnet, ipPool.Spec.ExcludeIPs); err != nil {
-		return err
-	}
-
-	newIPs, err := spiderpoolip.AssembleTotalIPs(*ipPool.Spec.IPVersion, ipPool.Spec.IPs, ipPool.Spec.ExcludeIPs)
+	newPool, err := spiderpoolip.NewCIDR(ipPool.Spec.Subnet, ipPool.Spec.IPs, ipPool.Spec.ExcludeIPs)
 	if err != nil {
-		return field.InternalError(ipsField, fmt.Errorf("failed to assemble the total IP addresses of the IPPool %s: %v", ipPool.Name, err))
-	}
-	if len(newIPs) == 0 {
-		return nil
+		return field.Invalid(subnetField, ipPool.Spec.Subnet, err.Error())
 	}
 
 	cidr, err := spiderpoolip.CIDRToLabelValue(*ipPool.Spec.IPVersion, ipPool.Spec.Subnet)
@@ -260,39 +249,16 @@ func (iw *IPPoolWebhook) validateIPPoolAvailableIPs(ctx context.Context, ipPool 
 
 	for _, pool := range ipPoolList.Items {
 		if pool.Name != ipPool.Name {
-			existIPs, err := spiderpoolip.AssembleTotalIPs(*pool.Spec.IPVersion, pool.Spec.IPs, pool.Spec.ExcludeIPs)
+			existPool, err := spiderpoolip.NewCIDR(pool.Spec.Subnet, pool.Spec.IPs, pool.Spec.ExcludeIPs)
 			if err != nil {
-				return field.InternalError(ipsField, fmt.Errorf("failed to assemble the total IP addresses of the existing IPPool %s: %v", pool.Name, err))
+				return field.Invalid(subnetField, pool.Spec.Subnet, err.Error())
 			}
-
-			overlapIPs := spiderpoolip.IPsIntersectionSet(newIPs, existIPs, false)
-			if len(overlapIPs) > 0 {
-				overlapRanges, _ := spiderpoolip.ConvertIPsToIPRanges(*pool.Spec.IPVersion, overlapIPs)
+			if overlapRanges, isOverlap := newPool.IsOverlapIPRanges(existPool.IPRange()); isOverlap {
 				return field.Forbidden(
 					ipsField,
 					fmt.Sprintf("overlap with IPPool %s in IP ranges %v, total IP addresses of an IPPool are jointly determined by 'spec.ips' and 'spec.excludeIPs'", pool.Name, overlapRanges),
 				)
 			}
-		}
-	}
-
-	return nil
-}
-
-func (iw *IPPoolWebhook) validateIPPoolIPs(version types.IPVersion, subnet string, ips []string) *field.Error {
-	for i, r := range ips {
-		if err := ValidateContainsIPRange(ipsField.Index(i), version, subnet, r); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func validateIPPoolExcludeIPs(version types.IPVersion, subnet string, excludeIPs []string) *field.Error {
-	for i, r := range excludeIPs {
-		if err := ValidateContainsIPRange(excludeIPsField.Index(i), version, subnet, r); err != nil {
-			return err
 		}
 	}
 

--- a/pkg/subnetmanager/subnet_informer.go
+++ b/pkg/subnetmanager/subnet_informer.go
@@ -486,7 +486,7 @@ func (sc *SubnetController) syncControlledIPPoolIPs(ctx context.Context, subnet 
 			} else {
 				_, err := sc.IPPoolsLister.Get(poolName)
 				if apierrors.IsNotFound(err) {
-					logger.Sugar().Infof("The Application %v corresponding to the auto-created IPPool %s no longer exists, remove the pre-allocation from Subnet", appNamespacedName, poolName)
+					logger.Sugar().Infof("The Application %v corresponding to the auto-created Subnet %s no longer exists, remove the pre-allocation from CIDR", appNamespacedName, poolName)
 					// discard the legacy allocation for subnet.status
 					continue
 				}

--- a/pkg/subnetmanager/subnet_manager.go
+++ b/pkg/subnetmanager/subnet_manager.go
@@ -407,8 +407,7 @@ func (sm *subnetManager) preAllocateIPsFromSubnet(ctx context.Context, subnet *s
 }
 
 func subnetStatusCount(subnet *spiderpoolv2beta1.SpiderSubnet) (totalCount, allocatedCount int64) {
-	// total IP Count
-	subnetTotalIPs, _ := spiderpoolip.AssembleTotalIPs(*subnet.Spec.IPVersion, subnet.Spec.IPs, subnet.Spec.ExcludeIPs)
+	s, _ := spiderpoolip.NewCIDR(subnet.Spec.Subnet, subnet.Spec.IPs, subnet.Spec.ExcludeIPs)
 
 	if subnet.Status.ControlledIPPools == nil {
 		return 0, 0
@@ -425,5 +424,5 @@ func subnetStatusCount(subnet *spiderpoolv2beta1.SpiderSubnet) (totalCount, allo
 		tmpIPs, _ := spiderpoolip.ParseIPRanges(*subnet.Spec.IPVersion, poolAllocation.IPs)
 		allocatedIPCount += int64(len(tmpIPs))
 	}
-	return int64(len(subnetTotalIPs)), allocatedIPCount
+	return int64(s.TotalIPInt()), allocatedIPCount
 }

--- a/pkg/subnetmanager/subnet_webhook_test.go
+++ b/pkg/subnetmanager/subnet_webhook_test.go
@@ -397,7 +397,7 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 					Expect(warns).To(BeNil())
 				})
 
-				It("creates IPv4 Subnet but IPv4 is disbale'", func() {
+				It("creates IPv4 Subnet but IPv4 is disable", func() {
 					subnetWebhook.EnableIPv4 = false
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
@@ -413,7 +413,7 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 					Expect(warns).To(BeNil())
 				})
 
-				It("creates IPv6 Subnet but IPv6 is disbale'", func() {
+				It("creates IPv6 Subnet but IPv6 is disable", func() {
 					subnetWebhook.EnableIPv6 = false
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv6)
 					subnetT.Spec.Subnet = "adbc:1234::/120"
@@ -975,7 +975,7 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 					Expect(warns).To(BeNil())
 				})
 
-				It("updates IPv4 Subnet but IPv4 is disbale'", func() {
+				It("updates IPv4 Subnet but IPv4 is disable", func() {
 					subnetWebhook.EnableIPv4 = false
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
@@ -989,7 +989,7 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 					Expect(warns).To(BeNil())
 				})
 
-				It("updates IPv6 Subnet but IPv6 is disbale'", func() {
+				It("updates IPv6 Subnet but IPv6 is disable", func() {
 					subnetWebhook.EnableIPv6 = false
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv6)
 					subnetT.Spec.Subnet = "adbc:1234::/120"

--- a/test/doc/ippoolcr.md
+++ b/test/doc/ippoolcr.md
@@ -1,7 +1,7 @@
 # E2E Cases for IPPool CR
 
 | Case ID | Title                                                                                                                                  | Priority | Smoke | Status | Other |
-| ------- |----------------------------------------------------------------------------------------------------------------------------------------|----------|-------|--------| ----- |
+|---------|----------------------------------------------------------------------------------------------------------------------------------------|----------|-------|--------|-------|
 | D00001  | An IPPool fails to add an IP that already exists in an other IPPool                                                                    | p2       |       | done   |       |
 | D00002  | Add a route with `routes` and `gateway` fields in the ippool spec, which only takes effect on the new pod and does not on the old pods | p2       | smoke | done   |       |
 | D00003  | Failed to add wrong IPPool gateway and route to an IPPool CR                                                                           | p2       |       | done   |       |
@@ -18,3 +18,5 @@
 | D00014  | The namespace where the pod is located matches the namespaceName, and the IP can be assigned                                           | p2       |       | done   |       |
 | D00015  | The namespace where the pod resides does not match the namespaceName, and the IP cannot be assigned                                    | p2       |       | done   |       |
 | D00016  | namespaceName has higher priority than namespaceAffinity                                                                               | p3       |       | done   |       |
+| D00017  | Large IPv6 pool, correct statistics of IP number.                                                                                      | p3       |       | done   |       |
+

--- a/test/e2e/reclaim/reclaim_test.go
+++ b/test/e2e/reclaim/reclaim_test.go
@@ -459,7 +459,7 @@ var _ = Describe("test ip with reclaim ip case", Label("reclaim"), func() {
 				}
 			})
 		})
-		DescribeTable("dirty IP record in the IPPool should be auto clean by Spiderpool", func() {
+		DescribeTable("dirty IP record in the IPPool should be auto clean by Spiderpool", Pending, func() {
 			// Generate IPPool annotation string
 			podIppoolAnnoStr := common.GeneratePodIPPoolAnnotations(frame, common.NIC1, v4poolNameList, v6poolNameList)
 


### PR DESCRIPTION
## Changes
- calculator pool use big int
- update the number of total to CRD `.status` use `TotalInt() int`
    - if we update CRD `total` filed to string, we can change the method to `Total() *big.Int` once.

## TODO
- [x] Test