### PR TITLE
Fix wrong validate for unicast podMACPrefix when creating spiderMultusConfig

### DIFF
--- a/pkg/coordinatormanager/coordinator_validate.go
+++ b/pkg/coordinatormanager/coordinator_validate.go
@@ -155,12 +155,6 @@ func validateCoordinatorPodMACPrefix(prefix *string) *field.Error {
 		return errInvalid
 	}
 
-	// the lowest bit of first byte must be 0
-	// example: 0*:**
-	if string(parts[0][0]) != "0" {
-		return field.Invalid(podMACPrefixField, *prefix, "the lowest bit of the first byte must be 0")
-	}
-
 	fb, err := strconv.ParseInt(parts[0], 16, 0)
 	if err != nil {
 		return errInvalid
@@ -172,7 +166,7 @@ func validateCoordinatorPodMACPrefix(prefix *string) *field.Error {
 
 	bb := fmt.Sprintf("%08b", fb)
 	if string(bb[7]) != "0" {
-		return field.Invalid(podMACPrefixField, *prefix, "not a unicast MAC")
+		return field.Invalid(podMACPrefixField, *prefix, "not a unicast MAC: the lowest bit of the first byte must be 0")
 	}
 
 	return nil

--- a/test/doc/spidermultus.md
+++ b/test/doc/spidermultus.md
@@ -25,3 +25,6 @@
 | M00021  |    create a spidermultusconfig and pod to verify chainCNI json config if works                                                                                     | p3       |       | done   |       |
 | M00022 | test podRPFilter and hostRPFilter in spidermultusconfig | p3 | | done |
 | M00023 | set hostRPFilter and podRPFilter to a invalid value | p3 | | done |
+| M00024  |    verify the podMACPrefix filed                                                                                     | p3       |       | done   |       |
+
+

--- a/test/e2e/spidermultus/spidermultus_test.go
+++ b/test/e2e/spidermultus/spidermultus_test.go
@@ -829,4 +829,55 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 		Expect(string(data)).To(Equal("4096\n"), "net.core.somaxconn: %s", data)
 	})
 
+	It("verify the podMACPrefix filed", Label("M00024"), func() {
+		smcName := "test-multus-" + common.GenerateString(10, true)
+		smc := &spiderpoolv2beta1.SpiderMultusConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      smcName,
+				Namespace: namespace,
+			},
+			Spec: spiderpoolv2beta1.MultusCNIConfigSpec{
+				CniType: ptr.To(constant.MacvlanCNI),
+				MacvlanConfig: &v2beta1.SpiderMacvlanCniConfig{
+					Master: []string{"eth0"},
+					SpiderpoolConfigPools: &v2beta1.SpiderpoolPools{
+						IPv4IPPool: []string{"spiderpool-ipv4-ippool"},
+					},
+				},
+				EnableCoordinator: ptr.To(true),
+				CoordinatorConfig: &spiderpoolv2beta1.CoordinatorSpec{
+					PodMACPrefix: ptr.To("9e:10"),
+				},
+			},
+		}
+
+		ginkgo.By("create a spiderMultusConfig with valid podMACPrefix")
+		err := frame.CreateSpiderMultusInstance(smc)
+		Expect(err).NotTo(HaveOccurred())
+
+		tmpName := "invalid-macprefix" + common.GenerateString(10, true)
+		invalid := &spiderpoolv2beta1.SpiderMultusConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      tmpName,
+				Namespace: namespace,
+			},
+			Spec: spiderpoolv2beta1.MultusCNIConfigSpec{
+				CniType: ptr.To(constant.MacvlanCNI),
+				MacvlanConfig: &v2beta1.SpiderMacvlanCniConfig{
+					Master: []string{"eth0"},
+					SpiderpoolConfigPools: &v2beta1.SpiderpoolPools{
+						IPv4IPPool: []string{"spiderpool-ipv4-ippool"},
+					},
+				},
+				EnableCoordinator: ptr.To(true),
+				CoordinatorConfig: &spiderpoolv2beta1.CoordinatorSpec{
+					PodMACPrefix: ptr.To("01:10"),
+				},
+			},
+		}
+
+		ginkgo.By("create a spiderMultusConfig with invalid podMACPrefix")
+		err = frame.CreateSpiderMultusInstance(invalid)
+		Expect(err).To(HaveOccurred(), "create invalid spiderMultusConfig should fail: %v", err)
+	})
 })


### PR DESCRIPTION
robot cherry pick PR <https://github.com/spidernet-io/spiderpool/pull/4098> from cyclinder,to branch release-v0.9,  action <https://github.com/spidernet-io/spiderpool/actions/runs/11027086897>  , commits 55dbd7328838526adea19c4318a6aedae8061c32 