### PR TITLE
e2e: fix openkruise installtion and debug ovs installtion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -324,17 +324,18 @@ e2e_init_spiderpool:
 
 .PHONY: e2e_init_cilium_ebpfservice
 e2e_init_cilium_ebpfservice:
-	$(QUIET)  make e2e_init -e INSTALL_OVERLAY_CNI=true -e INSTALL_CALICO=false -e INSTALL_CILIUM=true -e DISABLE_KUBE_PROXY=true -e E2E_SPIDERPOOL_ENABLE_SUBNET=false
+	$(QUIET)  make e2e_init -e INSTALL_OVERLAY_CNI=true -e INSTALL_CALICO=false -e INSTALL_CILIUM=true -e DISABLE_KUBE_PROXY=true \
+	-e E2E_SPIDERPOOL_ENABLE_SUBNET=false -e INSTALL_OVS=false
 
 .PHONY: e2e_init_calico
 e2e_init_calico:
 	$(QUIET)  make e2e_init -e INSTALL_OVERLAY_CNI=true -e INSTALL_CALICO=true -e INSTALL_CILIUM=false -e E2E_SPIDERPOOL_ENABLE_SUBNET=false \
-	E2E_SPIDERPOOL_ENABLE_DRA=true 
+	-e E2E_SPIDERPOOL_ENABLE_DRA=true -e INSTALL_OVS=false
 
 .PHONY: e2e_init_cilium_legacyservice
 e2e_init_cilium_legacyservice:
-	$(QUIET)  make e2e_init -e INSTALL_OVERLAY_CNI=true -e INSTALL_CALICO=false -e INSTALL_CILIUM=true -e DISABLE_KUBE_PROXY=false -e E2E_SPIDERPOOL_ENABLE_SUBNET=false
-
+	$(QUIET)  make e2e_init -e INSTALL_OVERLAY_CNI=true -e INSTALL_CALICO=false -e INSTALL_CILIUM=true -e DISABLE_KUBE_PROXY=false \
+	-e E2E_SPIDERPOOL_ENABLE_SUBNET=false -e INSTALL_OVS=false
 
 .PHONY: e2e_test
 e2e_test:

--- a/test/Makefile
+++ b/test/Makefile
@@ -225,7 +225,11 @@ setup_kruise:
 				docker pull $${IMAGE} ; \
 				kind load docker-image $${IMAGE} --name $(E2E_CLUSTER_NAME);	\
 			done; \
-			helm upgrade --install kruise openkruise/kruise --wait --timeout 20m --debug --set manager.image.repository=$(E2E_OPENKRUISE_IMAGE) \
+			HELM_OPTION=" --wait --timeout 20m --debug --set manager.image.repository=$(E2E_OPENKRUISE_IMAGE) " ; \
+			# openkruise failed to run with 1.7.3, see 
+			# https://github.com/spidernet-io/spiderpool/issues/4396
+			HELM_OPTION+=" --version $(E2E_OPENKRUISE_VERSION) " ; \
+			helm upgrade --install kruise openkruise/kruise $${HELM_OPTION} \
 			    --kubeconfig $(E2E_KUBECONFIG) || { KIND_CLUSTER_NAME=$(E2E_CLUSTER_NAME) ./scripts/debugEnv.sh $(E2E_KUBECONFIG) "detail" "$(E2E_LOG_FILE)" ; exit 1 ; } ; \
 
 .PHONY: setup_spiderpool

--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -190,7 +190,9 @@ E2E_LOG_FILE ?= $(ROOT_DIR)/test/e2edebugLog.txt
 E2E_UNINSTALL_LOG_FILE ?= $(ROOT_DIR)/test/e2e-uninstall-debugLog.txt
 
 #========= openkruise =========
-
+# openkruise failed to run with 1.7.3, see 
+# https://github.com/spidernet-io/spiderpool/issues/4396
+E2E_OPENKRUISE_VERSION := 1.7.2
 ifeq ($(E2E_CHINA_IMAGE_REGISTRY),true)
     E2E_OPENKRUISE_IMAGE ?= docker.m.daocloud.io/openkruise/kruise-manager
 else


### PR DESCRIPTION
# Thanks for contributing!

**Notice**:

* [ ] unite test or E2E test
* [ ] do not forget essential code comment and log
* [ ] document for the PR
* [ ] release note label
  "release/none"
  "release/bug"
  "release/feature"
* [ ] read about  Contribution notice: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>

**What issue(s) does this PR fix**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/spidernet-io/spiderpool/issues/4396
Fixes https://github.com/spidernet-io/spiderpool/issues/4397

**Special notes for your reviewer**:

1. openkruise 1.7.3 安装失败，临时回退到 1.7.2
2. auto-nightly-ci , auto-pr-ci 使用 ubuntu-latest systemd start openvswitch 失败，临时回退到 ubuntu-22.04。待成功后恢复为 24.04 