### PR TITLE
ipam: add GC option for running pods with empty podIPs

### DIFF
--- a/charts/spiderpool/README.md
+++ b/charts/spiderpool/README.md
@@ -127,22 +127,23 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 
 ### ipam parameters
 
-| Name                                                  | Description                                                                                      | Value   |
-| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ------- |
-| `ipam.enableIPv4`                                     | enable ipv4                                                                                      | `true`  |
-| `ipam.enableIPv6`                                     | enable ipv6                                                                                      | `true`  |
-| `ipam.enableStatefulSet`                              | the network mode                                                                                 | `true`  |
-| `ipam.enableKubevirtStaticIP`                         | the feature to keep kubevirt vm pod static IP                                                    | `true`  |
-| `ipam.enableIPConflictDetection`                      | enable IP conflict detection                                                                     | `false` |
-| `ipam.enableGatewayDetection`                         | enable gateway detection                                                                         | `false` |
-| `ipam.spiderSubnet.enable`                            | SpiderSubnet feature.                                                                            | `true`  |
-| `ipam.spiderSubnet.autoPool.enable`                   | SpiderSubnet Auto IPPool feature.                                                                | `true`  |
-| `ipam.spiderSubnet.autoPool.defaultRedundantIPNumber` | the default redundant IP number of SpiderSubnet feature auto-created IPPools                     | `1`     |
-| `ipam.gc.enabled`                                     | enable retrieve IP in spiderippool CR                                                            | `true`  |
-| `ipam.gc.gcAll.intervalInSecond`                      | the gc all interval duration                                                                     | `600`   |
-| `ipam.gc.statelessPod.zombieOnReadyNode`              | enable reclaim IP for the stateless pod who is over deleting graceful period on a ready node     | `true`  |
-| `ipam.gc.statelessPod.zombieOnNotReadyNode`           | enable reclaim IP for the stateless pod who is over deleting graceful period on a not-ready node | `true`  |
-| `ipam.gc.gcDeletingTimeOutPodDelay`                   | the gc delay seconds after the pod times out of deleting graceful period                         | `0`     |
+| Name                                                         | Description                                                                                      | Value   |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ | ------- |
+| `ipam.enableIPv4`                                            | enable ipv4                                                                                      | `true`  |
+| `ipam.enableIPv6`                                            | enable ipv6                                                                                      | `true`  |
+| `ipam.enableStatefulSet`                                     | the network mode                                                                                 | `true`  |
+| `ipam.enableKubevirtStaticIP`                                | the feature to keep kubevirt vm pod static IP                                                    | `true`  |
+| `ipam.enableIPConflictDetection`                             | enable IP conflict detection                                                                     | `false` |
+| `ipam.enableGatewayDetection`                                | enable gateway detection                                                                         | `false` |
+| `ipam.spiderSubnet.enable`                                   | SpiderSubnet feature.                                                                            | `true`  |
+| `ipam.spiderSubnet.autoPool.enable`                          | SpiderSubnet Auto IPPool feature.                                                                | `true`  |
+| `ipam.spiderSubnet.autoPool.defaultRedundantIPNumber`        | the default redundant IP number of SpiderSubnet feature auto-created IPPools                     | `1`     |
+| `ipam.gc.enabled`                                            | enable retrieve IP in spiderippool CR                                                            | `true`  |
+| `ipam.gc.gcAll.intervalInSecond`                             | the gc all interval duration                                                                     | `600`   |
+| `ipam.gc.statelessPod.zombieOnReadyNode`                     | enable reclaim IP for the stateless pod who is over deleting graceful period on a ready node     | `true`  |
+| `ipam.gc.statelessPod.zombieOnNotReadyNode`                  | enable reclaim IP for the stateless pod who is over deleting graceful period on a not-ready node | `true`  |
+| `ipam.gc.statelessPod.enableGcRunningPodOnEmptyPodStatusIPs` | enable reclaim IP for the stateless pod who is running and empty pod status IPs                  | `false` |
+| `ipam.gc.gcDeletingTimeOutPodDelay`                          | the gc delay seconds after the pod times out of deleting graceful period                         | `0`     |
 
 ### grafanaDashboard parameters
 

--- a/charts/spiderpool/templates/deployment.yaml
+++ b/charts/spiderpool/templates/deployment.yaml
@@ -165,6 +165,8 @@ spec:
           value: {{ .Values.ipam.gc.statelessPod.zombieOnReadyNode | quote }}
         - name: SPIDERPOOL_GC_STATELESS_TERMINATING_POD_ON_NOT_READY_NODE_ENABLED
           value: {{ .Values.ipam.gc.statelessPod.zombieOnNotReadyNode | quote }}
+        - name: SPIDERPOOL_GC_ENABLE_STATELESS_RUNNING_POD_ON_EMPTY_POD_STATUS_IPS
+          value: {{ .Values.ipam.gc.statelessPod.enableGcRunningPodOnEmptyPodStatusIPs | quote }}
         - name: SPIDERPOOL_GC_ADDITIONAL_GRACE_DELAY
           value: {{ .Values.ipam.gc.gcDeletingTimeOutPodDelay | quote }}
         - name: SPIDERPOOL_GC_DEFAULT_INTERVAL_DURATION

--- a/charts/spiderpool/values.yaml
+++ b/charts/spiderpool/values.yaml
@@ -85,6 +85,9 @@ ipam:
       ## @param ipam.gc.statelessPod.zombieOnNotReadyNode enable reclaim IP for the stateless pod who is over deleting graceful period on a not-ready node
       zombieOnNotReadyNode: true
 
+      ## @param ipam.gc.statelessPod.enableGcRunningPodOnEmptyPodStatusIPs enable reclaim IP for the stateless pod who is running and empty pod status IPs
+      enableGcRunningPodOnEmptyPodStatusIPs: false
+
     ## @param ipam.gc.gcDeletingTimeOutPodDelay the gc delay seconds after the pod times out of deleting graceful period
     gcDeletingTimeOutPodDelay: 0
 

--- a/cmd/spiderpool-controller/cmd/config.go
+++ b/cmd/spiderpool-controller/cmd/config.go
@@ -67,6 +67,7 @@ var envInfo = []envConf{
 	{"SPIDERPOOL_GC_IP_ENABLED", "true", true, nil, &gcIPConfig.EnableGCIP, nil},
 	{"SPIDERPOOL_GC_STATELESS_TERMINATING_POD_ON_READY_NODE_ENABLED", "true", true, nil, &gcIPConfig.EnableGCStatelessTerminatingPodOnReadyNode, nil},
 	{"SPIDERPOOL_GC_STATELESS_TERMINATING_POD_ON_NOT_READY_NODE_ENABLED", "true", true, nil, &gcIPConfig.EnableGCStatelessTerminatingPodOnNotReadyNode, nil},
+	{"SPIDERPOOL_GC_ENABLE_STATELESS_RUNNING_POD_ON_EMPTY_POD_STATUS_IPS", "false", true, nil, &gcIPConfig.EnableGCStatelessRunningPodOnEmptyPodStatusIPs, nil},
 	{"SPIDERPOOL_GC_IP_WORKER_NUM", "3", true, nil, nil, &gcIPConfig.ReleaseIPWorkerNum},
 	{"SPIDERPOOL_GC_CHANNEL_BUFFER", "5000", true, nil, nil, &gcIPConfig.GCIPChannelBuffer},
 	{"SPIDERPOOL_GC_MAX_PODENTRY_DB_CAP", "100000", true, nil, nil, &gcIPConfig.MaxPodEntryDatabaseCap},

--- a/docs/concepts/ipam-des-zh_CN.md
+++ b/docs/concepts/ipam-des-zh_CN.md
@@ -186,6 +186,8 @@ NOTE：
   
   - 对于处于 `Terminating` 阶段的 **无状态** Pod，Spiderpool 将在 Pod 的 `spec.terminationGracePeriodSecond` + [spiderpool-controller ENV](./../reference/spiderpool-controller.md#env) `SPIDERPOOL_GC_ADDITIONAL_GRACE_DELAY` 时间后，自动释放其 IP 地址。该功能可通过环境变量 `SPIDERPOOL_GC_STATELESS_TERMINATING_POD_ON_NOT_READY_NODE_ENABLED` 控制，解决 `节点意外宕机` 的故障场景。
 
+- 对于节点重启等意外情况导致 Pod 的 Sandbox 容器重启，Pod 状态为 Running 但 status 中的 podIPs 字段被清空，Spiderpool 之前会将其 IP 地址回收，但可能会导致 IP 地址的重复分配。目前 Spiderpool 默认不会回收该状态的 Pod。该功能可通过环境变量 [spiderpool-controller ENV](./../reference/spiderpool-controller.md#env)`SPIDERPOOL_GC_ENABLE_STATELESS_RUNNING_POD_ON_EMPTY_POD_STATUS_IPS` 控制（默认为 false）。
+
 ### IP 冲突检测和网关可达性检测
 
 对于 Underlay 网络，IP 冲突是无法接受的，这可能会造成严重的问题。Spiderpool 支持 IP 冲突检测和网关可达性检测，该功能以前由 coordinator 插件实现，由于可能会导致一些潜在的通信问题。现在由 IPAM 完成。

--- a/docs/concepts/ipam-des.md
+++ b/docs/concepts/ipam-des.md
@@ -210,6 +210,8 @@ The above complete IP recovery algorithm can ensure the correct recovery of IP a
 
   - For the **stateless** Pod in the `Terminating` phase, Spiderpool will automatically release its IP address after the Pod's `spec.terminationGracePeriodSecond`. This feature can be controlled by the environment variable `SPIDERPOOL_GC_STATELESS_TERMINATING_POD_ON_NOT_READY_NODE_ENABLED`. This capability can be used to solve the failure scenario of `unexpected node downtime`.
 
+- For the **stateless** Pod in the `Running` phase, Spiderpool will not release its IP address when the Pod's `status.podIPs` is empty. This feature can be controlled by the environment variable `SPIDERPOOL_GC_ENABLE_STATELESS_RUNNING_POD_ON_EMPTY_POD_STATUS_IPS`.
+
 ### IP Conflict Detection and Gateway Reachability Detection
 
 For Underlay networks, IP conflicts are unacceptable as they can cause serious issues. Spiderpool supports IP conflict detection and gateway reachability detection, which were previously implemented by the coordinator plugin but could cause some potential communication problems. Now, this is handled by IPAM.

--- a/docs/reference/spiderpool-controller.md
+++ b/docs/reference/spiderpool-controller.md
@@ -26,6 +26,7 @@ Run the spiderpool controller daemon.
 | SPIDERPOOL_GC_IP_ENABLED                                          | true    | Enable/disable IP GC.                                                                            |
 | SPIDERPOOL_GC_STATELESS_TERMINATING_POD_ON_READY_NODE_ENABLED     | true    | Enable/disable IP GC for stateless Terminating pod when the pod corresponding node is ready.     |
 | SPIDERPOOL_GC_STATELESS_TERMINATING_POD_ON_NOT_READY_NODE_ENABLED | true    | Enable/disable IP GC for stateless Terminating pod when the pod corresponding node is not ready. |
+| SPIDERPOOL_GC_ENABLE_STATELESS_RUNNING_POD_ON_EMPTY_POD_STATUS_IPS | false   | Enable/disable IP GC for stateless pod who is running and empty pod status IPs.                  |
 | SPIDERPOOL_GC_ADDITIONAL_GRACE_DELAY                              | true    | The gc delay seconds after the pod times out of deleting graceful period.                        |
 | SPIDERPOOL_GC_DEFAULT_INTERVAL_DURATION                           | true    | The gc all interval duration.                                                                    |
 | SPIDERPOOL_MULTUS_CONFIG_ENABLED                                  | true    | Enable/disable SpiderMultusConfig.                                                               |

--- a/pkg/gcmanager/gc_manager.go
+++ b/pkg/gcmanager/gc_manager.go
@@ -24,11 +24,12 @@ import (
 )
 
 type GarbageCollectionConfig struct {
-	EnableGCIP                                    bool
-	EnableGCStatelessTerminatingPodOnReadyNode    bool
-	EnableGCStatelessTerminatingPodOnNotReadyNode bool
-	EnableStatefulSet                             bool
-	EnableKubevirtStaticIP                        bool
+	EnableGCIP                                     bool
+	EnableGCStatelessTerminatingPodOnReadyNode     bool
+	EnableGCStatelessTerminatingPodOnNotReadyNode  bool
+	EnableGCStatelessRunningPodOnEmptyPodStatusIPs bool
+	EnableStatefulSet                              bool
+	EnableKubevirtStaticIP                         bool
 
 	ReleaseIPWorkerNum     int
 	GCIPChannelBuffer      int

--- a/pkg/gcmanager/scanAll_IPPool.go
+++ b/pkg/gcmanager/scanAll_IPPool.go
@@ -238,8 +238,17 @@ func (s *SpiderGC) executeScanAll(ctx context.Context) {
 								flagPodStatusShouldGCIP = true
 							}
 						} else {
-							wrappedLog.Sugar().Infof("pod %s/%s has no IP address assigned and is not a static Pod. IPPool.Status.AllocatedIPs %s in IPPool should be reclaimed.", podNS, podName, poolIP)
-							flagPodStatusShouldGCIP = true
+							if podYaml.Status.Phase == corev1.PodRunning {
+								if s.gcConfig.EnableGCStatelessRunningPodOnEmptyPodStatusIPs {
+									wrappedLog.Sugar().Infof("Try to GC IP %s of pod %s/%s, because GC flag EnableGCStatelessRunningPodOnEmptyPodStatusIPs is enabled, and pod in running state has no IP address assigned and is not a static Pod.", poolIP, podNS, podName)
+									flagPodStatusShouldGCIP = true
+								} else {
+									wrappedLog.Sugar().Debugf("No need to GC IP %s of pod %s/%s, because GC flag EnableGCStatelessRunningPodOnEmptyPodStatusIPs is disabled, even pod %s/%s in running state has no IP address assigned and is not a static Pod.", poolIP, podNS, podName)
+								}
+							} else {
+								wrappedLog.Sugar().Debugf("Try to GC IP %s of pod %s/%s, pod is in %s state and has no IP address assigned.", poolIP, podNS, podName, podYaml.Status.Phase)
+								flagPodStatusShouldGCIP = true
+							}
 						}
 					}
 				}


### PR DESCRIPTION
# Thanks for contributing!

**Notice**:

* [ ] unite test or E2E test
* [ ] do not forget essential code comment and log
* [ ] document for the PR
* [ ] release note label
  "release/none"
  "release/bug"
  "release/feature"
* [ ] read about  Contribution notice: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>

**What issue(s) does this PR fix**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/spidernet-io/spiderpool/issues/4888

**Special notes for your reviewer**:

- 提供环境变量：`SPIDERPOOL_GC_ENABLE_STATELESS_RUNNING_POD_ON_EMPTY_POD_STATUS_IPS`，默认为 false，意味不会 GC 调那些 status.podIPs 为空但 Running 的 Pod。当设置为 true, 则会 GC。

- Provide environment variable:  `SPIDERPOOL_GC_ENABLE_STATELESS_RUNNING_POD_ON_EMPTY_POD_STATUS_IPS`, default is false, meaning it will not GC pods that are Running but have empty status.podIPs. When set to true, it will GC these pods.

This configuration controls Spiderpool's Pod GC strategy:

When false (default): Spiderpool will not GC pods that are Running but have empty status.podIPs
When true: Spiderpool will GC these pods
This feature is used to handle cases where pods are running but their status is empty due to some issues, allowing you to control whether these pods should be GC'd through this configuration.
