### PR TITLE
Detect IP conflicts before gateway detection to fix communication fail

### DIFF
--- a/.github/workflows/trivy-scan-image.yaml
+++ b/.github/workflows/trivy-scan-image.yaml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/download-artifact@v4.1.8
         with:
           pattern: image-tar-spiderpool-*-${{ inputs.ref }}
+          merge-multiple: true
           path: test/.download
 
       - name: List downloaded files

--- a/cmd/coordinator/cmd/cni_types.go
+++ b/cmd/coordinator/cmd/cni_types.go
@@ -285,11 +285,11 @@ func ValidateDelectOptions(config *DetectOptions) (*DetectOptions, error) {
 	}
 
 	if config.Interval == "" {
-		config.Interval = "1s"
+		config.Interval = "10ms"
 	}
 
 	if config.TimeOut == "" {
-		config.TimeOut = "3s"
+		config.TimeOut = "100ms"
 	}
 
 	_, err := time.ParseDuration(config.Interval)

--- a/docs/concepts/coordinator-zh_CN.md
+++ b/docs/concepts/coordinator-zh_CN.md
@@ -41,7 +41,7 @@ EOF
 | podRPFilter       | 设置 Pod 的 sysctl 参数 rp_filter                                                                                                                                                                                                                                              | 整数型      | optional   | 0                                 |
 | hostRPFilter       | (遗弃)设置节点 的 sysctl 参数 rp_filter                                                                                                                                                                                                                                              | 整数型      | optional   | 0                                 |
 | txQueueLen         | 设置 Pod 的网卡传输队列                                                                                                                                                                                                                                                          | 整数型      | optional   | 0                                 |
-| detectOptions      | 检测地址冲突和网关可达性的高级配置项: 包括重试次数(默认为 3 次), 探测间隔(默认为 1s) 和 超时时间(默认为 1s)                                                                                                                                                                                                        | 对象类型     | optional   | 空                                 |
+| detectOptions      | 检测地址冲突和网关可达性的高级配置项: 包括重试次数(默认为 3 次), 探测间隔(默认为 10ms) 和 超时时间(默认为 100ms)                                                                                                                                                                                                        | 对象类型     | optional   | 空                                 |
 | logOptions         | 日志配置，包括 logLevel(默认为 debug) 和 logFile(默认为 /var/log/spidernet/coordinator.log)                                                                                                                                                                                           | 对象类型     | optional   | -                                 |
 
 > 如果您通过 `SpinderMultusConfig CR`  帮助创建 NetworkAttachmentDefinition CR，您可以在 `SpinderMultusConfig` 中配置 `coordinator` (所有字段)。参考: [SpinderMultusConfig](../reference/crd-spidermultusconfig.md)。
@@ -171,7 +171,7 @@ spec:
     vethLinkAddress: "169.254.200.1"
 ```
 
-> `vethLinkAddress` 默认为空，表示不配置。不为空则必须是一个合法的本地链路地址。 
+> `vethLinkAddress` 默认为空，表示不配置。不为空则必须是一个合法的本地链路地址。
 
 ## 自动获取集群 Service 的 CIDR
 

--- a/docs/concepts/coordinator.md
+++ b/docs/concepts/coordinator.md
@@ -42,7 +42,7 @@ Let's delve into how coordinator implements these features.
 | podRPFilter       | Set the rp_filter sysctl parameter on the pod, which is recommended to be set to 0                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | int      | optional   | 0           |
 | hostRPFilter      | (deprecated)Set the rp_filter sysctl parameter on the node, which is recommended to be set to 0                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | int      | optional   | 0           |
 | txQueueLen         | set txqueuelen(Transmit Queue Length) of the pod's interface                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | int      | optional   | 0           |
-| detectOptions      | The advanced configuration of detectGateway and detectIPConflict, including retry numbers(default is 3), interval(default is 1s) and timeout(default is 1s)                                                                                                                                                                                                                                                                                                                                                                                                                             | obejct   | optional   | nil         |
+| detectOptions      | The advanced configuration of detectGateway and detectIPConflict, including retry numbers(default is 3), interval(default is 10ms) and timeout(default is 100ms)                                                                                                                                                                                                                                                                                                                                                                                                                             | obejct   | optional   | nil         |
 | logOptions         | The configuration of logging, including logLevel(default is debug) and logFile(default is /var/log/spidernet/coordinator.log)                                                                                                                                                                                                                                                                                                                                                                                                                                                           | obejct   | optional   | nil         |
 
 > You can configure `coordinator` by specifying all the relevant fields in `SpinderMultusConfig` if a NetworkAttachmentDefinition CR is created via `SpinderMultusConfig CR`. For more information, please refer to [SpinderMultusConfig](../reference/crd-spidermultusconfig.md).
@@ -101,17 +101,16 @@ spec:
 
 > Note: There are some switches that are not allowed to be probed by arp, otherwise an alarm will be issued, in this case, we need to set detectGateway to false
 
-
 ## Fix MAC address prefix for Pods(alpha)
 
-Some traditional applications may require a fixed MAC address or IP address to couple the behavior of the application. For example, the License Server may need to apply a fixed Mac address 
-or IP address to issue a license for the app. If the MAC address of a pod changes, the issued license may be invalid. Therefore, you need to fix the MAC address of the pod. Spiderpool can fix 
+Some traditional applications may require a fixed MAC address or IP address to couple the behavior of the application. For example, the License Server may need to apply a fixed Mac address
+or IP address to issue a license for the app. If the MAC address of a pod changes, the issued license may be invalid. Therefore, you need to fix the MAC address of the pod. Spiderpool can fix
 the MAC address of the application through `coordinator`, and the fixed rule is to configure the MAC address prefix (2 bytes) + convert the IP of the pod (4 bytes).
 
 Note:
 
 > currently supports updating  Macvlan and SR-IOV as pods for CNI. In IPVlan L2 mode, the MAC addresses of the primary interface and the sub-interface are the same and cannot be modified.
-> 
+>
 > The fixed rule is to configure the MAC address prefix (2 bytes) + the IP of the converted pod (4 bytes). An IPv4 address is 4 bytes long and can be fully converted to 2 hexadecimal numbers. For IPv6 addresses, only the last 4 bytes are taken.
 
 We can configure it via Spidermultusconfig:

--- a/test/e2e/coordinator/macvlan-overlay-one/macvlan_overlay_one_test.go
+++ b/test/e2e/coordinator/macvlan-overlay-one/macvlan_overlay_one_test.go
@@ -419,6 +419,10 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 			Expect(frame.CreateSpiderMultusInstance(nad)).NotTo(HaveOccurred())
 
 			DeferCleanup(func() {
+				if CurrentSpecReport().Failed() {
+					GinkgoWriter.Println("If the use case fails, the cleanup step will be skipped")
+					return
+				}
 				GinkgoWriter.Printf("delete spiderMultusConfig %v/%v. \n", namespace, multusNadName)
 				Expect(frame.DeleteSpiderMultusInstance(namespace, multusNadName)).NotTo(HaveOccurred())
 
@@ -698,6 +702,10 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 			Expect(frame.CreateSpiderMultusInstance(nad)).NotTo(HaveOccurred())
 
 			DeferCleanup(func() {
+				if CurrentSpecReport().Failed() {
+					GinkgoWriter.Println("If the use case fails, the cleanup step will be skipped")
+					return
+				}
 				GinkgoWriter.Printf("delete spiderMultusConfig %v/%v. \n", namespace, multusNadName)
 				Expect(frame.DeleteSpiderMultusInstance(namespace, multusNadName)).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Detect IP conflicts before gateway detection to  fix gateway detection could potentially update the arp table causing communication fail

# Thanks for contributing!

**Notice**:

* [ ] unite test or E2E test
* [ ] do not forget essential code comment and log
* [ ] document for the PR
* [ ] release note label
  "release/none"
  "release/bug"
  "release/feature"
* [ ] read about  Contribution notice: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>

**What issue(s) does this PR fix**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/spidernet-io/spiderpool/issues/4475

**Special notes for your reviewer**:
