### PR TITLE
fix: Optimize CI machine disk cleanup method to avoid no space left

### DIFF
--- a/.github/workflows/e2e-init.yaml
+++ b/.github/workflows/e2e-init.yaml
@@ -56,15 +56,22 @@ jobs:
           echo "=========Current system kernel================="
           uname -r
 
-      - name: Free disk space
+      - name: Free Disk Space (Ubuntu)
+        # https://github.com/spidernet-io/spiderpool/issues/3277
         # https://github.com/actions/virtual-environments/issues/709
-        run: |
-          echo "=========original CI disk space"
-          df -h
-          sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-          echo "=========after clean up, the left CI disk space"
-          df -h
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+          # all of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
 
       - name: Prepare
         id: prepare


### PR DESCRIPTION
## Thanks for contributing!

<!--Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>-->

#### What type of PR is this?

<!--
Add one of the following kinds:

Required labels:

- release/none 
- release/bug 
- release/feature

Optional labels:

- kind/bug
- kind/feature
- kind/ci-bug
- kind/doc
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3846 
#3845 

**Special notes for your reviewer**:
在原本的代码中，清理磁盘空间比较简单，
```
          sudo rm -rf "/usr/local/share/boost"
          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
          echo "=========after clean up, the left CI disk space"
```

并未清理出足够的空间，新的 CI 中，我们借助于 jlumbroso/free-disk-space@main ，帮助深度清理 vm 磁盘，可以留出足够的空间帮助运行 CI。

如下是，清理后，并且运行了部署 kind 集群后的可用空间
<img width="832" alt="image" src="https://github.com/user-attachments/assets/63c3a0c0-467d-4a53-a0d5-54200b7f63ac">
