### PR TITLE
fix: cannot uninstall spiderpool when sriovOperatorConfig is installed

### DIFF
--- a/.github/workflows/e2e-init.yaml
+++ b/.github/workflows/e2e-init.yaml
@@ -205,22 +205,10 @@ jobs:
           path: e2ereport.json
           retention-days: 1
 
-      - name: uninstalls spiderpool
-        id: clean
-        if: ${{ inputs.run_e2e == 'true' }}
-        run: |
-          RESULT=0
-          make clean_e2e_spiderpool || RESULT=1
-          if ((RESULT==0)) ; then
-              echo "CLEAN_E2E_PASS=true" >> $GITHUB_ENV
-          else
-              echo "CLEAN_E2E_PASS=false" >> $GITHUB_ENV
-          fi
-
       - name: Show e2e Result
         if: ${{ inputs.run_e2e == 'true' }}
         run: |
-          if ${{ env.RUN_E2E_PASS == 'true' && env.CLEAN_E2E_PASS == 'true' }} ;then
+          if ${{ env.RUN_E2E_PASS == 'true' }} ;then
               exit 0
           else
               exit 1
@@ -249,3 +237,39 @@ jobs:
           label: performance
           message: ${{ env.PERFORMANCE_RESULT }}
           color: lightgrey
+
+      - name: Uninstall Spiderpool
+        if: ${{ inputs.run_e2e == 'true' }}
+        run: |
+          RESULT=0
+          make clean_e2e_spiderpool || RESULT=1
+          if ((RESULT==0)) ; then
+              echo "UNINSTALL_E2E_PASS=true" >> $GITHUB_ENV
+              echo "succeeded to uninstall spiderpool"
+          else
+              echo "UNINSTALL_E2E_PASS=false" >> $GITHUB_ENV
+              echo "failed to uninstall spiderpool"
+          fi
+
+          if [ -f "test/e2e-uninstall-debugLog.txt" ] ; then
+              echo "UPLOAD_UNINSTALL_E2E_LOG=true" >> $GITHUB_ENV
+          else
+              echo "UPLOAD_UNINSTALL_E2E_LOG=false" >> $GITHUB_ENV
+          fi
+
+      - name: Upload Uninstall Spiderpool e2e log
+        if: ${{ env.UNINSTALL_E2E_PASS == 'false' && env.UPLOAD_UNINSTALL_E2E_LOG == 'true' }}
+        uses: actions/upload-artifact@v3.1.3
+        with:
+          name: ${{ inputs.os }}-${{ inputs.ip_family }}-${{ matrix.e2e_test_mode }}-${{ inputs.k8s_version }}-uninstall-debugLog.txt
+          path: test/e2e-uninstall-debugLog.txt
+          retention-days: 7
+
+      - name: Show uninstall e2e Result
+        if: ${{ inputs.run_e2e == 'true' }}
+        run: |
+          if ${{ env.UNINSTALL_E2E_PASS == 'true' }} ;then
+              exit 0
+          else
+              exit 1
+          fi

--- a/Makefile
+++ b/Makefile
@@ -430,11 +430,11 @@ clean: clean_e2e
 
 .PHONY: clean_e2e_spiderpool
 clean_e2e_spiderpool:
-	-$(QUIET) make -C test uninstall_spiderpool
+	$(QUIET) make -C test uninstall_spiderpool
 
 .PHONY: upgrade_e2e_spiderpool
 upgrade_e2e_spiderpool:
-	-$(QUIET) make -C test upgrade_spiderpool
+	$(QUIET) make -C test upgrade_spiderpool
 
 .PHONY: codegen
 codegen:

--- a/charts/spiderpool/templates/deleteHook.yaml
+++ b/charts/spiderpool/templates/deleteHook.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.spiderpoolController.name | trunc 48 | trimSuffix "-" }}-hook-pre-delete
   annotations:
     "helm.sh/hook": pre-delete
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:
     spec:
@@ -22,6 +22,10 @@ spec:
             - --mutating
             - {{ .Values.spiderpoolController.name | trunc 63 | trimSuffix "-" }}
           env:
+            - name: SPIDERPOOL_POD_NAMESPACE
+              value: {{ .Release.Namespace | quote }}
+            - name: SPIDERPOOL_INIT_NAME
+              value: {{ .Values.spiderpoolInit.name | trunc 63 | trimSuffix "-" | quote }}
             - name: SPIDERPOOL_POD_NAME
               valueFrom:
                 fieldRef:

--- a/charts/spiderpool/templates/role.yaml
+++ b/charts/spiderpool/templates/role.yaml
@@ -46,6 +46,7 @@ rules:
   - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
   verbs:
+  - delete
   - get
   - list
   - watch
@@ -88,6 +89,7 @@ rules:
   - cronjobs
   - jobs
   verbs:
+  - delete
   - get
   - list
   - update

--- a/pkg/constant/k8s.go
+++ b/pkg/constant/k8s.go
@@ -187,3 +187,17 @@ const (
 	DRADriverPluginPath       = "/var/lib/kubelet/plugins/" + DRADriverName
 	DRADriverPluginSocketPath = DRADriverPluginPath + "/plugin.sock"
 )
+
+// spiderpool cleaning sriov
+const (
+	SriovNetworkOperatorAPIGroup                 = "sriovnetwork.openshift.io"
+	SriovOperatorWebhookConfigMutatingOrValidate = "sriov-operator-webhook-config"
+	SriovNetworkResourcesInjectorMutating        = "network-resources-injector-config"
+	SriovNetworkOperatorConfigs                  = "sriovoperatorconfigs.sriovnetwork.openshift.io"
+)
+
+// webhook Mutating or Validating Configuration
+const (
+	MutatingWebhookConfiguration   = "MutatingWebhookConfiguration"
+	ValidatingWebhookConfiguration = "ValidatingWebhookConfiguration"
+)

--- a/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/rbac.go
+++ b/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/rbac.go
@@ -10,12 +10,12 @@
 // +kubebuilder:rbac:groups="apps",resources=statefulsets;deployments;replicasets;daemonsets,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups="resource.k8s.io",resources=resourceclaims;resourceclaims/status;podschedulingcontexts/status;resourceclaimtemplates;resourceclasses;podschedulingcontexts,verbs=get;list;patch;watch;update
 // +kubebuilder:rbac:groups="networking.k8s.io",resources=servicecidrs,verbs=get;list;watch
-// +kubebuilder:rbac:groups="batch",resources=jobs;cronjobs,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups="batch",resources=jobs;cronjobs,verbs=get;list;watch;update;delete
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=namespaces;endpoints;pods;pods/status;configmaps,verbs=get;list;watch;update;patch;delete;deletecollection
 // +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=network-attachment-definitions,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachines;virtualmachineinstances,verbs=get;list
-// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=get;list;watch
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=get;list;watch;delete
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps.kruise.io,resources=clonesets;statefulsets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=crd.projectcalico.org,resources=ippools,verbs=get;list;watch

--- a/pkg/k8s/utils/utils.go
+++ b/pkg/k8s/utils/utils.go
@@ -6,16 +6,12 @@ package utils
 import (
 	"context"
 
-	api_errors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func DeleteWebhookConfiguration(ctx context.Context, c client.Client, name string, obj client.Object) error {
 	err := c.Get(ctx, client.ObjectKey{Name: name}, obj)
 	if err != nil {
-		if api_errors.IsNotFound(err) {
-			return nil
-		}
 		return err
 	}
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -392,8 +392,9 @@ setup_spiderpool:
 uninstall_spiderpool:
 	@echo -e "\033[35m [uninstall spiderpool] \033[0m"
 	@echo -e "\033[35m [helm uninstall spiderpool] \033[0m"
+	echo "=========== after test `date` ===========" >> $(E2E_UNINSTALL_LOG_FILE) ; \
 	helm uninstall $(RELEASE_NAME) --wait --debug -n $(RELEASE_NAMESPACE) \
-	     --kubeconfig $(E2E_KUBECONFIG)  || { KIND_CLUSTER_NAME=$(E2E_CLUSTER_NAME) ./scripts/debugEnv.sh $(E2E_KUBECONFIG) "detail"   ; exit 1 ; } ; \
+	     --kubeconfig $(E2E_KUBECONFIG)  || { KIND_CLUSTER_NAME=$(E2E_CLUSTER_NAME) ./scripts/debugEnv.sh $(E2E_KUBECONFIG) "detail" "$(E2E_UNINSTALL_LOG_FILE)" ; exit 1 ; } ; \
 	echo "Multus config has been cleanup successfully." ; \
 	for ((i=0; i<100; i++)); do \
     	if ! kubectl --kubeconfig=$(E2E_KUBECONFIG) get all --all-namespaces | grep -q "spiderpool" ; then \
@@ -424,7 +425,6 @@ upgrade_spiderpool:
 .PHONY: helm_upgrade_spiderpool
 helm_upgrade_spiderpool:
 	@echo -e "\033[35m [helm upgrade spiderpool] \033[0m"
-	kubectl delete po -n $(RELEASE_NAMESPACE) spiderpool-init --kubeconfig $(E2E_KUBECONFIG) || true ;\
 	HELM_OPTION="";\
 	HELM_OPTION+=" --set spiderpoolController.replicas=1 " ; \
 	if [ "$(INSTALL_OVERLAY_CNI)" == "true" ]; then \

--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -187,6 +187,7 @@ GLOBAL_KIND_CONFIG_PATH := $(ROOT_DIR)/test/yamls/global-kind.yaml
 http_proxy ?=
 
 E2E_LOG_FILE ?= $(ROOT_DIR)/test/e2edebugLog.txt
+E2E_UNINSTALL_LOG_FILE ?= $(ROOT_DIR)/test/e2e-uninstall-debugLog.txt
 
 #========= openkruise =========
 


### PR DESCRIPTION
## Thanks for contributing!

<!--Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>-->

#### What type of PR is this?

<!--
Add one of the following kinds:

Required labels:

- release/none 
- release/bug 
- release/feature

Optional labels:

- kind/bug
- kind/feature
- kind/ci-bug
- kind/doc
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3865

**Special notes for your reviewer**:

#### 主要修复三个问题：

fix #3865 
在原本 clean 流程中，会去删除 sriovoperatorconfigs.sriovnetwork.openshift.io CRD，但当引入 sriovoperatorconfigs 后，如果该 CRD 被删除，helm uninstall sriovoperatorconfigs 会去清理 default 配置，但由于找不到对应的 CRD，从而导致 helm uninstall 失败。为了清理能够成功，能删除 sriov webhook、spiderpool-webhook等（避免再次安装spiderpool 失败），在 clean 中跳过 sriovoperatorconfigs.sriovnetwork.openshift.io CRD 不要删除它。

fix #3958 
在 pr #3880 中的 rbac 删除权限被移除了，导致 clean 删除 webhook 会失败，残留 webhook 会导致再次安装 spiderpool 失败

fix #3960 
在 https://github.com/spidernet-io/spiderpool/pull/3811 将 spiderpool-init 由 Pod 修改为 Job，并启用了 "helm.sh/hook": post-install 功能，但是该功能启用 ，job 运行完成后，它的默认删除机制是 "helm.sh/hook-delete-policy": before-hook-creation ， 运行成功后，将一直残留，它并不会随着 helm uninstall 而被删除。从而导致了卸载 spiderpool 出现额外的 spiderpool-init 资源残留。