### PR TITLE
SpiderMultusConfig: Add mtu size support for macvlan / ipvlan / sriov

### DIFF
--- a/charts/spiderpool/crds/spiderpool.spidernet.io_spidermultusconfigs.yaml
+++ b/charts/spiderpool/crds/spiderpool.spidernet.io_spidermultusconfigs.yaml
@@ -247,6 +247,13 @@ spec:
                     items:
                       type: string
                     type: array
+                  mtu:
+                    default: 0
+                    description: explicitly set MTU to the specified value. Defaults('0'
+                      or no value provided) to the value chosen by the kernel.
+                    format: int32
+                    minimum: 0
+                    type: integer
                   rdmaResourceName:
                     description: The RDMA resource name of the nic. the RDMA resource
                       is often reported to kubelet by the k8s-rdma-shared-dev-plugin.
@@ -304,6 +311,13 @@ spec:
                     items:
                       type: string
                     type: array
+                  mtu:
+                    default: 0
+                    description: explicitly set MTU to the specified value. Defaults('0'
+                      or no value provided) to the value chosen by the kernel.
+                    format: int32
+                    minimum: 0
+                    type: integer
                   rdmaResourceName:
                     description: The RDMA resource name of the nic. the RDMA resource
                       is often reported to kubelet by the k8s-rdma-shared-dev-plugin.
@@ -384,6 +398,14 @@ spec:
                     minimum: 0
                     type: integer
                   minTxRateMbps:
+                    minimum: 0
+                    type: integer
+                  mtu:
+                    default: 0
+                    description: explicitly set MTU to the specified value via tuning
+                      plugin. Defaults('0' or no value provided) to the value chosen
+                      by the kernel.
+                    format: int32
                     minimum: 0
                     type: integer
                   rdmaIsolation:

--- a/docs/reference/crd-spidermultusconfig.md
+++ b/docs/reference/crd-spidermultusconfig.md
@@ -71,6 +71,7 @@ This is the SpiderReservedIP spec for users to configure.
 | master  | the Interfaces on your master, you could specify a single one Interface<br/> or multiple Interfaces to generate one bond Interface | list of strings                                                | required   |          |
 | vlanID  | vlan ID                                                                                                                            | int                                                            | optional   | [0,4094] |
 | bond    | expected bond Interface configurations                                                                                             | [BondConfig](./crd-spidermultusconfig.md#bondconfig)           | optional   |          |
+| mtu     | mtu of the Interface                                                        | int                                                            | optional   | the max mtu can't be over than the max mtu of the Interface  |
 | ippools | the default IPPools in your CNI configurations                                                                                     | [SpiderpoolPools](./crd-spidermultusconfig.md#spiderpoolpools) | optional   |          |
 
 #### SpiderIPvlanCniConfig
@@ -80,6 +81,7 @@ This is the SpiderReservedIP spec for users to configure.
 | master  | the Interfaces on your master, you could specify a single one Interface<br/> or multiple Interfaces to generate one bond Interface | list of strings                                                | required   |          |
 | vlanID  | vlan ID                                                                                                                            | int                                                            | optional   | [0,4094] |
 | bond    | expected bond Interface configurations                                                                                             | [BondConfig](./crd-spidermultusconfig.md#bondconfig)           | optional   |          |
+| mtu     | mtu of the Interface                                                        | int                                                            | optional   | the max mtu can't be over than the max mtu of the Interface  |
 | ippools | the default IPPools in your CNI configurations                                                                                     | [SpiderpoolPools](./crd-spidermultusconfig.md#spiderpoolpools) | optional   |          |
 
 #### SpiderSRIOVCniConfig
@@ -88,6 +90,7 @@ This is the SpiderReservedIP spec for users to configure.
 |---------------|-------------------------------------------------------------------------------------------|----------------------------------------------------------------|------------|
 | resourceName  | this property will create an annotation for Multus net-attach-def to cooperate with SRIOV | string                                                         | required   |
 | vlanID        | vlan ID                                                                                   | int                                                            | optional   |
+| mtu           | mtu of the vf Interface, the max mtu can't be over than the PF Interface                  | int                                                            | optional   |
 | minTxRateMbps | change the allowed minimum transmit bandwidth, in Mbps, for the VF. Setting this to 0 disables rate limiting. The min_tx_rate value should be <= max_tx_rate. Support of this feature depends on NICs and drivers | int | optional |
 | maxTxRateMbps | change the allowed maximum transmit bandwidth, in Mbps, for the VF. Setting this to 0 disables rate limiting | int | optional |
 | rdmaIsolation    | enable RDMA CNI plugin is intended to be run as a chained CNI plugin. it ensures isolation of RDMA traffic from other workloads in the system by moving the associated RDMA interfaces of the provided network interface to the container'snetwork namespace path                                          | bool                                                           | optional   |

--- a/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/spidermultus_types.go
+++ b/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/spidermultus_types.go
@@ -80,6 +80,12 @@ type SpiderMacvlanCniConfig struct {
 	// by the ifacer plugin.
 	Master []string `json:"master"`
 
+	// +kubebuilder:default=0
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Minimum=0
+	// explicitly set MTU to the specified value. Defaults('0' or no value provided) to the value chosen by the kernel.
+	MTU *int32 `json:"mtu,omitempty"`
+
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=4094
@@ -106,6 +112,12 @@ type SpiderIPvlanCniConfig struct {
 	// If multiple master interfaces are specified, the spiderpool will create a bond device with the bondConfig
 	// by the ifacer plugin.
 	Master []string `json:"master"`
+
+	// +kubebuilder:default=0
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Minimum=0
+	// explicitly set MTU to the specified value. Defaults('0' or no value provided) to the value chosen by the kernel.
+	MTU *int32 `json:"mtu,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Minimum=0
@@ -138,6 +150,12 @@ type SpiderSRIOVCniConfig struct {
 	// +kubebuilder:validation:Maximum=4094
 	// The VLAN ID for the CNI configuration, optional and must be within the specified range: [0.4096).
 	VlanID *int32 `json:"vlanID,omitempty"`
+
+	// +kubebuilder:default=0
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Minimum=0
+	// explicitly set MTU to the specified value via tuning plugin. Defaults('0' or no value provided) to the value chosen by the kernel.
+	MTU *int32 `json:"mtu,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Minimum=0

--- a/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/zz_generated.deepcopy.go
+++ b/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/zz_generated.deepcopy.go
@@ -741,6 +741,11 @@ func (in *SpiderIPvlanCniConfig) DeepCopyInto(out *SpiderIPvlanCniConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.MTU != nil {
+		in, out := &in.MTU, &out.MTU
+		*out = new(int32)
+		**out = **in
+	}
 	if in.VlanID != nil {
 		in, out := &in.VlanID, &out.VlanID
 		*out = new(int32)
@@ -800,6 +805,11 @@ func (in *SpiderMacvlanCniConfig) DeepCopyInto(out *SpiderMacvlanCniConfig) {
 		in, out := &in.Master, &out.Master
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.MTU != nil {
+		in, out := &in.MTU, &out.MTU
+		*out = new(int32)
+		**out = **in
 	}
 	if in.VlanID != nil {
 		in, out := &in.VlanID, &out.VlanID
@@ -995,6 +1005,11 @@ func (in *SpiderSRIOVCniConfig) DeepCopyInto(out *SpiderSRIOVCniConfig) {
 	}
 	if in.VlanID != nil {
 		in, out := &in.VlanID, &out.VlanID
+		*out = new(int32)
+		**out = **in
+	}
+	if in.MTU != nil {
+		in, out := &in.MTU, &out.MTU
 		*out = new(int32)
 		**out = **in
 	}

--- a/pkg/multuscniconfig/multusconfig_informer.go
+++ b/pkg/multuscniconfig/multusconfig_informer.go
@@ -429,6 +429,15 @@ func generateNetAttachDef(netAttachName string, multusConf *spiderpoolv2beta1.Sp
 		// head insertion
 		plugins = append([]interface{}{sriovCNIConf}, plugins...)
 
+		if multusConfSpec.SriovConfig.MTU != nil && *multusConfSpec.SriovConfig.MTU > 0 {
+			tuningConf := tuningConf{
+				Type: "tuning",
+				Mtu:  *multusConfSpec.SriovConfig.MTU,
+			}
+			// head insertion
+			plugins = append(plugins, tuningConf)
+		}
+
 		confStr, err = marshalCniConfig2String(netAttachName, cniVersion, plugins)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal sriov cniConfig to String: %w", err)
@@ -518,6 +527,10 @@ func generateMacvlanCNIConf(disableIPAM bool, multusConfSpec spiderpoolv2beta1.M
 		Mode:   "bridge",
 	}
 
+	if multusConfSpec.MacvlanConfig.MTU != nil {
+		netConf.MTU = multusConfSpec.MacvlanConfig.MTU
+	}
+
 	if !disableIPAM {
 		netConf.IPAM = &spiderpoolcmd.IPAMConfig{
 			Type: constant.Spiderpool,
@@ -551,6 +564,10 @@ func generateIPvlanCNIConf(disableIPAM bool, multusConfSpec spiderpoolv2beta1.Mu
 	netConf := IPvlanNetConf{
 		Type:   constant.IPVlanCNI,
 		Master: masterName,
+	}
+
+	if multusConfSpec.IPVlanConfig.MTU != nil {
+		netConf.MTU = multusConfSpec.IPVlanConfig.MTU
 	}
 
 	if !disableIPAM {

--- a/pkg/multuscniconfig/multusconfig_mutate.go
+++ b/pkg/multuscniconfig/multusconfig_mutate.go
@@ -79,6 +79,10 @@ func setMacvlanDefaultConfig(macvlanConfig *spiderpoolv2beta1.SpiderMacvlanCniCo
 		macvlanConfig.Bond = setBondDefaultConfig(macvlanConfig.Bond)
 	}
 
+	if macvlanConfig.MTU == nil {
+		macvlanConfig.MTU = ptr.To(int32(0))
+	}
+
 	if macvlanConfig.RdmaResourceName == nil {
 		macvlanConfig.RdmaResourceName = ptr.To("")
 	}
@@ -111,6 +115,10 @@ func setIPVlanDefaultConfig(ipvlanConfig *spiderpoolv2beta1.SpiderIPvlanCniConfi
 		ipvlanConfig.RdmaResourceName = ptr.To("")
 	}
 
+	if ipvlanConfig.MTU == nil {
+		ipvlanConfig.MTU = ptr.To(int32(0))
+	}
+
 	if ipvlanConfig.Bond != nil {
 		ipvlanConfig.Bond = setBondDefaultConfig(ipvlanConfig.Bond)
 	}
@@ -130,6 +138,10 @@ func setSriovDefaultConfig(sriovConfig *spiderpoolv2beta1.SpiderSRIOVCniConfig) 
 
 	if sriovConfig.VlanID == nil {
 		sriovConfig.VlanID = ptr.To(int32(0))
+	}
+
+	if sriovConfig.MTU == nil {
+		sriovConfig.MTU = ptr.To(int32(0))
 	}
 
 	if sriovConfig.MinTxRateMbps == nil {

--- a/pkg/multuscniconfig/multusconfig_validate.go
+++ b/pkg/multuscniconfig/multusconfig_validate.go
@@ -102,6 +102,10 @@ func validateCNIConfig(multusConfig *spiderpoolv2beta1.SpiderMultusConfig) *fiel
 			}
 		}
 
+		if multusConfig.Spec.MacvlanConfig.MTU != nil && *multusConfig.Spec.MacvlanConfig.MTU < 0 {
+			return field.Invalid(macvlanConfigField, *multusConfig.Spec.MacvlanConfig.MTU, "MTU must be greater than or equal to 0")
+		}
+
 		if err := validateVlanCNIConfig(multusConfig.Spec.MacvlanConfig.Master, multusConfig.Spec.MacvlanConfig.Bond); err != nil {
 			return field.Invalid(macvlanConfigField, *multusConfig.Spec.MacvlanConfig, err.Error())
 		}
@@ -133,6 +137,10 @@ func validateCNIConfig(multusConfig *spiderpoolv2beta1.SpiderMultusConfig) *fiel
 			}
 		}
 
+		if multusConfig.Spec.IPVlanConfig.MTU != nil && *multusConfig.Spec.IPVlanConfig.MTU < 0 {
+			return field.Invalid(ipvlanConfigField, *multusConfig.Spec.IPVlanConfig.MTU, "MTU must be greater than or equal to 0")
+		}
+
 		if err := validateVlanCNIConfig(multusConfig.Spec.IPVlanConfig.Master, multusConfig.Spec.IPVlanConfig.Bond); err != nil {
 			return field.Invalid(ipvlanConfigField, *multusConfig.Spec.IPVlanConfig, err.Error())
 		}
@@ -162,6 +170,10 @@ func validateCNIConfig(multusConfig *spiderpoolv2beta1.SpiderMultusConfig) *fiel
 			if err := validateVlanId(*multusConfig.Spec.SriovConfig.VlanID); err != nil {
 				return field.Invalid(sriovConfigField, *multusConfig.Spec.SriovConfig.VlanID, err.Error())
 			}
+		}
+
+		if multusConfig.Spec.SriovConfig.MTU != nil && *multusConfig.Spec.SriovConfig.MTU < 0 {
+			return field.Invalid(macvlanConfigField, *multusConfig.Spec.MacvlanConfig.MTU, "MTU must be greater than or equal to 0")
 		}
 
 		if multusConfig.Spec.SriovConfig.MinTxRateMbps != nil && multusConfig.Spec.SriovConfig.MaxTxRateMbps != nil {

--- a/pkg/multuscniconfig/utils.go
+++ b/pkg/multuscniconfig/utils.go
@@ -38,12 +38,14 @@ type MacvlanNetConf struct {
 	Type   string                    `json:"type"`
 	Master string                    `json:"master"`
 	Mode   string                    `json:"mode"`
+	MTU    *int32                    `json:"mtu,omitempty"`
 	IPAM   *spiderpoolcmd.IPAMConfig `json:"ipam,omitempty"`
 }
 
 type IPvlanNetConf struct {
 	Type   string                    `json:"type"`
 	Master string                    `json:"master"`
+	MTU    *int32                    `json:"mtu,omitempty"`
 	IPAM   *spiderpoolcmd.IPAMConfig `json:"ipam,omitempty"`
 }
 
@@ -91,6 +93,11 @@ type IfacerNetConf struct {
 	Type       string              `json:"type"`
 	Interfaces []string            `json:"interfaces,omitempty"`
 	Bond       *v2beta1.BondConfig `json:"bond,omitempty"`
+}
+
+type tuningConf struct {
+	Type string `json:"type"`
+	Mtu  int32  `json:"mtu,omitempty"`
 }
 
 type CoordinatorConfig struct {

--- a/test/doc/spidermultus.md
+++ b/test/doc/spidermultus.md
@@ -33,3 +33,6 @@
 | M00030  |    return an err if cniType is not in [macvlan,ipvlan,sriov,ib-sriov,ipoib] when spidermutlus with annotation: cni.spidernet.io/rdma-resource-inject                                                                                     | p3       |       | done   |       |
 | M00031  |    resoucename and ippools config must be both set when spidermutlus with annotation: cni.spidernet.io/network-resource-inject                                                                                  | p3       |       | done   |       |
 | M00032  |    return an err if resoucename is set without ippools config when spidermutlus with annotation: cni.spidernet.io/network-resource-inject                                                                                  | p3       |       | done   |       |
+| M00033  |    test the multusConfig with mtu size for macvlan                                            | p3       |       | done   |       |
+| M00034  |    test the multusConfig with mtu size for ipvlan                                             | p3       |       | done   |       |
+| M00035  |    test the multusConfig with mtu size for sriov                                             | p3       |       | done   |       |


### PR DESCRIPTION
# Thanks for contributing!

**Notice**:

* [x] unite test or E2E test
* [x] do not forget essential code comment and log
* [x] document for the PR
* [x] release note label
  "release/none"
  "release/bug"
  "release/feature"
* [x] read about  Contribution notice: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>

**What issue(s) does this PR fix**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/spidernet-io/spiderpool/issues/4422

**Special notes for your reviewer**:

SpiderMultusConfig: Add mtu size support for macvlan and ipvlan
