### PR TITLE
fix cilium installation --set tunnel

### DIFF
--- a/test/scripts/install-default-cni.sh
+++ b/test/scripts/install-default-cni.sh
@@ -191,7 +191,6 @@ function install_cilium() {
             CILIUM_HELM_OPTIONS+=" --set ipam.operator.clusterPoolIPv6PodCIDRList=${CILIUM_CLUSTER_POD_SUBNET_V6} \
                                    --set ipv4.enabled=false \
                                    --set ipv6.enabled=true \
-                                   --set tunnel=disabled \
                                    --set ipv6NativeRoutingCIDR=${CILIUM_CLUSTER_POD_SUBNET_V6} \
                                    --set autoDirectNodeRoutes=true \
                                    --set enableIPv6Masquerade=true \


### PR DESCRIPTION
## Thanks for contributing!

<!--Before submitting a pull request, make sure you read about our Contribution notice here: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>-->

#### What type of PR is this?

<!--
Add one of the following kinds:

Required labels:

- release/none 
- release/bug 
- release/feature

Optional labels:

- kind/bug
- kind/feature
- kind/ci-bug
- kind/doc
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4125 

**Special notes for your reviewer**:

https://docs.cilium.io/en/v1.15/operations/upgrade/#helm-options

The tunnel option (deprecated in Cilium 1.14) has been removed. To enable native-routing mode, set routing-mode=native (previously tunnel=disabled). To configure the tunneling protocol, set tunnel-protocol=vxlan|geneve (previously tunnel=vxlan|geneve).