### PR TITLE
Remove ServiceMonitor dup namespaceSelector

### DIFF
--- a/charts/spiderpool/templates/servicemonitor.yaml
+++ b/charts/spiderpool/templates/servicemonitor.yaml
@@ -15,9 +15,6 @@ metadata:
       {{- end }}
   {{- end }}
 spec:
-  namespaceSelector:
-    matchNames:
-      - {{ .Release.Namespace }}
   selector:
     matchLabels:
       {{- if .Values.global.commonLabels }}


### PR DESCRIPTION
https://github.com/spidernet-io/spiderpool/blob/main/charts/spiderpool/templates/servicemonitor.yaml#L31

ServiceMonitor has dup key was `namespaceSelector `.