### PR TITLE
Add chainCNI support for spidermultusconfig

### DIFF
--- a/charts/spiderpool/crds/spiderpool.spidernet.io_spidermultusconfigs.yaml
+++ b/charts/spiderpool/crds/spiderpool.spidernet.io_spidermultusconfigs.yaml
@@ -37,6 +37,12 @@ spec:
           spec:
             description: Spec is the specification of the MultusCNIConfig
             properties:
+              chainCNIJsonData:
+                description: ChainCNIJsonData is used to configure the configuration
+                  of chain CNI. format in json.
+                items:
+                  type: string
+                type: array
               cniType:
                 default: custom
                 enum:

--- a/docs/reference/crd-spidermultusconfig.md
+++ b/docs/reference/crd-spidermultusconfig.md
@@ -62,6 +62,7 @@ This is the SpiderReservedIP spec for users to configure.
 | disableIPAM       | disable IPAM. when set to be true, any configuration of CNI's ippools field will be ignored | boolean                                                                      | optional   | true,false                                    | false    |
 | coordinator       | coordinator CNI configuration                                                               | [CoordinatorSpec](./crd-spidercoordinator.md#spec)                           | optional   |                                               |         |
 | customCNI         | a string that represents custom CNI configuration                                           | string                                                                       | optional   |                                               |         |
+| chainCNIJsonData         | a list of string that represents chain CNI configuration, such as tune plugin.                                           | []string                                                                       | optional   |                                               |         |
 
 #### SpiderMacvlanCniConfig
 

--- a/docs/usage/spider-multus-config.md
+++ b/docs/usage/spider-multus-config.md
@@ -538,6 +538,56 @@ EOF
 
 To create other types of CNI configurations, such OVS, refer to [Ovs](./install/underlay/get-started-ovs.md).
 
+#### ChainCNI 配置
+
+If you need to add ChainCNI to the CNI configuration, for example, you need to use the tuning plug-in to configure the system kernel parameters of the pod (such as net.core.somaxconn, etc.). This can be achieved with the following configuration (MacVlan CNI as an example):
+
+Create a SpiderMultusConfig CR:
+
+```shell
+~# cat << EOF | kubectl apply -f - 
+apiVersion: spiderpool.spidernet.io/v2beta1
+kind: SpiderMultusConfig
+metadata:
+  name: macvlan-conf
+  namespace: kube-system
+spec:
+  cniType: macvlan
+  macvlan:
+    master:
+    - ens192
+  chainCNIJsonData:
+  - |
+    {
+        "type": "tuning",
+        "sysctl": {
+          "net.core.somaxconn": "4096"
+        }
+    }
+EOF
+```
+
+Note that every element of Shanknick Senda must be a legitimate Ethan string, you can refer to as follow manifest. When created, view the corresponding Maltus Netwalk-Atahement-De Finity object:
+
+```shell
+~# kubectl get network-attachment-definitions.k8s.cni.cncf.io -n kube-system macvlan-ens192 -oyaml
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  generation: 1
+  name: macvlan-conf
+  namespace: kube-system
+  ownerReferences:
+  - apiVersion: spiderpool.spidernet.io/v2beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: SpiderMultusConfig
+    name: macvlan-ens192
+    uid: 94bbd704-ff9d-4318-8356-f4ae59856228
+spec:
+  config: '{"cniVersion":"0.3.1","name":"macvlan-ens192","plugins":[{"type":"macvlan","master":"ens192","mode":"bridge","ipam":{"type":"spiderpool"}},{"type":"coordinator"},{"type":"tuning", "sysctl": {"net.core.somaxconn": "4096"}}]}'
+```
+
 ## Conclusion
 
 SpiderMultusConfig CR automates the management of Multus NetworkAttachmentDefinition CRs, improving the experience of creating configurations and reducing operational costs.

--- a/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/spidermultus_types.go
+++ b/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/spidermultus_types.go
@@ -62,6 +62,11 @@ type MultusCNIConfigSpec struct {
 	// +kubebuilder:validation:Optional
 	CoordinatorConfig *CoordinatorSpec `json:"coordinator,omitempty"`
 
+	// ChainCNIJsonData is used to configure the configuration of chain CNI.
+	// format in json.
+	// +kubebuilder:validation:Optional
+	ChainCNIJsonData []string `json:"chainCNIJsonData"`
+
 	// OtherCniTypeConfig only used for CniType custom, valid json format, can be empty
 	// +kubebuilder:validation:Optional
 	CustomCNIConfig *string `json:"customCNI,omitempty"`

--- a/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/zz_generated.deepcopy.go
+++ b/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/zz_generated.deepcopy.go
@@ -381,6 +381,11 @@ func (in *MultusCNIConfigSpec) DeepCopyInto(out *MultusCNIConfigSpec) {
 		*out = new(CoordinatorSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ChainCNIJsonData != nil {
+		in, out := &in.ChainCNIJsonData, &out.ChainCNIJsonData
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.CustomCNIConfig != nil {
 		in, out := &in.CustomCNIConfig, &out.CustomCNIConfig
 		*out = new(string)

--- a/pkg/multuscniconfig/multusconfig_informer.go
+++ b/pkg/multuscniconfig/multusconfig_informer.go
@@ -347,13 +347,20 @@ func generateNetAttachDef(netAttachName string, multusConf *spiderpoolv2beta1.Sp
 	}
 
 	var plugins []interface{}
-
 	// with Kubernetes OpenAPI validation, multusConfSpec.EnableCoordinator must not be nil
 	hasCoordinator := *multusConfSpec.EnableCoordinator
 	if hasCoordinator {
 		coordinatorCNIConf := generateCoordinatorCNIConf(multusConfSpec.CoordinatorConfig)
 		// head insertion later
 		plugins = append(plugins, coordinatorCNIConf)
+	}
+
+	for _, cf := range multusConfSpec.ChainCNIJsonData {
+		var plugin interface{}
+		if err := json.Unmarshal([]byte(cf), &plugin); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal chain cni config %s: %v", cf, err)
+		}
+		plugins = append(plugins, plugin)
 	}
 
 	disableIPAM := false

--- a/pkg/multuscniconfig/multusconfig_mutate.go
+++ b/pkg/multuscniconfig/multusconfig_mutate.go
@@ -47,6 +47,10 @@ func mutateSpiderMultusConfig(ctx context.Context, smc *spiderpoolv2beta1.Spider
 	} else {
 		smc.Spec.CoordinatorConfig = setCoordinatorDefaultConfig(smc.Spec.CoordinatorConfig)
 	}
+
+	if smc.Spec.ChainCNIJsonData == nil {
+		smc.Spec.ChainCNIJsonData = []string{}
+	}
 }
 
 func setMacvlanDefaultConfig(macvlanConfig *spiderpoolv2beta1.SpiderMacvlanCniConfig) {

--- a/test/doc/spidermultus.md
+++ b/test/doc/spidermultus.md
@@ -22,3 +22,5 @@
 | M00018  | set sriov.enableRdma to true and see if multus's nad has rdma config                                                                                    | p3       |       | done   |       |
 | M00019  | set spidermultusconfig.spec to empty and see if works                                                                                                   | p3       |       | done   |       |
 | M00020  | annotating custom names that are too long or empty should fail                                                                                          | p3       |       | done   |       |
+| M00021  |    create a spidermultusconfig and pod to verify chainCNI json config if works                                                                                     | p3       |       | done   |       |
+


### PR DESCRIPTION
## Thanks for contributing!

<!--Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>-->

#### What type of PR is this?

- release/feature

<!--
Add one of the following kinds:

Required labels:

- release/none 
- release/bug 
- release/feature

Optional labels:

- kind/bug
- kind/feature
- kind/ci-bug
- kind/doc
-->

**What this PR does / why we need it**:

Add chainCNI support for spidermultusconfig, In this way, we use a plugin like `tuning` to help configure the kernel parameters of the pod.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/spidernet-io/spiderpool/issues/3919

**Special notes for your reviewer**:

```
root@worker-node-1:/home/cyclinder/spiderpool/charts# cat test-chain-cni.yaml
apiVersion: spiderpool.spidernet.io/v2beta1
kind: SpiderMultusConfig
metadata:
  name: test-chaincni
  namespace: kube-system
spec:
  cniType: macvlan
  coordinator:
    detectGateway: false
    detectIPConflict: false
    hostRPFilter: 1
    hostRuleTable: 500
    mode: auto
    podDefaultRouteNIC: net1
    podMACPrefix: ""
    tunePodRoutes: true
    txQueueLen: 0
  disableIPAM: false
  enableCoordinator: true
  chainCNIJsonData: 
  - | 
    {
      "type": "tuning",
      "sysctl": {
          "net.core.conn.max": "4096"
      }
    }
  macvlan:
    enableRdma: false
    ippools:
      ipv4:
      - default-v4-ippool
      ipv6:
      - default-v6-ippool
    master:
    - eth0
    rdmaResourceName: ""
    vlanID: 0
```

nad:

```
root@worker-node-1:/home/cyclinder/spiderpool/charts# kubectl get network-attachment-definitions.k8s.cni.cncf.io -n kube-system test-chaincni -o json | jq -r '.spec.config' | jq
{
  "cniVersion": "0.3.1",
  "name": "test-chaincni",
  "plugins": [
    {
      "type": "macvlan",
      "master": "eth0",
      "mode": "bridge",
      "ipam": {
        "type": "spiderpool",
        "default_ipv4_ippool": [
          "default-v4-ippool"
        ],
        "default_ipv6_ippool": [
          "default-v6-ippool"
        ]
      }
    },
    {
      "txQueueLen": 0,
      "detectIPConflict": false,
      "detectGateway": false,
      "tunePodRoutes": true,
      "mode": "auto",
      "type": "coordinator",
      "podDefaultRouteNic": "net1"
    },
    [
      {
        "sysctl": {
          "net.core.conn.max": "4096"
        },
        "type": "tuning"
      }
    ]
  ]
}
```
