### PR TITLE
e2e fix: the latest version of calico cannot find the felixconfigurations resource

### DIFF
--- a/test/scripts/install-default-cni.sh
+++ b/test/scripts/install-default-cni.sh
@@ -134,7 +134,8 @@ function install_calico() {
         echo "the value of E2E_IP_FAMILY: ipv4 or ipv6 or dual"
         exit 1
     esac
-    kubectl patch felixconfigurations.crd.projectcalico.org default --type='merge' -p '{"spec":{"chainInsertMode":"Append"}}' || { echo "failed to patch calico chainInsertMode"; exit 1; }
+    # there no default felixconfigurations.crd.projectcalico.org in latest calico version (https://github.com/projectcalico/calico/releases/tag/v3.29.0)
+    kubectl patch felixconfigurations.crd.projectcalico.org default --type='merge' -p '{"spec":{"chainInsertMode":"Append"}}' || true
     
     # restart calico pod
     kubectl -n kube-system delete pod -l k8s-app=calico-node --force --grace-period=0 && sleep 3


### PR DESCRIPTION
# Thanks for contributing!

**Notice**:

* [ ] unite test or E2E test
* [ ] do not forget essential code comment and log
* [ ] document for the PR
* [ ] release note label
  "release/none"
  "release/bug"
  "release/feature"
* [ ] read about  Contribution notice: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>

**What issue(s) does this PR fix**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4231 

**Special notes for your reviewer**:

spiderpool 尝试修改 felixconfigurations 的 chainInsertMode 为 true 适配 egressGateway。 但在 calico 最新版本中缺少 felixconfigurations 的 default 资源，故失败。

当前 e2e 没有 egressGateway 相关，暂时注释。