### PR TITLE
Fixes a issue with multus and webhook not working when the manifest file is restored during a helm update

### DIFF
--- a/charts/spiderpool/templates/configmap.yaml
+++ b/charts/spiderpool/templates/configmap.yaml
@@ -43,6 +43,9 @@ metadata:
       {{- if .Values.global.commonLabels }}
       {{- include "tplvalues.render" ( dict "value" .Values.global.commonLabels "context" $ ) | nindent 4 }}
       {{- end }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/resource_policy": keep
 data:
   cni-conf.json: |
     {

--- a/charts/spiderpool/templates/tls.yaml
+++ b/charts/spiderpool/templates/tls.yaml
@@ -9,6 +9,8 @@ metadata:
     {{- if (eq .Values.spiderpoolController.tls.method "certmanager") }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Values.spiderpoolController.name | trunc 63 | trimSuffix "-" }}-server-certs
     {{- end }}
+    "helm.sh/hook": pre-install
+    "helm.sh/resource_policy": keep
 webhooks:
 - admissionReviewVersions:
   - v1
@@ -154,6 +156,8 @@ metadata:
     {{- if (eq .Values.spiderpoolController.tls.method "certmanager") }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Values.spiderpoolController.name | trunc 63 | trimSuffix "-" }}-server-certs
     {{- end }}
+    "helm.sh/hook": pre-install
+    "helm.sh/resource_policy": keep
 webhooks:
 - admissionReviewVersions:
   - v1
@@ -324,6 +328,9 @@ kind: Secret
 metadata:
   name: {{ .Values.spiderpoolController.tls.secretName | trunc 63 | trimSuffix "-" }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/resource_policy": keep
 type: kubernetes.io/tls
 data:
   ca.crt:  {{ .Values.spiderpoolController.tls.provided.tlsCa | required "missing spiderpoolController.tls.provided.tlsCa" }}
@@ -347,6 +354,9 @@ kind: Secret
 metadata:
   name: {{ .Values.spiderpoolController.tls.secretName | trunc 63 | trimSuffix "-" }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/resource_policy": keep
 type: kubernetes.io/tls
 data:
   ca.crt:  {{ .ca.Cert | b64enc }}


### PR DESCRIPTION
# Thanks for contributing!

**Notice**:

* [ ] unite test or E2E test
* [ ] do not forget essential code comment and log
* [ ] document for the PR
* [ ] release note label
  "release/none"
  "release/bug"
  "release/feature"
* [ ] read about  Contribution notice: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>

**What issue(s) does this PR fix**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/spidernet-io/spiderpool/issues/4357
Fixes https://github.com/spidernet-io/spiderpool/issues/4344

**Special notes for your reviewer**:

When the admin executes the `helm upgrade` for spiderpool, the configMap spiderpool-multus, webhookconfig and secrets  these manifest files are restored.  which can raises issues:    https://github.com/spidernet-io/spiderpool/issues/4357 and https://github.com/spidernet-io/spiderpool/issues/4344. 

To solve these issues, we add helm hook annotations(`"helm.sh/hook": pre-install`) to these manifests, when helm upgrade spiderpool, these files wouldn't be updated.

执行 Helm 更新时，一些资源如 configMap, webhookconfig, secret 会被 helm 还原为初始配置，但这些资源都会在 spiderpool 运行时动态更新，所以当 helm 更新后，配置被还原这导致 pod webhook 和 multus 无法工作。

所以在这些资源清单文件上添加 helm hook 的 annotation: helm.sh/hook": pre-install, 这期望这些资源只会在安装时下发，而不会在 helm update 时重新下发。

但这里会有一个其他的问题：如果老版本没有如上的 annotation，更新上来后存量的  configMap, webhookconfig, secret 会被删除（这是helm的机制，如果老版本有如上的 annotations，问题不存在）。所以为了避免该情况下，这些资源被 helm 删除，加上另外一个 annotation: `helm.sh/resource-type: keep`, 但这会导致这些资源残留。所以在 delete-hook 中清理这些资源。 