### PR TITLE
chart: optimize rdma titles

### DIFF
--- a/charts/spiderpool/files/grafana-rdma-cluster.json
+++ b/charts/spiderpool/files/grafana-rdma-cluster.json
@@ -103,7 +103,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Number of RDMA-Capable Nodes",
+            "title": "RDMA-Capable Node Number",
             "type": "stat"
         },
         {
@@ -168,7 +168,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "RDMA Pod Count",
+            "title": "RDMA-Capable Pod Number",
             "type": "stat"
         },
         {
@@ -288,7 +288,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Cluster Bandwidth | Read",
+            "title": "Cluster Read Throughput In Total",
             "type": "timeseries"
         },
         {
@@ -412,7 +412,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Cluster Bandwidth  | Write",
+            "title": "Cluster Write Throughput In Total",
             "type": "timeseries"
         },
         {
@@ -532,7 +532,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Node Bandwidth | Read",
+            "title": "Node Read Throughput In Total",
             "type": "timeseries"
         },
         {
@@ -652,7 +652,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Node Bandwidth  | Write",
+            "title": "Node Write Throughput In Total",
             "type": "timeseries"
         },
         {
@@ -772,7 +772,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Rate of Bandwidth | Node | Read",
+            "title": "Node Read Bandwidth Usage Rate",
             "type": "timeseries"
         },
         {
@@ -892,7 +892,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Rate of Bandwidth | Node | Write",
+            "title": "Node Write Bandwidth Usage Rate",
             "type": "timeseries"
         },
         {
@@ -905,7 +905,7 @@
             },
             "id": 18,
             "panels": [],
-            "title": "Top traffic",
+            "title": "Hotspot",
             "type": "row"
         },
         {
@@ -1028,7 +1028,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Node Top 10 | Bandwidth | Read",
+            "title": "Top 10 Nodes With Highest Read Throughput",
             "type": "timeseries"
         },
         {
@@ -1151,7 +1151,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Node Top 10 | Bandwidth | Write",
+            "title": "Top 10 Nodes With Highest Write Throughput",
             "type": "timeseries"
         },
         {
@@ -1270,7 +1270,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Node Top 10 | Rate of Bandwidth  | Read",
+            "title": "Top 10 Nodes With Highest Read Throughput",
             "type": "timeseries"
         },
         {
@@ -1389,7 +1389,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Node Top 10 | Rate of Bandwidth | Write",
+            "title": "Top 10 Nodes With Highest Write Throughput",
             "type": "timeseries"
         },
         {
@@ -1512,7 +1512,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Pod Top 10 | Bandwidth | Read",
+            "title": "Top 10 Pods With Highest Read Throughput",
             "type": "timeseries"
         },
         {
@@ -1620,7 +1620,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Pod Top 10 | Bandwidth | Write",
+            "title": "Top 10 Pods With Highest Write Throughput",
             "type": "timeseries"
         },
         {
@@ -1743,7 +1743,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Workload Top 10 | Bandwidth | Read",
+            "title": "Top 10 AI Workloads with Highest Write Throughput",
             "type": "timeseries"
         },
         {
@@ -1866,7 +1866,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Workload Top 10 | Bandwidth | Read",
+            "title": "Top 10 AI Workloads with Highest Read Throughput",
             "type": "timeseries"
         }
     ],

--- a/charts/spiderpool/files/grafana-rdma-node.json
+++ b/charts/spiderpool/files/grafana-rdma-node.json
@@ -38,7 +38,7 @@
             },
             "id": 11,
             "panels": [],
-            "title": "Physical  Network Card",
+            "title": "Host PF (Physical Function)",
             "type": "row"
         },
         {
@@ -146,7 +146,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Bandwidth | Read",
+            "title": "Read Throughput",
             "type": "timeseries"
         },
         {
@@ -254,7 +254,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Bandwidth | Write",
+            "title": "Write Throughput",
             "type": "timeseries"
         },
         {
@@ -345,7 +345,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Rate of Bandwidth | Read",
+            "title": "Read Bandwidth Rate",
             "type": "timeseries"
         },
         {
@@ -437,7 +437,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Rate of Bandwidth | Write",
+            "title": "Write Bandwidth Rate",
             "type": "timeseries"
         },
         {
@@ -450,7 +450,7 @@
             },
             "id": 13,
             "panels": [],
-            "title": "Host RDMA Device",
+            "title": "Host PF and VF",
             "type": "row"
         },
         {
@@ -570,7 +570,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Host Bandwidth | Read",
+            "title": "Read Throughput",
             "type": "timeseries"
         },
         {
@@ -659,7 +659,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Host Bandwidth | Write",
+            "title": "Write Throughput",
             "type": "timeseries"
         },
         {
@@ -761,7 +761,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Pod Bandwidth | Read",
+            "title": "Read Throughput",
             "type": "timeseries"
         },
         {
@@ -850,7 +850,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Pod Bandwidth  Write",
+            "title": "Write Throughput",
             "type": "timeseries"
         },
         {
@@ -943,7 +943,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Pod Top 10 | Bandwidth | Read",
+            "title": "Top 10 Pods With Highest Read Throughput",
             "type": "timeseries"
         },
         {
@@ -1036,7 +1036,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Pod Top 10 | Bandwidth | Write",
+            "title": "Top 10 Pods With Highest Write Throughput",
             "type": "timeseries"
         }
     ],

--- a/charts/spiderpool/files/grafana-rdma-node.json
+++ b/charts/spiderpool/files/grafana-rdma-node.json
@@ -345,7 +345,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Read Bandwidth Rate",
+            "title": "Read Bandwidth Usage Rate",
             "type": "timeseries"
         },
         {
@@ -437,7 +437,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Write Bandwidth Rate",
+            "title": "Write Bandwidth Usage Rate",
             "type": "timeseries"
         },
         {

--- a/charts/spiderpool/files/grafana-rdma-pod.json
+++ b/charts/spiderpool/files/grafana-rdma-pod.json
@@ -419,7 +419,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Read Bandwidth Rate",
+            "title": "Read Bandwidth Usage Rate",
             "type": "timeseries"
         },
         {
@@ -546,7 +546,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Write Bandwidth Rate",
+            "title": "Write Bandwidth Usage Rate",
             "type": "timeseries"
         },
         {

--- a/charts/spiderpool/files/grafana-rdma-pod.json
+++ b/charts/spiderpool/files/grafana-rdma-pod.json
@@ -38,7 +38,7 @@
             },
             "id": 47,
             "panels": [],
-            "title": "Pod Level",
+            "title": "Pod",
             "type": "row"
         },
         {
@@ -165,7 +165,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Bandwidth | Read",
+            "title": "Read Throughput",
             "type": "timeseries"
         },
         {
@@ -292,7 +292,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Bandwidth | Write",
+            "title": "Write Throughput",
             "type": "timeseries"
         },
         {
@@ -419,7 +419,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Rate of Bandwidth | Read",
+            "title": "Read Bandwidth Rate",
             "type": "timeseries"
         },
         {
@@ -546,7 +546,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Rate of Bandwidth | Write",
+            "title": "Write Bandwidth Rate",
             "type": "timeseries"
         },
         {
@@ -4049,32 +4049,6 @@
                 "regex": "",
                 "skipUrlSync": false,
                 "sort": 0,
-                "type": "query"
-            },
-            {
-                "current": {
-                    "selected": true,
-                    "text": "10-20-1-50",
-                    "value": "10-20-1-50"
-                },
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                },
-                "definition": "label_values(rdma_tx_vport_rdma_unicast_bytes_total{cluster=~\"$cluster\"}, node_name)",
-                "hide": 0,
-                "includeAll": true,
-                "multi": false,
-                "name": "node",
-                "options": [],
-                "query": {
-                    "query": "label_values(rdma_tx_vport_rdma_unicast_bytes_total{cluster=~\"$cluster\"}, node_name)",
-                    "refId": "StandardVariableQuery"
-                },
-                "refresh": 1,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 1,
                 "type": "query"
             },
             {

--- a/charts/spiderpool/files/grafana-rdma-workload.json
+++ b/charts/spiderpool/files/grafana-rdma-workload.json
@@ -555,7 +555,7 @@
           "refId": "A"
         }
       ],
-      "title": "Unicast Read PPS",
+      "title": "Unicast Read Packets",
       "type": "timeseries"
     },
     {
@@ -667,7 +667,7 @@
           "refId": "A"
         }
       ],
-      "title": "Unicast Write PPS",
+      "title": "Unicast Written Packets",
       "type": "timeseries"
     },
     {
@@ -779,7 +779,7 @@
           "refId": "A"
         }
       ],
-      "title": "Multicast Read PPS",
+      "title": "Multicast Read Packets",
       "type": "timeseries"
     },
     {
@@ -891,7 +891,7 @@
           "refId": "A"
         }
       ],
-      "title": "Multicast Write PPS",
+      "title": "Multicast Written Packets",
       "type": "timeseries"
     },
     {
@@ -985,7 +985,7 @@
           "refId": "A"
         }
       ],
-      "title": "Out Of Sequence PPS",
+      "title": "Packets Out Of Sequence",
       "type": "timeseries"
     },
     {
@@ -1079,7 +1079,7 @@
           "refId": "A"
         }
       ],
-      "title": "Packet Sequence Error PPS ",
+      "title": "Packets In Sequence Error",
       "type": "timeseries"
     }
   ],

--- a/charts/spiderpool/files/grafana-rdma-workload.json
+++ b/charts/spiderpool/files/grafana-rdma-workload.json
@@ -127,7 +127,7 @@
           "refId": "A"
         }
       ],
-      "title": "Bandwidth per $kind | Read ",
+      "title": "Total Read Throughput",
       "type": "timeseries"
     },
     {
@@ -217,7 +217,7 @@
           "refId": "A"
         }
       ],
-      "title": "Bandwidth per $kind | Write",
+      "title": "Total Write Throughput",
       "type": "timeseries"
     },
     {
@@ -337,7 +337,7 @@
           "refId": "A"
         }
       ],
-      "title": "Bandwidth per Pod | Read",
+      "title": "Read Throughput",
       "type": "timeseries"
     },
     {
@@ -443,7 +443,7 @@
           "refId": "A"
         }
       ],
-      "title": "Bandwidth per Pod | Write",
+      "title": "Write Throughput",
       "type": "timeseries"
     },
     {
@@ -555,7 +555,7 @@
           "refId": "A"
         }
       ],
-      "title": "Packets per Pod | unicast | Read",
+      "title": "Unicast Read PPS",
       "type": "timeseries"
     },
     {
@@ -667,7 +667,7 @@
           "refId": "A"
         }
       ],
-      "title": "Packets per Pod | unicast | Write",
+      "title": "Unicast Write PPS",
       "type": "timeseries"
     },
     {
@@ -779,7 +779,7 @@
           "refId": "A"
         }
       ],
-      "title": "Packets per Pod | multicast | Read",
+      "title": "Multicast Read PPS",
       "type": "timeseries"
     },
     {
@@ -891,7 +891,7 @@
           "refId": "A"
         }
       ],
-      "title": "Packets per Pod | multicast | Write",
+      "title": "Multicast Write PPS",
       "type": "timeseries"
     },
     {
@@ -985,7 +985,7 @@
           "refId": "A"
         }
       ],
-      "title": "Pod Out of sequence ",
+      "title": "Out Of Sequence PPS",
       "type": "timeseries"
     },
     {
@@ -1079,7 +1079,7 @@
           "refId": "A"
         }
       ],
-      "title": "Pod Packet sequence error",
+      "title": "Packet Sequence Error PPS ",
       "type": "timeseries"
     }
   ],


### PR DESCRIPTION
一些描述需要精简，避免冗长
需要体现 400g bandwidth 等信息，错开使用 throughout 的关键字
标题的首字母 大写
一些语法问题