### PR TITLE
coordinator: fix wrong policy route when there is more than 1 secondary nics

### DIFF
--- a/api/v1/agent/models/coordinator_config.go
+++ b/api/v1/agent/models/coordinator_config.go
@@ -48,9 +48,6 @@ type CoordinatorConfig struct {
 	// pod m a c prefix
 	PodMACPrefix string `json:"podMACPrefix,omitempty"`
 
-	// pod n i cs
-	PodNICs []string `json:"podNICs"`
-
 	// pod r p filter
 	PodRPFilter int64 `json:"podRPFilter,omitempty"`
 

--- a/api/v1/agent/openapi.yaml
+++ b/api/v1/agent/openapi.yaml
@@ -344,10 +344,6 @@ definitions:
         type: boolean
       detectGateway:
         type: boolean
-      podNICs:
-        type: array
-        items:
-          type: string
     required:
       - overlayPodCIDR
       - serviceCIDR

--- a/api/v1/agent/server/embedded_spec.go
+++ b/api/v1/agent/server/embedded_spec.go
@@ -321,12 +321,6 @@ func init() {
         "podMACPrefix": {
           "type": "string"
         },
-        "podNICs": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
         "podRPFilter": {
           "type": "integer"
         },
@@ -878,12 +872,6 @@ func init() {
         },
         "podMACPrefix": {
           "type": "string"
-        },
-        "podNICs": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
         },
         "podRPFilter": {
           "type": "integer"

--- a/cmd/spiderpool-agent/cmd/coordinator.go
+++ b/cmd/spiderpool-agent/cmd/coordinator.go
@@ -28,7 +28,6 @@ func (g *_unixGetCoordinatorConfig) Handle(params daemonset.GetCoordinatorConfig
 	ctx := params.HTTPRequest.Context()
 	crdClient := agentContext.CRDManager.GetClient()
 	podClient := agentContext.PodManager
-	epClient := agentContext.EndpointManager
 	kubevirtMgr := agentContext.KubevirtManager
 
 	var coordList spiderpoolv2beta1.SpiderCoordinatorList
@@ -46,8 +45,6 @@ func (g *_unixGetCoordinatorConfig) Handle(params daemonset.GetCoordinatorConfig
 	}
 
 	var err error
-	var spNics []string
-	var se *spiderpoolv2beta1.SpiderEndpoint
 
 	var pod *corev1.Pod
 	pod, err = podClient.GetPodByName(ctx, params.GetCoordinatorConfig.PodNamespace, params.GetCoordinatorConfig.PodName, constant.UseCache)
@@ -57,17 +54,9 @@ func (g *_unixGetCoordinatorConfig) Handle(params daemonset.GetCoordinatorConfig
 
 	isVMPod := false
 	// kubevirt vm pod corresponding SpiderEndpoint uses kubevirt VM/VMI name
-	endpointName := params.GetCoordinatorConfig.PodName
 	ownerReference := metav1.GetControllerOf(pod)
 	if ownerReference != nil && agentContext.Cfg.EnableKubevirtStaticIP && ownerReference.APIVersion == kubevirtv1.SchemeGroupVersion.String() && ownerReference.Kind == constant.KindKubevirtVMI {
-		endpointName = ownerReference.Name
 		isVMPod = true
-	}
-
-	// get spiderendpoint
-	se, err = epClient.GetEndpointByName(ctx, params.GetCoordinatorConfig.PodNamespace, endpointName, constant.UseCache)
-	if err != nil && !apierrors.IsNotFound(err) {
-		return daemonset.NewGetCoordinatorConfigFailure().WithPayload(models.Error(fmt.Sprintf("failed to get spiderendpoint %s/%s", params.GetCoordinatorConfig.PodNamespace, params.GetCoordinatorConfig.PodName)))
 	}
 
 	// cancel IP conflict detection for the kubevirt vm live migration new pod
@@ -92,12 +81,6 @@ func (g *_unixGetCoordinatorConfig) Handle(params daemonset.GetCoordinatorConfig
 				logger.Sugar().Infof("cancel IP conflict detection for live migration new pod '%s/%s'", pod.Namespace, pod.Name)
 				detectIPConflict = false
 			}
-		}
-	}
-
-	if se != nil {
-		for _, spip := range se.Status.Current.IPs {
-			spNics = append(spNics, spip.NIC)
 		}
 	}
 
@@ -129,7 +112,6 @@ func (g *_unixGetCoordinatorConfig) Handle(params daemonset.GetCoordinatorConfig
 		TxQueueLen:         int64(*coord.Spec.TxQueueLen),
 		DetectGateway:      *coord.Spec.DetectGateway,
 		DetectIPConflict:   detectIPConflict,
-		PodNICs:            spNics,
 	}
 
 	if config.OverlayPodCIDR == nil {

--- a/docs/usage/install/overlay/get-started-calico-zh_cn.md
+++ b/docs/usage/install/overlay/get-started-calico-zh_cn.md
@@ -269,8 +269,8 @@ nginx-4653bc4f24-aswpm   net1        10-6-v4             10.6.212.148/16        
        valid_lft forever preferred_lft forever
 /# ip rule
 0: from all lookup local
-32760: from 10.6.212.132 lookup 100
-32762: from 10.233.73.210 lookup 500
+32760: from 10.6.212.132 lookup 101
+32762: from 10.233.73.210 lookup 100
 32766: from all lookup main
 32767: from all lookup default
 /# ip route
@@ -280,13 +280,13 @@ default via 169.254.1.1 dev eth0
 10.233.0.0/18 via 10.6.212.132 dev eth0 
 10.233.64.0/18 via 10.6.212.132 dev eth0
 169.254.1.1 dev eth0 scope link
-/ # ip route show table 100
+/ # ip route show table 101
 default via 10.6.0.1 dev net1
 10.6.0.0/16 dev net1 scope link  src 10.6.212.145
 10.6.212.132 dev eth0 scope link
 10.233.0.0/18 via 10.6.212.132 dev eth0 
 10.233.64.0/18 via 10.6.212.132 dev eth0
-/ # ip route show table 500
+/ # ip route show table 100
 default via 169.254.1.1 dev eth0
 ```
 
@@ -302,7 +302,7 @@ default via 169.254.1.1 dev eth0
 >
 > 在默认情况下，Pod 的默认路由保留在 eth0。如果想要保留在其他网卡(如 net1)，可以通过在 Pod 的 annotations 中注入: "ipam.spidernet.io/default-route-nic: net1" 实现。
 > 
-> 对于默认路由在 eth0 的场景，pod 中会存在一条 table 为 500 的策略路由， 该路由确保从 eth0 接收的流量从 eth0 转发，防止来回路径不一致导致丢包。
+> 对于默认路由在 eth0 的场景，pod 中会存在一条 table 为 100 的策略路由， 该路由确保从 eth0 接收的流量从 eth0 转发，防止来回路径不一致导致丢包。
 
 下面测试 Pod 基本网络连通性，以访问 CoreDNS 的 Pod 和 Service 为例:
 

--- a/docs/usage/install/overlay/get-started-calico.md
+++ b/docs/usage/install/overlay/get-started-calico.md
@@ -264,8 +264,8 @@ Enter the Pod and use the command `ip` to view information such as IP addresses 
        valid_lft forever preferred_lft forever
 /# ip rule
 0: from all lookup local
-32760: from 10.6.212.132 lookup 100
-32762: from 10.233.73.210 lookup 500
+32760: from 10.6.212.132 lookup 101
+32762: from 10.233.73.210 lookup 100
 32766: from all lookup main
 32767: from all lookup default
 /# ip route
@@ -275,13 +275,13 @@ default via 169.254.1.1 dev eth0
 10.233.0.0/18 via 10.6.212.132 dev eth0 
 10.233.64.0/18 via 10.6.212.132 dev eth0
 169.254.1.1 dev eth0 scope link
-/ # ip route show table 100
+/ # ip route show table 101
 default via 10.6.0.1 dev net1
 10.6.0.0/16 dev net1 scope link  src 10.6.212.145
 10.6.212.132 dev eth0 scope link
 10.233.0.0/18 via 10.6.212.132 dev eth0 
 10.233.64.0/18 via 10.6.212.132 dev eth0
-/ # ip route show table 500
+/ # ip route show table 100
 default via 169.254.1.1 dev eth0
 ```
 
@@ -297,7 +297,7 @@ Explanation of the above:
 >
 > By default, the Pod's default route is reserved in eth0. To reserve it in net1, add the following annotation to the Pod's metadata: "ipam.spidernet.io/default-route-nic: net1".
 > 
-> If the default route is eth0, a policy-based route with table 500 exists in the pod. This route ensures that traffic received from eth0 is forwarded from eth0 to prevent packet loss caused by inconsistent forward and return paths.
+> If the default route is eth0, a policy-based route with table 100 exists in the pod. This route ensures that traffic received from eth0 is forwarded from eth0 to prevent packet loss caused by inconsistent forward and return paths.
 
 To test the basic network connectivity of the Pod, we will use the example of accessing the CoreDNS Pod and Service:
 

--- a/docs/usage/install/overlay/get-started-cilium-zh_cn.md
+++ b/docs/usage/install/overlay/get-started-cilium-zh_cn.md
@@ -269,8 +269,8 @@ nginx-4653bc4f24-ougjk   net1        10-6-v4             10.6.212.230/16        
        valid_lft forever preferred_lft forever
 / # ip rule
 0: from all lookup local
-32760: from 10.6.212.131  lookup 100
-32762：from 10.233.120.101 lookup 500
+32760: from 10.6.212.131  lookup 101
+32762：from 10.233.120.101 lookup 100
 32766: from all lookup main
 32767: from all lookup default
 / # ip route
@@ -280,14 +280,14 @@ default via 10.233.65.96 dev eth0
 10.233.0.0/18 via 10.6.212.132 dev eth0 
 10.233.64.0/18 via 10.6.212.132 dev eth0
 10.6.0.0/16 dev net1 scope link  src 10.6.212.202
-/ # ip route show table 100
+/ # ip route show table 101
 default via 10.6.0.1 dev net1
 10.6.0.0/16 dev net1 scope link  src 10.6.212.202
 10.233.65.96 dev eth0 scope link
 10.6.212.131 dev eth0 scope link
 10.233.0.0/18 via 10.6.212.132 dev eth0 
 10.233.64.0/18 via 10.6.212.132 dev eth0
-/ # ip route show table 500
+/ # ip route show table 100
 default via 10.233.65.96 dev eth0
 ```
 
@@ -303,7 +303,7 @@ default via 10.233.65.96 dev eth0
 >
 > 在默认情况下，Pod 的默认路由保留在 eth0。如果想要保留在 net1，可以通过在 Pod 的 annotations 中注入: "ipam.spidernet.io/default-route-nic: net1" 实现。
 > 
-> 对于默认路由在 eth0 的场景，pod 中会存在一条 table 为 500 的策略路由， 该路由确保从 eth0 接收的流量从 eth0 转发，防止来回路径不一致导致丢包。
+> 对于默认路由在 eth0 的场景，pod 中会存在一条 table 为 100 的策略路由， 该路由确保从 eth0 接收的流量从 eth0 转发，防止来回路径不一致导致丢包。
 
 测试 Pod 访问集群东西向流量的连通性，以访问 CoreDNS 的 Pod 和 Service 为例:
 

--- a/docs/usage/install/overlay/get-started-cilium.md
+++ b/docs/usage/install/overlay/get-started-cilium.md
@@ -265,8 +265,8 @@ Use the command `ip` to view the Pod's information such as routes:
        valid_lft forever preferred_lft forever
 / # ip rule
 0: from all lookup local
-32760: from 10.6.212.131  lookup 100
-32762：from 10.233.120.101 lookup 500
+32760: from 10.6.212.131  lookup 101
+32762：from 10.233.120.101 lookup 100
 32766: from all lookup main
 32767: from all lookup default
 / # ip route
@@ -276,14 +276,14 @@ default via 10.233.65.96 dev eth0
 10.233.0.0/18 via 10.6.212.132 dev eth0 
 10.233.64.0/18 via 10.6.212.132 dev eth0
 10.6.0.0/16 dev net1 scope link  src 10.6.212.202
-/ # ip route show table 100
+/ # ip route show table 101
 default via 10.6.0.1 dev net1
 10.6.0.0/16 dev net1 scope link  src 10.6.212.202
 10.233.65.96 dev eth0 scope link
 10.6.212.131 dev eth0 scope link
 10.233.0.0/18 via 10.6.212.132 dev eth0 
 10.233.64.0/18 via 10.6.212.132 dev eth0
-/ # ip route show table 500
+/ # ip route show table 100
 default via 10.233.65.96 dev eth0
 ```
 
@@ -299,7 +299,7 @@ Explanation of the above:
 >
 > By default, the Pod's default route is reserved in eth0. To reserve it in net1, add the following annotation to the Pod's metadata: "ipam.spidernet.io/default-route-nic: net1".
 > 
-> If the default route is eth0, a policy-based route with table 500 exists in the pod. This route ensures that traffic received from eth0 is forwarded from eth0 to prevent packet loss caused by inconsistent forward and return paths.
+> If the default route is eth0, a policy-based route with table 100 exists in the pod. This route ensures that traffic received from eth0 is forwarded from eth0 to prevent packet loss caused by inconsistent forward and return paths.
 
 To test the east-west connectivity of the Pod, we will use the example of accessing the CoreDNS Pod and Service:
 

--- a/pkg/networking/networking/ip.go
+++ b/pkg/networking/networking/ip.go
@@ -174,6 +174,42 @@ func isInterfaceExist(iface string) (bool, error) {
 	}
 }
 
+func GetUPLinkList(netns ns.NetNS) ([]netlink.Link, error) {
+	var err error
+	var links []netlink.Link
+	if netns != nil {
+		if err := netns.Do(func(nn ns.NetNS) error {
+			links, err = netlink.LinkList()
+			return err
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	// only include devices in up|broadcast|multicast state
+	// include:
+	//   example: eth0/net1, flag: up|broadcast|multicast
+	// exclude:
+	//   lo, flags: up|loopback
+	//   tunl0: flags: 0
+	res := make([]netlink.Link, 0)
+	for _, link := range links {
+		if link.Attrs().Flags&net.FlagUp == 0 {
+			continue
+		}
+
+		if link.Attrs().Flags&net.FlagBroadcast == 0 {
+			continue
+		}
+
+		if link.Attrs().Flags&net.FlagMulticast == 0 {
+			continue
+		}
+
+		res = append(res, link)
+	}
+	return res, nil
+}
 func LinkSetBondSlave(slave string, bond *netlink.Bond) error {
 	l, err := netlink.LinkByName(slave)
 	if err != nil {

--- a/test/doc/coordinator.md
+++ b/test/doc/coordinator.md
@@ -22,3 +22,4 @@
 | C00018  | The conflict IPs for stateless Pod should be released                                                                                                         | p3       |       | done   |       |
 | C00019  | The conflict IPs for stateful Pod should not be released                                                                                                      | p3       |       | done   |       |
 | C00020 | kdoctor connectivity should be succeed with annotations: ipam.spidernet.io/default-route-nic: net1 |  p3       |       | done   |       |
+| C00021 | kdoctor connectivity should be succeed with three macvlan interfaces, and set rp_filter to 1 |  p3       |       | done   |       |

--- a/test/e2e/coordinator/macvlan-overlay-one/macvlan_overlay_one_suite_test.go
+++ b/test/e2e/coordinator/macvlan-overlay-one/macvlan_overlay_one_suite_test.go
@@ -3,6 +3,7 @@
 package macvlan_overlay_one_test
 
 import (
+	"fmt"
 	"testing"
 
 	multus_v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -12,7 +13,10 @@ import (
 	e2e "github.com/spidernet-io/e2eframework/framework"
 	spiderpool "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1"
 	"github.com/spidernet-io/spiderpool/test/e2e/common"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 )
 
 func TestMacvlanOverlayOne(t *testing.T) {
@@ -28,13 +32,16 @@ var name string
 var err error
 var delayMs = int64(15000)
 var (
-	task        *kdoctorV1beta1.NetReach
-	netreach    *kdoctorV1beta1.AgentSpec
-	targetAgent *kdoctorV1beta1.NetReachTarget
-	request     *kdoctorV1beta1.NetHttpRequest
-	schedule    *kdoctorV1beta1.SchedulePlan
-	condition   *kdoctorV1beta1.NetSuccessCondition
-	run         = true
+	task           *kdoctorV1beta1.NetReach
+	netreach       *kdoctorV1beta1.AgentSpec
+	targetAgent    *kdoctorV1beta1.NetReachTarget
+	request        *kdoctorV1beta1.NetHttpRequest
+	schedule       *kdoctorV1beta1.SchedulePlan
+	condition      *kdoctorV1beta1.NetSuccessCondition
+	run            = true
+	macvlanVlan0   = "test-macvlan1"
+	macvlanVlan100 = "test-macvlan2"
+	macvlanVlan200 = "test-macvlan3"
 )
 
 var _ = BeforeSuite(func() {
@@ -45,4 +52,36 @@ var _ = BeforeSuite(func() {
 		Skip("overlay CNI is not installed , ignore this suite")
 	}
 
+	// create spidermultusconfig to set rp_filter to 1, which can
+	// better to test the connection
+	for idx, name := range []string{common.MacvlanUnderlayVlan0, common.MacvlanVlan100, common.MacvlanVlan200} {
+		smc, err := frame.GetSpiderMultusInstance(common.MultusNs, name)
+		Expect(err).NotTo(HaveOccurred())
+
+		copy := smc.Spec
+		copy.CoordinatorConfig.HostRPFilter = ptr.To(1)
+		err = frame.CreateSpiderMultusInstance(&spiderpool.SpiderMultusConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("test-macvlan%d", idx+1),
+				Namespace: common.MultusNs,
+			},
+			Spec: copy,
+		})
+
+		if err == nil || apierrors.IsAlreadyExists(err) {
+			GinkgoWriter.Printf("create spiderMultusConfig %s/%s successfully\n", common.MultusNs, fmt.Sprintf("test-macvlan%d", idx+1))
+			continue
+		}
+
+		Expect(err).NotTo(HaveOccurred())
+	}
 })
+
+// var _ = AfterSuite(func() {
+// delete the test spidermultusconfig
+//for idx := range []string{common.MacvlanUnderlayVlan0, common.MacvlanVlan100, common.MacvlanVlan200} {
+//	err = frame.DeleteSpiderMultusInstance(common.MultusNs, fmt.Sprintf("test-macvlan%d", idx+1))
+//	GinkgoWriter.Printf("failed to delete spiderMultusConfig: %v\n", err)
+// Expect(err).NotTo(HaveOccurred())
+//}
+//})

--- a/test/e2e/reclaim/reclaim_test.go
+++ b/test/e2e/reclaim/reclaim_test.go
@@ -587,7 +587,7 @@ var _ = Describe("test ip with reclaim ip case", Label("reclaim"), func() {
 			Expect(frame.DeletePod(podName, namespace)).To(Succeed(), "Failed to delete pod %v/%v\n", namespace, podName)
 			GinkgoWriter.Printf("succeed to delete pod %v/%v\n", namespace, podName)
 		},
-			Entry("a dirty IP record (pod name is wrong or containerID is wrong) in the IPPool should be auto clean by Spiderpool", Serial, Label("G00005", "G00007")),
+			PEntry("a dirty IP record (pod name is wrong or containerID is wrong) in the IPPool should be auto clean by Spiderpool", Serial, Label("G00005", "G00007")),
 		)
 	})
 

--- a/test/scripts/debugEnv.sh
+++ b/test/scripts/debugEnv.sh
@@ -253,8 +253,12 @@ elif [ "$TYPE"x == "detail"x ] ; then
               kubectl exec -ti -n ${NS_NAME} --kubeconfig ${E2E_KUBECONFIG} -- ip -6 rule
               echo "--------------- execute ip route in pod: ${NS_NAME} ------------"
               kubectl exec -ti -n ${NS_NAME} --kubeconfig ${E2E_KUBECONFIG} -- ip route
+              kubectl exec -ti -n ${NS_NAME} --kubeconfig ${E2E_KUBECONFIG} -- ip route show table 100
+              kubectl exec -ti -n ${NS_NAME} --kubeconfig ${E2E_KUBECONFIG} -- ip route show table 101
               echo "--------------- execute ip -6 route in pod: ${NS_NAME} ------------"
               kubectl exec -ti -n ${NS_NAME} --kubeconfig ${E2E_KUBECONFIG} -- ip -6 route
+              kubectl exec -ti -n ${NS_NAME} --kubeconfig ${E2E_KUBECONFIG} -- ip -6 route table 100
+              kubectl exec -ti -n ${NS_NAME} --kubeconfig ${E2E_KUBECONFIG} -- ip -6 route table 101
           done
     fi
 
@@ -268,7 +272,6 @@ elif [ "$TYPE"x == "detail"x ] ; then
       kubectl logs ${POD} -n ${NAMESPACE} --kubeconfig ${E2E_KUBECONFIG} --previous
     done
 
-
     echo ""
     echo "=============== open kruise logs ============== "
     for POD in $KRUISE_POD_LIST ; do
@@ -278,6 +281,11 @@ elif [ "$TYPE"x == "detail"x ] ; then
       echo "--------- kubectl logs ${POD} -n kruise-system --previous"
       kubectl logs ${POD} -n kruise-system --kubeconfig ${E2E_KUBECONFIG} --previous
     done
+    
+    echo ""
+    echo "=============== kdoctor netreach details ============== "
+    kubectl get netreach --kubeconfig ${E2E_KUBECONFIG}
+    kubectl get netreach --kubeconfig ${E2E_KUBECONFIG} -o yaml
 
 elif [ "$TYPE"x == "error"x ] ; then
     CHECK_ERROR(){


### PR DESCRIPTION
## Thanks for contributing!

<!--Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>-->

#### What type of PR is this?

- release/bug 

<!--
Add one of the following kinds:

Required labels:

- release/none 
- release/bug 
- release/feature

Optional labels:

- kind/bug
- kind/feature
- kind/ci-bug
- kind/doc
-->

**What this PR does / why we need it**:

- No longer rely on the API to get the rule number of the NIC, getting it through the API may cause the number to be wrong, which can avoid the wrong policy route when there is more than 1 secondary nics.
- New a netlink.Route object without use of raw object when adding the route, which can avoid netlink return "invalid argument" error.



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/spidernet-io/spiderpool/issues/3877

**Special notes for your reviewer**:
