### PR TITLE
Fix: statefulSet applications failed to create in multi-NIC scenarios.

### DIFF
--- a/pkg/ipam/allocate.go
+++ b/pkg/ipam/allocate.go
@@ -77,7 +77,7 @@ func (i *ipam) Allocate(ctx context.Context, addArgs *models.IpamAddArgs) (*mode
 	releaseStsOutdatedIPFlag := false
 	if i.config.EnableStatefulSet && podTopController.APIVersion == appsv1.SchemeGroupVersion.String() && podTopController.Kind == constant.KindStatefulSet {
 		if endpoint != nil {
-			releaseStsOutdatedIPFlag, err = i.releaseStsOutdatedIPIfNeed(ctx, addArgs, pod, endpoint, podTopController)
+			releaseStsOutdatedIPFlag, err = i.releaseStsOutdatedIPIfNeed(ctx, addArgs, pod, endpoint, podTopController, IsMultipleNicWithNoName(pod.Annotations))
 			if err != nil {
 				return nil, err
 			}
@@ -114,13 +114,15 @@ func (i *ipam) Allocate(ctx context.Context, addArgs *models.IpamAddArgs) (*mode
 }
 
 func (i *ipam) releaseStsOutdatedIPIfNeed(ctx context.Context, addArgs *models.IpamAddArgs,
-	pod *corev1.Pod, endpoint *spiderpoolv2beta1.SpiderEndpoint, podTopController types.PodTopController) (bool, error) {
+	pod *corev1.Pod, endpoint *spiderpoolv2beta1.SpiderEndpoint, podTopController types.PodTopController, isMultipleNicWithNoName bool) (bool, error) {
 	logger := logutils.FromContext(ctx)
 
 	preliminary, err := i.getPoolCandidates(ctx, addArgs, pod, podTopController)
 	if err != nil {
 		return false, err
 	}
+	logger.Sugar().Infof("Preliminary IPPool candidates: %s", preliminary)
+
 	poolMap := make(map[string]map[string]struct{})
 	for _, candidates := range preliminary {
 		if _, ok := poolMap[candidates.NIC]; !ok {
@@ -131,38 +133,97 @@ func (i *ipam) releaseStsOutdatedIPIfNeed(ctx context.Context, addArgs *models.I
 			poolMap[candidates.NIC][pool] = struct{}{}
 		}
 	}
-	endpointMap := make(map[string]map[string]struct{})
-	for _, ip := range endpoint.Status.Current.IPs {
-		if _, ok := endpointMap[ip.NIC]; !ok {
-			endpointMap[ip.NIC] = make(map[string]struct{})
-		}
+	logger.Sugar().Debugf("The current mapping between the Pod's IPPool candidates and NICs: %v", poolMap)
+
+	// Spiderpool assigns IP addresses to NICs one by one.
+	// Some NICs may have their IP pools changed, while others may remain unchanged.
+	// Record these changes and differences to handle specific NICs accordingly.
+	releaseEndpointIPsFlag := false
+	needReleaseEndpointIPs := []spiderpoolv2beta1.IPAllocationDetail{}
+	noReleaseEndpointIPs := []spiderpoolv2beta1.IPAllocationDetail{}
+	for index, ip := range endpoint.Status.Current.IPs {
 		if ip.IPv4Pool != nil && *ip.IPv4Pool != "" {
-			endpointMap[ip.NIC][*ip.IPv4Pool] = struct{}{}
-		}
-		if ip.IPv6Pool != nil && *ip.IPv6Pool != "" {
-			endpointMap[ip.NIC][*ip.IPv6Pool] = struct{}{}
-		}
-	}
-	if !checkNicPoolExistence(endpointMap, poolMap) {
-		logger.Sugar().Info("StatefulSet Pod need to release IP: owned pool %v, expected pools: %v", endpointMap, poolMap)
-		if endpoint.DeletionTimestamp == nil {
-			logger.Sugar().Infof("delete outdated endpoint of statefulset pod: %v/%v", endpoint.Namespace, endpoint.Name)
-			if err := i.endpointManager.DeleteEndpoint(ctx, endpoint); err != nil {
-				return false, err
+			if isMultipleNicWithNoName {
+				if _, ok := poolMap[strconv.Itoa(index)][*ip.IPv4Pool]; !ok {
+					// If using the multi-NIC feature through ipam.spidernet.io/ippools without specifying interface names,
+					// and if the IP pool of one NIC changes, only reclaiming the corresponding endpoint IP could cause the IPAM allocation method to lose allocation records.
+					// When the interface name is not specified, the allocated NIC name might be "", which cannot be handled properly.
+					// If isMultipleNicWithNoName is true, all NIC IP addresses will be reclaimed and reallocated.
+					logger.Sugar().Infof("StatefulSet Pod need to release IP, owned pool: %v, expected pools: %v", *ip.IPv4Pool, poolMap[strconv.Itoa(index)])
+					releaseEndpointIPsFlag = true
+					break
+				}
+			}
+			// All other cases determine here whether an IP address needs to be reclaimed.
+			if _, ok := poolMap[ip.NIC][*ip.IPv4Pool]; !ok && ip.NIC == *addArgs.IfName {
+				// The multi-NIC feature can be used in the following two ways:
+				//   1. By specifying additional NICs through k8s.v1.cni.cncf.io/networks and configure the default pool.
+				//   2. By using ipam.spidernet.io/ippools (excluding cases where the interface name is empty).
+				// When a change is detected in the corresponding NIC's IP pool,
+				// the IP information for that NIC will be automatically reclaimed and reallocated.
+				logger.Sugar().Infof("StatefulSet Pod need to release IP, owned pool: %v, expected pools: %v", *ip.IPv4Pool, poolMap[ip.NIC])
+				releaseEndpointIPsFlag = true
+				needReleaseEndpointIPs = append(needReleaseEndpointIPs, ip)
+				continue
 			}
 		}
-		err := i.release(ctx, endpoint.Status.Current.UID, endpoint.Status.Current.IPs)
-		if err != nil {
-			return false, err
+		if ip.IPv6Pool != nil && *ip.IPv6Pool != "" {
+			if isMultipleNicWithNoName {
+				if _, ok := poolMap[strconv.Itoa(index)][*ip.IPv6Pool]; !ok {
+					logger.Sugar().Infof("StatefulSet Pod need to release IP, owned pool: %v, expected pools: %v", *ip.IPv6Pool, poolMap[strconv.Itoa(index)])
+					releaseEndpointIPsFlag = true
+					break
+				}
+			}
+			if _, ok := poolMap[ip.NIC][*ip.IPv6Pool]; !ok && ip.NIC == *addArgs.IfName {
+				logger.Sugar().Infof("StatefulSet Pod need to release IP, owned pool: %v, expected pools: %v", *ip.IPv6Pool, poolMap[ip.NIC])
+				releaseEndpointIPsFlag = true
+				needReleaseEndpointIPs = append(needReleaseEndpointIPs, ip)
+				continue
+			}
 		}
-		logger.Sugar().Info("remove outdated of StatefulSet pod %s/%s: %v", endpoint.Namespace, endpoint.Name, endpoint.Status.Current.IPs)
-		if err := i.endpointManager.RemoveFinalizer(ctx, endpoint); err != nil {
-			return false, fmt.Errorf("failed to clean statefulset pod's Endpoint when expected ippool was changed: %v", err)
+
+		// According to the NIC allocation mechanism, we check whether the pool information for each NIC has changed.
+		// If there is no change, we do not need to reclaim the corresponding endpoint and IP for that NIC.
+		noReleaseEndpointIPs = append(noReleaseEndpointIPs, ip)
+	}
+
+	if releaseEndpointIPsFlag {
+		if isMultipleNicWithNoName || len(needReleaseEndpointIPs) == len(endpoint.Status.Current.IPs) {
+			// The endpoint should be deleted in the following cases:
+			// 1. If the multi-NIC feature is used through ipam.spidernet.io/ippools without specifying the interface name, and the IPPool has changed.
+			// 2. In other multi-NIC or single-NIC scenarios, if the IPPool of all NICs has changed.
+			logger.Sugar().Infof("remove outdated of StatefulSet pod %s/%s: %v", endpoint.Namespace, endpoint.Name, endpoint.Status.Current.IPs)
+			if endpoint.DeletionTimestamp == nil {
+				logger.Sugar().Infof("delete outdated endpoint of statefulset pod: %v/%v", endpoint.Namespace, endpoint.Name)
+				if err := i.endpointManager.DeleteEndpoint(ctx, endpoint); err != nil {
+					return false, err
+				}
+			}
+			if err := i.endpointManager.RemoveFinalizer(ctx, endpoint); err != nil {
+				return false, fmt.Errorf("failed to clean statefulset pod's endpoint when expected ippool was changed: %v", err)
+			}
+			err := i.release(ctx, endpoint.Status.Current.UID, endpoint.Status.Current.IPs)
+			if err != nil {
+				return false, err
+			}
+			logger.Sugar().Infof("remove outdated of StatefulSet Pod IPs: %v in Pool", endpoint.Status.Current.IPs)
+		} else {
+			// Only update the endpoint and IP corresponding to the changed NIC.
+			logger.Sugar().Infof("try to update the endpoint IPs of the StatefulSet Pod. Old: %+v, New: %+v.", endpoint.Status.Current.IPs, noReleaseEndpointIPs)
+			if err := i.endpointManager.PatchEndpointAllocationIPs(ctx, endpoint, noReleaseEndpointIPs); err != nil {
+				return false, err
+			}
+			err := i.release(ctx, endpoint.Status.Current.UID, needReleaseEndpointIPs)
+			if err != nil {
+				return false, err
+			}
+			logger.Sugar().Infof("remove outdated of StatefulSet Pod IPs: %v in Pool", needReleaseEndpointIPs)
 		}
-		endpoint = nil
+
 		return true, nil
 	} else {
-		logger.Sugar().Debugf("StatefulSet Pod does not need to release IP: owned pool %v, expected pools: %v", endpointMap, poolMap)
+		logger.Sugar().Debugf("StatefulSet Pod does not need to release IP: %v", endpoint.Status.Current.IPs)
 	}
 	return false, nil
 }

--- a/pkg/ipam/utils.go
+++ b/pkg/ipam/utils.go
@@ -7,12 +7,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
+	"strconv"
+
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/strings/slices"
-	"net"
-	"strconv"
 
 	"github.com/spidernet-io/spiderpool/api/v1/agent/models"
 	subnetmanagercontrollers "github.com/spidernet-io/spiderpool/pkg/applicationcontroller/applicationinformers"
@@ -177,10 +178,10 @@ func IsMultipleNicWithNoName(anno map[string]string) bool {
 		return false
 	}
 
-	result := true
+	result := false
 	for _, v := range annoPodIPPools {
-		if v.NIC != "" {
-			result = false
+		if v.NIC == "" {
+			result = true
 		}
 	}
 
@@ -223,20 +224,4 @@ func validateAndMutateMultipleNICAnnotations(annoIPPoolsValue types.AnnoPodIPPoo
 	}
 
 	return nil
-}
-
-func checkNicPoolExistence(endpointMap, poolMap map[string]map[string]struct{}) bool {
-	for outerKey, innerMap := range endpointMap {
-		poolInnerMap, exists := poolMap[outerKey]
-		if !exists {
-			return false
-		}
-
-		for innerKey := range innerMap {
-			if _, exists := poolInnerMap[innerKey]; !exists {
-				return false
-			}
-		}
-	}
-	return true
 }

--- a/pkg/ippoolmanager/ippool_manager.go
+++ b/pkg/ippoolmanager/ippool_manager.go
@@ -173,11 +173,12 @@ func (im *ipPoolManager) genRandomIP(ctx context.Context, ipPool *spiderpoolv2be
 		// Check if there is a duplicate Pod UID in IPPool.allocatedRecords.
 		// If so, we skip this allocation and assume that this Pod has already obtained an IP address in the pool.
 		if record.PodUID == string(pod.UID) {
-			logger.Sugar().Warnf("The Pod %s/%s UID %s already exists in the assigned IP %s", pod.Namespace, pod.Name, ip, string(pod.UID))
+			logger.Sugar().Infof("The Pod %s/%s UID %s already exists in the assigned IP %s", pod.Namespace, pod.Name, ip, string(pod.UID))
 			return net.ParseIP(ip), nil
 		}
 		used = append(used, ip)
 	}
+
 	usedIPs, err := spiderpoolip.ParseIPRanges(*ipPool.Spec.IPVersion, used)
 	if err != nil {
 		return nil, err

--- a/pkg/workloadendpointmanager/workloadendpoint_manager.go
+++ b/pkg/workloadendpointmanager/workloadendpoint_manager.go
@@ -34,6 +34,7 @@ type WorkloadEndpointManager interface {
 	UpdateAllocationNICName(ctx context.Context, endpoint *spiderpoolv2beta1.SpiderEndpoint, nic string) (*spiderpoolv2beta1.PodIPAllocation, error)
 	ReleaseEndpointIPs(ctx context.Context, endpoint *spiderpoolv2beta1.SpiderEndpoint, uid string) ([]spiderpoolv2beta1.IPAllocationDetail, error)
 	ReleaseEndpointAndFinalizer(ctx context.Context, namespace, podName string, cached bool) error
+	PatchEndpointAllocationIPs(ctx context.Context, endpoint *spiderpoolv2beta1.SpiderEndpoint, endpointIPs []spiderpoolv2beta1.IPAllocationDetail) error
 }
 
 type workloadEndpointManager struct {
@@ -164,7 +165,21 @@ func (em *workloadEndpointManager) PatchIPAllocationResults(ctx context.Context,
 		return nil
 	}
 
-	endpoint.Status.Current.IPs = append(endpoint.Status.Current.IPs, convert.ConvertResultsToIPDetails(results, isMultipleNicWithNoName)...)
+	// Using ipam.spidernet.io/ippools to specify multiple NICs,
+	// if only one NIC's IP pool changes, only the changed NIC needs to have its IP address reassigned, while the other NICs remain unaffected.
+	convertResults := convert.ConvertResultsToIPDetails(results, isMultipleNicWithNoName)
+	for _, result := range convertResults {
+		exists := false
+		for _, existingIP := range endpoint.Status.Current.IPs {
+			if existingIP.NIC == result.NIC {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			endpoint.Status.Current.IPs = append(endpoint.Status.Current.IPs, result)
+		}
+	}
 	logger.Sugar().Infof("try to update SpiderEndpoint %s", endpoint)
 	return em.client.Update(ctx, endpoint)
 }
@@ -218,13 +233,26 @@ func (em *workloadEndpointManager) UpdateAllocationNICName(ctx context.Context, 
 			break
 		}
 	}
-
 	err := em.client.Update(ctx, endpoint)
 	if nil != err {
 		return nil, err
 	}
 
 	return &endpoint.Status.Current, nil
+}
+
+// PatchEndpointAllocationIPs will patch the SpiderEndpoint status recorded IPs.
+func (em *workloadEndpointManager) PatchEndpointAllocationIPs(ctx context.Context, endpoint *spiderpoolv2beta1.SpiderEndpoint, newEndpointIPs []spiderpoolv2beta1.IPAllocationDetail) error {
+	log := logutils.FromContext(ctx)
+
+	endpoint.Status.Current.IPs = newEndpointIPs
+	log.Sugar().Debugf("try to update SpiderEndpoint recorded IPs: %s", endpoint)
+	err := em.client.Update(ctx, endpoint)
+	if nil != err {
+		return err
+	}
+
+	return nil
 }
 
 // ReleaseEndpointIPs will release the SpiderEndpoint status recorded IPs.

--- a/test/doc/annotation.md
+++ b/test/doc/annotation.md
@@ -17,4 +17,6 @@
 | A00013  | It's invalid to specify one NIC corresponding IPPool in IPPools annotation with multiple NICs                               | p2       |       | done   |       |
 | A00014  | It's invalid to specify same NIC name for IPPools annotation with multiple NICs                                             | p2       |       | done   |       |
 | A00015  | Use wildcard for 'ipam.spidernet.io/ippools' annotation to specify IPPools                                                  | p2       |       | done   |       |
-| A00016 | In the annotation ipam.spidernet.io/ippools for multi-NICs, when the IP pool for one NIC runs out of IPs, it should not exhaust IPs from other pools. | p2 | | done | |
+| A00016  | In the annotation ipam.spidernet.io/ippools for multi-NICs, when the IP pool for one NIC runs out of IPs, it should not exhaust IPs from other pools.  | p2       |       | done   |       |
+| A00017  | Stateful applications can use multiple NICs via k8s.v1.cni.cncf.io/networks, enabling creation, restart, and IP address changes.  | p3       |       | done   |       |
+| A00018  | Stateful applications using the annotation ipam.spidernet.io/ippools without specifying a NIC name can still create Pods, restart them, and update their IP addresses.  | p3       |       | done   |       |

--- a/test/doc/ippoolcr.md
+++ b/test/doc/ippoolcr.md
@@ -19,4 +19,3 @@
 | D00015  | The namespace where the pod resides does not match the namespaceName, and the IP cannot be assigned                                    | p2       |       | done   |       |
 | D00016  | namespaceName has higher priority than namespaceAffinity                                                                               | p3       |       | done   |       |
 | D00017  | Large IPv6 pool, correct statistics of IP number.                                                                                      | p3       |       | done   |       |
-

--- a/test/doc/spidercclaimparameter.md
+++ b/test/doc/spidercclaimparameter.md
@@ -1,9 +1,0 @@
-# E2E Cases for spiderclaimparameter
-
-| Case ID | Title | Priority | Smoke | Status | Other |
-| ------- | ------| -------- | ----- | ------ | ----- |
-| Y00001  | test create spiderclaimparameter       | p3       |      |   done    |
-| Y00002  | test create spiderclaimparameter for empty staticNics | p3   |    |    done   |
-| Y00003  | verify spidermultusconfig of the secondaryNics if is exist | p3 |  |   |
-| Y00004  | if defaultNic is empty, webhook set default cluster network | p3 |  |  |
-| Y00005  | the cniType of all the secondaryNics should be same | p3 |  |  |

--- a/test/doc/spiderclaimparameter.md
+++ b/test/doc/spiderclaimparameter.md
@@ -1,0 +1,9 @@
+# E2E Cases for spiderclaimparameter
+
+| Case ID | Title | Priority | Smoke | Status | Other |
+| ------- | ------| -------- | ----- | ------ | ----- |
+| Y00001  | test create spiderclaimparameter       | p3       |      |   done    |  |
+| Y00002  | test create spiderclaimparameter for empty staticNics | p3   |    |    done   |  |
+| Y00003  | verify spidermultusconfig of the secondaryNics if is exist | p3 |  |   |  |
+| Y00004  | if defaultNic is empty, webhook set default cluster network | p3 |  |  |  |
+| Y00005  | the cniType of all the secondaryNics should be same | p3 |  |  |  |

--- a/test/e2e/affinity/affinity_test.go
+++ b/test/e2e/affinity/affinity_test.go
@@ -447,7 +447,7 @@ var _ = Describe("test Affinity", Label("affinity"), func() {
 			})
 		})
 
-		It("Successfully restarted statefulSet/pod with matching podSelector, ip remains the same", Label("L00008", "A00009"), func() {
+		It("After the statefulset changes the IP pool and restarts, the IP is changed correctly and the UID recorded in the endpoint is synchronized correctly.", Label("L00008", "A00009"), func() {
 			// A00009:Modify the annotated IPPool for a specified StatefulSet pod
 			// Generate ippool annotation string
 			podIppoolAnnoStr := common.GeneratePodIPPoolAnnotations(frame, common.NIC1, defaultV4PoolNameList, defaultV6PoolNameList)
@@ -496,7 +496,7 @@ var _ = Describe("test Affinity", Label("affinity"), func() {
 				object, err := common.GetWorkloadByName(frame, pod.Namespace, pod.Name)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(object).NotTo(BeNil())
-				uidMap[string(object.UID)] = pod.Name
+				uidMap[string(object.Status.Current.UID)] = pod.Name
 			}
 			GinkgoWriter.Printf("StatefulSet %s/%s corresponding Pod IP allocations: %v \n", stsObject.Namespace, stsObject.Name, ipMap)
 
@@ -569,7 +569,7 @@ var _ = Describe("test Affinity", Label("affinity"), func() {
 				// WorkloadEndpoint UID remains the same
 				object, err := common.GetWorkloadByName(frame, pod.Namespace, pod.Name)
 				Expect(err).NotTo(HaveOccurred(), "Failed to get the same uid")
-				d, ok := uidMap[string(object.UID)]
+				d, ok := uidMap[string(object.Status.Current.UID)]
 				Expect(ok).To(BeFalse(), "Unexpectedly got the same uid")
 				GinkgoWriter.Printf("Pod %v workloadendpoint UID %v remains the same \n", d, object.UID)
 			}


### PR DESCRIPTION
# Thanks for contributing!

**Notice**:

* [x] unite test or E2E test
* [x] do not forget essential code comment and log
* [x] document for the PR
* [x] release note label
  "release/none"
  "release/bug"
  "release/feature"
* [x] read about  Contribution notice: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>

**What issue(s) does this PR fix**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4362

**Special notes for your reviewer**:

### statefulset 应用在多网卡场景下，创建 Pod 失败：

```bash
  Warning  FailedCreatePodSandBox  13s   kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "a0d4fe8eb1b4d9a115997df44488c4b297d5cb845234dd069f6db8decb282b98": plugin type="multus" name="multus-cni-network" failed (add): [default/test-sts-0/07793483-79f5-47ff-acdd-4a67d697ef85:macvlan-vlan100]: error adding container to network "macvlan-vlan100": spiderpool IP allocation error: [POST /ipam/ip][500] postIpamIpFailure  failed to retrieve the existing IP allocation: failed to update SpiderEndpoint allocation details NIC name net1, error: Operation cannot be fulfilled on spiderendpoints.spiderpool.spidernet.io "test-sts-0": StorageError: invalid object, Code: 4, Key: /registry/spiderpool.spidernet.io/spiderendpoints/default/test-sts-0, ResourceVersion: 0, AdditionalErrorMsg: Precondition failed: UID in precondition: 7be12fb3-6b7c-4d6f-8536-e16b924305e4, UID in object meta:
```

### 多网卡功能有以下两种使用方式：

- 方式一：通过 k8s.v1.cni.cncf.io/networks 指定额外网卡，并配置默认池。
- 方式二：使用 ipam.spidernet.io/ippools

#### 对于方式一指定额外网卡的场景：一张网卡：eth0 分配 IP 地址后，会创建好 endpoint，endpiont 如下：

```
  current:
    ips:
    - cleanGateway: false
      interface: eth0
      ipv4: 172.18.40.5/16
      ipv4Gateway: 172.18.0.1
      ipv4Pool: default-v4-ippool
      vlan: 0
```

当第二张网卡调用 IPAM 时，先检查到存在的 endpoint，然后走 releaseStsOutdatedIPIfNeed 流程，会对比 Pod 使用的 IP 池与 endpoint 中记录的是否一致。而 endpoint 中记录的是 eth0，第二张网卡的 Pod IPPool 注解为 "{NIC: net1}"，通过 checkNicPoolExistence 方法判断后它们一定不想等的，因此在给第二张网卡分配 IP 地址的时候，却把 Pod 的 endpoint 给回收掉了，找不到对应的网卡信息，无法为 Pod 继续分配。从而导致 Pod 创建失败。

#### 对于方式二  ipam.spidernet.io/ippools 指定多网卡的场景，如果没有指定 interface Name，当第一张卡 eth0 完成 IP 地址分配后，其 endpoint 如下（interface: ""）：

```
  current:
    ips:
    - cleanGateway: false
      interface: eth0
      ipv4: 172.18.40.5/16
      ipv4Gateway: 172.18.0.1
      ipv4Pool: default-v4-ippool
      vlan: 0
    - cleanGateway: false
      interface: ""
      ipv4: 172.20.40.200/16
      ipv4Gateway: 172.20.0.1
      ipv4Pool: test-v4-ippool
      vlan: 0
```

由于没有指定 interface Name，当调用 Spiderpool IPAM 会根据 IP 池的数组顺序，一次为所有网卡进行 IP 地址分配，数组第一位的网卡名称在 endpoint 中会被记录为 `eth0`，其他网卡 name 为 ""。在分配第二张网卡的 IP 地址时，会通过 multus 实际传入的网卡 name 去自动去刷新对应 endpoint 的 name。但是在原本的代码中，为第二张卡的 IP 时，会先进入 releaseStsOutdatedIPIfNeed 进行判断这个 statefulset 的 endpoint 和 Pod 的 IP 池信息是否变更，由于 interface name 是为空的，此时判断两者信息一定是不匹配的（因为已经被刷成 eth0 和 ""），因此会导致 endpoint 和 IP 被删除，从而 sts Pod 无法启动。

#### 补充

多网卡场景下，对于 statefulset 应用，它可能只变更了一张网卡的 IP 池，这种场景无需回收所有网卡的 endpoint 和 IP。对此额外判断，只回收变更对应网卡的 IP 信息，未变更的网卡 IP 继续为其固定。