### PR TITLE
coordinator: Fix error policy routing table when pod has multi nics

### DIFF
--- a/api/v1/agent/models/coordinator_config.go
+++ b/api/v1/agent/models/coordinator_config.go
@@ -51,9 +51,6 @@ type CoordinatorConfig struct {
 	// pod m a c prefix
 	PodMACPrefix string `json:"podMACPrefix,omitempty"`
 
-	// pod n i cs
-	PodNICs []string `json:"podNICs"`
-
 	// service c ID r
 	// Required: true
 	ServiceCIDR []string `json:"serviceCIDR"`

--- a/api/v1/agent/openapi.yaml
+++ b/api/v1/agent/openapi.yaml
@@ -328,10 +328,6 @@ definitions:
         type: boolean
       detectGateway:
         type: boolean
-      podNICs:
-        type: array
-        items:
-          type: string
     required:
       - overlayPodCIDR
       - serviceCIDR

--- a/api/v1/agent/server/embedded_spec.go
+++ b/api/v1/agent/server/embedded_spec.go
@@ -302,12 +302,6 @@ func init() {
         "podMACPrefix": {
           "type": "string"
         },
-        "podNICs": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
         "serviceCIDR": {
           "type": "array",
           "items": {
@@ -804,12 +798,6 @@ func init() {
         },
         "podMACPrefix": {
           "type": "string"
-        },
-        "podNICs": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
         },
         "serviceCIDR": {
           "type": "array",

--- a/cmd/coordinator/cmd/command_add.go
+++ b/cmd/coordinator/cmd/command_add.go
@@ -99,7 +99,6 @@ func CmdAdd(args *skel.CmdArgs) (err error) {
 		ipFamily:         ipFamily,
 		currentInterface: args.IfName,
 		tuneMode:         conf.Mode,
-		podNics:          coordinatorConfig.PodNICs,
 	}
 	c.HijackCIDR = append(c.HijackCIDR, conf.ServiceCIDR...)
 	c.HijackCIDR = append(c.HijackCIDR, conf.HijackCIDR...)
@@ -116,6 +115,13 @@ func CmdAdd(args *skel.CmdArgs) (err error) {
 		return fmt.Errorf("failed to get current netns: %v", err)
 	}
 	logger.Sugar().Debugf("Get current host netns: %v", c.hostNs.Path())
+
+	// checking if the nic is in up state
+	logger.Sugar().Debugf("checking if %s is in up state", args.IfName)
+	if err = c.checkNICState(args.IfName); err != nil {
+		logger.Error("error to check pod's nic state", zap.Error(err))
+		return fmt.Errorf("error to check pod's nic %s state: %v", args.Args, err)
+	}
 
 	// check if it's first time invoke
 	err = c.coordinatorModeAndFirstInvoke(logger, conf.PodDefaultCniNic)
@@ -273,13 +279,6 @@ func CmdAdd(args *skel.CmdArgs) (err error) {
 		logger.Error("failed to setupNeighborhood", zap.Error(err))
 		return err
 	}
-
-	c.currentRuleTable = c.mustGetRuleNumber(c.podNics)
-	if c.currentRuleTable < 0 {
-		logger.Error("coordinator must be working with spiderpool: no spiderendpoint records found", zap.Strings("spiderNics", c.podNics))
-		return fmt.Errorf("coordinator must be working with spiderpool: no spiderendpoint records found")
-	}
-	logger.Debug("Get currentRuleTable", zap.Int("ruleTable", c.currentRuleTable))
 
 	allPodVethAddrs, err := networking.IPAddressByName(c.netns, defaultOverlayVethName, c.ipFamily)
 	if err != nil {

--- a/docs/usage/install/overlay/get-started-calico-zh_cn.md
+++ b/docs/usage/install/overlay/get-started-calico-zh_cn.md
@@ -267,8 +267,8 @@ nginx-4653bc4f24-aswpm   net1        10-6-v4             10.6.212.148/16        
        valid_lft forever preferred_lft forever
 /# ip rule
 0: from all lookup local
-32760: from 10.6.212.132 lookup 100
-32762: from 10.233.73.210 lookup 500
+32760: from 10.6.212.132 lookup 101
+32762: from 10.233.73.210 lookup 100
 32766: from all lookup main
 32767: from all lookup default
 /# ip route
@@ -278,13 +278,13 @@ default via 169.254.1.1 dev eth0
 10.233.0.0/18 via 10.6.212.132 dev eth0 
 10.233.64.0/18 via 10.6.212.132 dev eth0
 169.254.1.1 dev eth0 scope link
-/ # ip route show table 100
+/ # ip route show table 101
 default via 10.6.0.1 dev net1
 10.6.0.0/16 dev net1 scope link  src 10.6.212.145
 10.6.212.132 dev eth0 scope link
 10.233.0.0/18 via 10.6.212.132 dev eth0 
 10.233.64.0/18 via 10.6.212.132 dev eth0
-/ # ip route show table 500
+/ # ip route show table 100
 default via 169.254.1.1 dev eth0
 ```
 
@@ -300,7 +300,7 @@ default via 169.254.1.1 dev eth0
 >
 > 在默认情况下，Pod 的默认路由保留在 eth0。如果想要保留在其他网卡(如 net1)，可以通过在 Pod 的 annotations 中注入: "ipam.spidernet.io/default-route-nic: net1" 实现。
 > 
-> 对于默认路由在 eth0 的场景，pod 中会存在一条 table 为 500 的策略路由， 该路由确保从 eth0 接收的流量从 eth0 转发，防止来回路径不一致导致丢包。
+> 对于默认路由在 eth0 的场景，pod 中会存在一条 table 为 100 的策略路由， 该路由确保从 eth0 接收的流量从 eth0 转发，防止来回路径不一致导致丢包。
 
 下面测试 Pod 基本网络连通性，以访问 CoreDNS 的 Pod 和 Service 为例:
 

--- a/docs/usage/install/overlay/get-started-calico.md
+++ b/docs/usage/install/overlay/get-started-calico.md
@@ -262,8 +262,8 @@ Enter the Pod and use the command `ip` to view information such as IP addresses 
        valid_lft forever preferred_lft forever
 /# ip rule
 0: from all lookup local
-32760: from 10.6.212.132 lookup 100
-32762: from 10.233.73.210 lookup 500
+32760: from 10.6.212.132 lookup 101
+32762: from 10.233.73.210 lookup 100
 32766: from all lookup main
 32767: from all lookup default
 /# ip route
@@ -273,13 +273,13 @@ default via 169.254.1.1 dev eth0
 10.233.0.0/18 via 10.6.212.132 dev eth0 
 10.233.64.0/18 via 10.6.212.132 dev eth0
 169.254.1.1 dev eth0 scope link
-/ # ip route show table 100
+/ # ip route show table 101
 default via 10.6.0.1 dev net1
 10.6.0.0/16 dev net1 scope link  src 10.6.212.145
 10.6.212.132 dev eth0 scope link
 10.233.0.0/18 via 10.6.212.132 dev eth0 
 10.233.64.0/18 via 10.6.212.132 dev eth0
-/ # ip route show table 500
+/ # ip route show table 100
 default via 169.254.1.1 dev eth0
 ```
 
@@ -295,7 +295,7 @@ Explanation of the above:
 >
 > By default, the Pod's default route is reserved in eth0. To reserve it in net1, add the following annotation to the Pod's metadata: "ipam.spidernet.io/default-route-nic: net1".
 > 
-> If the default route is eth0, a policy-based route with table 500 exists in the pod. This route ensures that traffic received from eth0 is forwarded from eth0 to prevent packet loss caused by inconsistent forward and return paths.
+> If the default route is eth0, a policy-based route with table 100 exists in the pod. This route ensures that traffic received from eth0 is forwarded from eth0 to prevent packet loss caused by inconsistent forward and return paths.
 
 To test the basic network connectivity of the Pod, we will use the example of accessing the CoreDNS Pod and Service:
 

--- a/docs/usage/install/overlay/get-started-cilium-zh_cn.md
+++ b/docs/usage/install/overlay/get-started-cilium-zh_cn.md
@@ -265,8 +265,8 @@ nginx-4653bc4f24-ougjk   net1        10-6-v4             10.6.212.230/16        
        valid_lft forever preferred_lft forever
 / # ip rule
 0: from all lookup local
-32760: from 10.6.212.131  lookup 100
-32762：from 10.233.120.101 lookup 500
+32760: from 10.6.212.131  lookup 101
+32762：from 10.233.120.101 lookup 100
 32766: from all lookup main
 32767: from all lookup default
 / # ip route
@@ -276,14 +276,14 @@ default via 10.233.65.96 dev eth0
 10.233.0.0/18 via 10.6.212.132 dev eth0 
 10.233.64.0/18 via 10.6.212.132 dev eth0
 10.6.0.0/16 dev net1 scope link  src 10.6.212.202
-/ # ip route show table 100
+/ # ip route show table 101
 default via 10.6.0.1 dev net1
 10.6.0.0/16 dev net1 scope link  src 10.6.212.202
 10.233.65.96 dev eth0 scope link
 10.6.212.131 dev eth0 scope link
 10.233.0.0/18 via 10.6.212.132 dev eth0 
 10.233.64.0/18 via 10.6.212.132 dev eth0
-/ # ip route show table 500
+/ # ip route show table 100
 default via 10.233.65.96 dev eth0
 ```
 
@@ -299,7 +299,7 @@ default via 10.233.65.96 dev eth0
 >
 > 在默认情况下，Pod 的默认路由保留在 eth0。如果想要保留在 net1，可以通过在 Pod 的 annotations 中注入: "ipam.spidernet.io/default-route-nic: net1" 实现。
 > 
-> 对于默认路由在 eth0 的场景，pod 中会存在一条 table 为 500 的策略路由， 该路由确保从 eth0 接收的流量从 eth0 转发，防止来回路径不一致导致丢包。
+> 对于默认路由在 eth0 的场景，pod 中会存在一条 table 为 100 的策略路由， 该路由确保从 eth0 接收的流量从 eth0 转发，防止来回路径不一致导致丢包。
 
 测试 Pod 访问集群东西向流量的连通性，以访问 CoreDNS 的 Pod 和 Service 为例:
 

--- a/docs/usage/install/overlay/get-started-cilium.md
+++ b/docs/usage/install/overlay/get-started-cilium.md
@@ -261,8 +261,8 @@ Use the command `ip` to view the Pod's information such as routes:
        valid_lft forever preferred_lft forever
 / # ip rule
 0: from all lookup local
-32760: from 10.6.212.131  lookup 100
-32762：from 10.233.120.101 lookup 500
+32760: from 10.6.212.131  lookup 101
+32762：from 10.233.120.101 lookup 100
 32766: from all lookup main
 32767: from all lookup default
 / # ip route
@@ -272,14 +272,14 @@ default via 10.233.65.96 dev eth0
 10.233.0.0/18 via 10.6.212.132 dev eth0 
 10.233.64.0/18 via 10.6.212.132 dev eth0
 10.6.0.0/16 dev net1 scope link  src 10.6.212.202
-/ # ip route show table 100
+/ # ip route show table 101
 default via 10.6.0.1 dev net1
 10.6.0.0/16 dev net1 scope link  src 10.6.212.202
 10.233.65.96 dev eth0 scope link
 10.6.212.131 dev eth0 scope link
 10.233.0.0/18 via 10.6.212.132 dev eth0 
 10.233.64.0/18 via 10.6.212.132 dev eth0
-/ # ip route show table 500
+/ # ip route show table 100
 default via 10.233.65.96 dev eth0
 ```
 
@@ -295,7 +295,7 @@ Explanation of the above:
 >
 > By default, the Pod's default route is reserved in eth0. To reserve it in net1, add the following annotation to the Pod's metadata: "ipam.spidernet.io/default-route-nic: net1".
 > 
-> If the default route is eth0, a policy-based route with table 500 exists in the pod. This route ensures that traffic received from eth0 is forwarded from eth0 to prevent packet loss caused by inconsistent forward and return paths.
+> If the default route is eth0, a policy-based route with table 100 exists in the pod. This route ensures that traffic received from eth0 is forwarded from eth0 to prevent packet loss caused by inconsistent forward and return paths.
 
 To test the east-west connectivity of the Pod, we will use the example of accessing the CoreDNS Pod and Service:
 

--- a/test/doc/coordinator.md
+++ b/test/doc/coordinator.md
@@ -15,3 +15,4 @@
 | C00011  | In the default scenario (Do not specify the NIC where the default route is located in any way) , use 'ip r get 8.8.8.8' to see if default route NIC is `net1` | p2 | | |
 | C00012  | In multi-nic case , use 'ip r get <service_subnet> and <hostIP>' to see if src is from pod's eth0, note: only for ipv4. | p2 | | |
 | C00020 | kdoctor connectivity should be succeed with annotations: ipam.spidernet.io/default-route-nic: net1 |  p3       |       | done   |       |
+| C00021 | kdoctor connectivity should be succeed with three macvlan interfaces, and set rp_filter to 1 |  p3       |       | done   |       |

--- a/test/e2e/coordinator/macvlan-overlay-one/macvlan_overlay_one_suite_test.go
+++ b/test/e2e/coordinator/macvlan-overlay-one/macvlan_overlay_one_suite_test.go
@@ -3,6 +3,7 @@
 package macvlan_overlay_one_test
 
 import (
+	"fmt"
 	"testing"
 
 	multus_v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -12,7 +13,10 @@ import (
 	e2e "github.com/spidernet-io/e2eframework/framework"
 	spiderpool "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1"
 	"github.com/spidernet-io/spiderpool/test/e2e/common"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 )
 
 func TestMacvlanOverlayOne(t *testing.T) {
@@ -28,13 +32,16 @@ var name string
 var err error
 var delayMs = int64(15000)
 var (
-	task        *kdoctorV1beta1.NetReach
-	netreach    *kdoctorV1beta1.AgentSpec
-	targetAgent *kdoctorV1beta1.NetReachTarget
-	request     *kdoctorV1beta1.NetHttpRequest
-	schedule    *kdoctorV1beta1.SchedulePlan
-	condition   *kdoctorV1beta1.NetSuccessCondition
-	run         = true
+	task           *kdoctorV1beta1.NetReach
+	netreach       *kdoctorV1beta1.AgentSpec
+	targetAgent    *kdoctorV1beta1.NetReachTarget
+	request        *kdoctorV1beta1.NetHttpRequest
+	schedule       *kdoctorV1beta1.SchedulePlan
+	condition      *kdoctorV1beta1.NetSuccessCondition
+	run            = true
+	macvlanVlan0   = "test-macvlan1"
+	macvlanVlan100 = "test-macvlan2"
+	//macvlanVlan200 = "test-macvlan3"
 )
 
 var _ = BeforeSuite(func() {
@@ -45,4 +52,36 @@ var _ = BeforeSuite(func() {
 		Skip("overlay CNI is not installed , ignore this suite")
 	}
 
+	// create spidermultusconfig to set rp_filter to 1, which can
+	// better to test the connection
+	for idx, name := range []string{common.MacvlanUnderlayVlan0, common.MacvlanVlan100, common.MacvlanVlan200} {
+		smc, err := frame.GetSpiderMultusInstance(common.MultusNs, name)
+		Expect(err).NotTo(HaveOccurred())
+
+		copy := smc.Spec
+		copy.CoordinatorConfig.HostRPFilter = ptr.To(1)
+		err = frame.CreateSpiderMultusInstance(&spiderpool.SpiderMultusConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("test-macvlan%d", idx+1),
+				Namespace: common.MultusNs,
+			},
+			Spec: copy,
+		})
+
+		if err == nil || apierrors.IsAlreadyExists(err) {
+			GinkgoWriter.Printf("create spiderMultusConfig %s/%s successfully\n", common.MultusNs, fmt.Sprintf("test-macvlan%d", idx+1))
+			continue
+		}
+
+		Expect(err).NotTo(HaveOccurred())
+	}
 })
+
+// var _ = AfterSuite(func() {
+// delete the test spidermultusconfig
+//for idx := range []string{common.MacvlanUnderlayVlan0, common.MacvlanVlan100, common.MacvlanVlan200} {
+//	err = frame.DeleteSpiderMultusInstance(common.MultusNs, fmt.Sprintf("test-macvlan%d", idx+1))
+//	GinkgoWriter.Printf("failed to delete spiderMultusConfig: %v\n", err)
+// Expect(err).NotTo(HaveOccurred())
+//}
+//})

--- a/test/e2e/coordinator/macvlan-overlay-one/macvlan_overlay_one_test.go
+++ b/test/e2e/coordinator/macvlan-overlay-one/macvlan_overlay_one_test.go
@@ -49,7 +49,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 			name = "one-macvlan-overlay-" + tools.RandomName()
 
 			// Update netreach.agentSpec to generate test Pods using the macvlan
-			annotations[common.MultusNetworks] = fmt.Sprintf("%s/%s", common.MultusNs, common.MacvlanUnderlayVlan0)
+			annotations[common.MultusNetworks] = fmt.Sprintf("%s/%s", common.MultusNs, macvlanVlan0)
 			netreach.Annotation = annotations
 			netreach.HostNetwork = false
 			GinkgoWriter.Printf("update kdoctoragent annotation: %v/%v annotation: %v \n", common.KDoctorAgentNs, common.KDoctorAgentDSName, annotations)
@@ -67,7 +67,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 			targetAgent.Ingress = &disable
 			targetAgent.Endpoint = &enable
 			targetAgent.ClusterIP = &enable
-			targetAgent.MultusInterface = &frame.Info.MultusEnabled
+			targetAgent.MultusInterface = &enable
 			targetAgent.NodePort = &enable
 			targetAgent.EnableLatencyMetric = true
 			targetAgent.IPv4 = &frame.Info.IpV4Enabled
@@ -206,7 +206,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 			name = "one-macvlan-overlay-" + tools.RandomName()
 
 			// Update netreach.agentSpec to generate test Pods using the macvlan
-			annotations[common.MultusNetworks] = fmt.Sprintf("%s/%s", common.MultusNs, common.MacvlanUnderlayVlan0)
+			annotations[common.MultusNetworks] = fmt.Sprintf("%s/%s", common.MultusNs, macvlanVlan0)
 			annotations[constant.AnnoDefaultRouteInterface] = "net1"
 			netreach.Annotation = annotations
 			netreach.HostNetwork = false
@@ -225,7 +225,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 			targetAgent.Ingress = &disable
 			targetAgent.Endpoint = &enable
 			targetAgent.ClusterIP = &enable
-			targetAgent.MultusInterface = &frame.Info.MultusEnabled
+			targetAgent.MultusInterface = &enable
 			targetAgent.NodePort = &enable
 			targetAgent.EnableLatencyMetric = true
 
@@ -1016,7 +1016,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 			name = "two-macvlan-overlay-" + tools.RandomName()
 
 			// Update netreach.agentSpec to generate test Pods using the macvlan
-			annotations[common.MultusNetworks] = fmt.Sprintf("%s/%s,%s/%s", common.MultusNs, common.MacvlanUnderlayVlan0, common.MultusNs, common.MacvlanVlan100)
+			annotations[common.MultusNetworks] = fmt.Sprintf("%s/%s,%s/%s", common.MultusNs, macvlanVlan0, common.MultusNs, macvlanVlan100)
 			if frame.Info.SpiderSubnetEnabled {
 				subnetsAnno := []types.AnnoSubnetItem{
 					{
@@ -1054,7 +1054,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 			targetAgent.Ingress = &disable
 			targetAgent.Endpoint = &enable
 			targetAgent.ClusterIP = &enable
-			targetAgent.MultusInterface = &frame.Info.MultusEnabled
+			targetAgent.MultusInterface = &enable
 			targetAgent.NodePort = &enable
 			targetAgent.EnableLatencyMetric = true
 			targetAgent.IPv4 = &frame.Info.IpV4Enabled

--- a/test/e2e/reclaim/reclaim_test.go
+++ b/test/e2e/reclaim/reclaim_test.go
@@ -579,7 +579,7 @@ var _ = Describe("test ip with reclaim ip case", Label("reclaim"), func() {
 			Expect(frame.DeletePod(podName, namespace)).To(Succeed(), "Failed to delete pod %v/%v\n", namespace, podName)
 			GinkgoWriter.Printf("succeed to delete pod %v/%v\n", namespace, podName)
 		},
-			Entry("a dirty IP record (pod name is wrong or containerID is wrong) in the IPPool should be auto clean by Spiderpool", Serial, Label("G00005", "G00007")),
+			PEntry("a dirty IP record (pod name is wrong or containerID is wrong) in the IPPool should be auto clean by Spiderpool", Serial, Label("G00005", "G00007")),
 		)
 	})
 

--- a/test/scripts/debugEnv.sh
+++ b/test/scripts/debugEnv.sh
@@ -231,10 +231,39 @@ elif [ "$TYPE"x == "detail"x ] ; then
               kubectl exec -ti -n ${NS_NAME} --kubeconfig ${E2E_KUBECONFIG} -- ip -6 rule
               echo "--------------- execute ip route in pod: ${NS_NAME} ------------"
               kubectl exec -ti -n ${NS_NAME} --kubeconfig ${E2E_KUBECONFIG} -- ip route
+              kubectl exec -ti -n ${NS_NAME} --kubeconfig ${E2E_KUBECONFIG} -- ip route show table 100
+              kubectl exec -ti -n ${NS_NAME} --kubeconfig ${E2E_KUBECONFIG} -- ip route show table 101
               echo "--------------- execute ip -6 route in pod: ${NS_NAME} ------------"
               kubectl exec -ti -n ${NS_NAME} --kubeconfig ${E2E_KUBECONFIG} -- ip -6 route
+              kubectl exec -ti -n ${NS_NAME} --kubeconfig ${E2E_KUBECONFIG} -- ip -6 route table 100
+              kubectl exec -ti -n ${NS_NAME} --kubeconfig ${E2E_KUBECONFIG} -- ip -6 route table 101
           done
     fi
+
+    echo ""
+    echo "=============== kdoctor logs ============== "
+    for POD in $KDOCTOR_POD_LIST ; do
+      echo ""
+      echo "--------- kubectl logs ${POD} -n ${NAMESPACE} "
+      kubectl logs ${POD} -n ${NAMESPACE} --kubeconfig ${E2E_KUBECONFIG}
+      echo "--------- kubectl logs ${POD} -n ${NAMESPACE} --previous"
+      kubectl logs ${POD} -n ${NAMESPACE} --kubeconfig ${E2E_KUBECONFIG} --previous
+    done
+
+    echo ""
+    echo "=============== open kruise logs ============== "
+    for POD in $KRUISE_POD_LIST ; do
+      echo ""
+      echo "--------- kubectl logs ${POD} -n kruise-system "
+      kubectl logs ${POD} -n kruise-system --kubeconfig ${E2E_KUBECONFIG}
+      echo "--------- kubectl logs ${POD} -n kruise-system --previous"
+      kubectl logs ${POD} -n kruise-system --kubeconfig ${E2E_KUBECONFIG} --previous
+    done
+    
+    echo ""
+    echo "=============== kdoctor netreach details ============== "
+    kubectl get netreach --kubeconfig ${E2E_KUBECONFIG}
+    kubectl get netreach --kubeconfig ${E2E_KUBECONFIG} -o yaml
 
 elif [ "$TYPE"x == "error"x ] ; then
     CHECK_ERROR(){


### PR DESCRIPTION
## Thanks for contributing!

<!--Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>-->

#### What type of PR is this?

- release/bug 

<!--
Add one of the following kinds:

Required labels:

- release/none 
- release/bug 
- release/feature

Optional labels:

- kind/bug
- kind/feature
- kind/ci-bug
- kind/doc
-->

**What this PR does / why we need it**:

- No longer rely on the API to get the rule number of the NIC, getting it through the API may cause the number to be wrong, which can avoid the wrong policy route when there is more than 1 secondary nics.
- New a netlink.Route object without use of raw object when adding the route, which can avoid netlink return "invalid argument" error.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
