### PR TITLE
Fix podwebhook cert don't update when spiderpool-controller restart

### DIFF
--- a/pkg/podmanager/utils.go
+++ b/pkg/podmanager/utils.go
@@ -269,14 +269,18 @@ func AddPodMutatingWebhook(admissionClient admissionClientv1.Admissionregistrati
 			return fmt.Errorf("no any mutating webhook found in MutatingWebhookConfiguration %s", mutatingWebhookName)
 		}
 
+		var newWebhooks []admissionregistrationv1.MutatingWebhook
 		for _, wb := range mwc.Webhooks {
 			// if the webhook already exists, do nothing
 			if wb.Name == constant.PodMutatingWebhookName {
-				return nil
+				continue
 			}
+			newWebhooks = append(newWebhooks, wb)
 		}
+
 		podWebhook := InitPodMutatingWebhook(*mwc.Webhooks[0].DeepCopy(), webhookNamespaceInclude)
-		mwc.Webhooks = append(mwc.Webhooks, podWebhook)
+		newWebhooks = append(newWebhooks, podWebhook)
+		mwc.Webhooks = newWebhooks
 
 		_, updateErr := admissionClient.MutatingWebhookConfigurations().Update(context.TODO(), mwc, metav1.UpdateOptions{})
 		return updateErr

--- a/pkg/podmanager/utils_test.go
+++ b/pkg/podmanager/utils_test.go
@@ -459,7 +459,7 @@ var _ = Describe("PodManager utils", Label("pod_manager_utils_test"), func() {
 				err = podmanager.AddPodMutatingWebhook(fakeClient.AdmissionregistrationV1(), webhookName, podWebhookNamespaceInclude)
 				Expect(err).NotTo(HaveOccurred())
 
-				// Verify the webhook was added
+				// // Verify the webhook was added
 				updatedConfig, err := fakeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(
 					context.TODO(), webhookName, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -481,7 +481,7 @@ var _ = Describe("PodManager utils", Label("pod_manager_utils_test"), func() {
 				err = podmanager.AddPodMutatingWebhook(fakeClient.AdmissionregistrationV1(), webhookName, podWebhookNamespaceInclude)
 				Expect(err).NotTo(HaveOccurred())
 
-				// Verify no additional webhook was added
+				// // Verify no additional webhook was added
 				updatedConfig, err := fakeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(
 					context.TODO(), webhookName, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())

--- a/test/Makefile
+++ b/test/Makefile
@@ -419,6 +419,7 @@ uninstall_spiderpool:
 helm_upgrade_spiderpool:
 	@echo -e "\033[35m [helm upgrade spiderpool] \033[0m"
 	HELM_OPTION="";\
+	kubectl get mutatingwebhookconfigurations spiderpool-controller -o yaml --kubeconfig $(E2E_KUBECONFIG) ;\
 	HELM_OPTION+=" --set spiderpoolController.replicas=1 " ; \
 	if [ "$(INSTALL_OVERLAY_CNI)" == "true" ]; then \
 		HELM_OPTION+=" --set multus.multusCNI.defaultCniCRName= " ; \
@@ -464,6 +465,7 @@ helm_upgrade_spiderpool:
 	kubectl wait --for=condition=ready -l app.kubernetes.io/instance=spiderpool --timeout=300s pod -n $(RELEASE_NAMESPACE) --kubeconfig $(E2E_KUBECONFIG) || true; \
 	kubectl scale deploy -n $(RELEASE_NAMESPACE) -l app.kubernetes.io/component=spiderpool-controller --replicas=2 --kubeconfig $(E2E_KUBECONFIG); \
 	kubectl wait --for=condition=ready -l app.kubernetes.io/component=spiderpool-controller --timeout=300s pod -n $(RELEASE_NAMESPACE) --kubeconfig $(E2E_KUBECONFIG) || true; \
+	kubectl get mutatingwebhookconfigurations spiderpool-controller -o yaml --kubeconfig $(E2E_KUBECONFIG) ;\
 	helm --kubeconfig $(E2E_KUBECONFIG) list -A ; \
 
 .PHONY: clean


### PR DESCRIPTION
# Thanks for contributing!

**Notice**:

* [ ] unite test or E2E test
* [ ] do not forget essential code comment and log
* [ ] document for the PR
* [ ] release note label
  "release/none"
  "release/bug"
  "release/feature"
* [ ] read about  Contribution notice: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>

**What issue(s) does this PR fix**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/spidernet-io/spiderpool/issues/4243

**Special notes for your reviewer**:
