### PR TITLE
Remove outdated endpoints to prevent blocking the creation of new Pods

### DIFF
--- a/charts/spiderpool/README.md
+++ b/charts/spiderpool/README.md
@@ -135,6 +135,7 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 | `ipam.enableKubevirtStaticIP`                                | the feature to keep kubevirt vm pod static IP                                                    | `true`  |
 | `ipam.enableIPConflictDetection`                             | enable IP conflict detection                                                                     | `false` |
 | `ipam.enableGatewayDetection`                                | enable gateway detection                                                                         | `false` |
+| `ipam.enableCleanOutdatedEndpoint`                           | enable clean outdated endpoint                                                                   | `false` |
 | `ipam.spiderSubnet.enable`                                   | SpiderSubnet feature.                                                                            | `true`  |
 | `ipam.spiderSubnet.autoPool.enable`                          | SpiderSubnet Auto IPPool feature.                                                                | `true`  |
 | `ipam.spiderSubnet.autoPool.defaultRedundantIPNumber`        | the default redundant IP number of SpiderSubnet feature auto-created IPPools                     | `1`     |

--- a/charts/spiderpool/templates/configmap.yaml
+++ b/charts/spiderpool/templates/configmap.yaml
@@ -20,6 +20,7 @@ data:
     enableIPv6: {{ .Values.ipam.enableIPv6 }}
     enableStatefulSet: {{ .Values.ipam.enableStatefulSet }}
     enableKubevirtStaticIP: {{ .Values.ipam.enableKubevirtStaticIP }}
+    enableCleanOutdatedEndpoint: {{ .Values.ipam.enableCleanOutdatedEndpoint }}
     enableSpiderSubnet: {{ .Values.ipam.spiderSubnet.enable }}
     enableAutoPoolForApplication: {{ .Values.ipam.spiderSubnet.autoPool.enable }}
     enableIPConflictDetection: {{ .Values.ipam.enableIPConflictDetection }}

--- a/charts/spiderpool/values.yaml
+++ b/charts/spiderpool/values.yaml
@@ -59,6 +59,9 @@ ipam:
   ## @param ipam.enableGatewayDetection enable gateway detection
   enableGatewayDetection: false
 
+  ## @param ipam.enableCleanOutdatedEndpoint enable clean outdated endpoint
+  enableCleanOutdatedEndpoint: false
+
   spiderSubnet:
     ## @param ipam.spiderSubnet.enable SpiderSubnet feature.
     enable: true

--- a/cmd/spiderpool-controller/cmd/daemon.go
+++ b/cmd/spiderpool-controller/cmd/daemon.go
@@ -399,6 +399,8 @@ func initGCManager(ctx context.Context) {
 	gcIPConfig.EnableStatefulSet = controllerContext.Cfg.EnableStatefulSet
 	// EnableKubevirtStaticIP was determined by Configmap.
 	gcIPConfig.EnableKubevirtStaticIP = controllerContext.Cfg.EnableKubevirtStaticIP
+	// EnableCleanOutdatedEndpoint was determined by Configmap.
+	gcIPConfig.EnableCleanOutdatedEndpoint = controllerContext.Cfg.EnableCleanOutdatedEndpoint
 	gcIPConfig.LeaderRetryElectGap = time.Duration(controllerContext.Cfg.LeaseRetryGap) * time.Second
 	gcManager, err := gcmanager.NewGCManager(
 		controllerContext.ClientSet,

--- a/docs/concepts/ipam-des-zh_CN.md
+++ b/docs/concepts/ipam-des-zh_CN.md
@@ -188,6 +188,21 @@ NOTE：
 
 - 对于节点重启等意外情况导致 Pod 的 Sandbox 容器重启，Pod 状态为 Running 但 status 中的 podIPs 字段被清空，Spiderpool 之前会将其 IP 地址回收，但可能会导致 IP 地址的重复分配。目前 Spiderpool 默认不会回收该状态的 Pod。该功能可通过环境变量 [spiderpool-controller ENV](./../reference/spiderpool-controller.md#env)`SPIDERPOOL_GC_ENABLE_STATELESS_RUNNING_POD_ON_EMPTY_POD_STATUS_IPS` 控制（默认为 false）。
 
+### 回收僵尸 SpiderEndpoint
+
+Spiderpool 会周期性扫描 SpiderEndpoint，如果发现 IP 池中的某个 Pod 对应的 IP 分配记录已经不存在，但是其 SpiderEndpoint 对象仍然存在，Spiderpool 将会回收该 SpiderEndpoint。该功能可通过 `spiderpool-conf` configMap 开启或关闭, 默认为 false:
+
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: spiderpool-conf
+      namespace: spiderpool
+    data:
+      conf.yml: |
+        ...
+        enableCleanOutdatedEndpoint: true
+        ...
+
 ### IP 冲突检测和网关可达性检测
 
 对于 Underlay 网络，IP 冲突是无法接受的，这可能会造成严重的问题。Spiderpool 支持 IP 冲突检测和网关可达性检测，该功能以前由 coordinator 插件实现，由于可能会导致一些潜在的通信问题。现在由 IPAM 完成。

--- a/docs/concepts/ipam-des.md
+++ b/docs/concepts/ipam-des.md
@@ -212,6 +212,23 @@ The above complete IP recovery algorithm can ensure the correct recovery of IP a
 
 - For the **stateless** Pod in the `Running` phase, Spiderpool will not release its IP address when the Pod's `status.podIPs` is empty. This feature can be controlled by the environment variable `SPIDERPOOL_GC_ENABLE_STATELESS_RUNNING_POD_ON_EMPTY_POD_STATUS_IPS`.
 
+### Clean Outdated SpiderEndpoint
+
+Spiderpool periodically scans SpiderEndpoints. If it finds that the IP allocation record for a Pod in the IP pool no longer exists, but the corresponding SpiderEndpoint object still exists, Spiderpool will reclaim that SpiderEndpoint. This feature can be enabled or disabled via the spiderpool-conf ConfigMap, and is disabled (false) by default:
+
+    ```yaml
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: spiderpool-conf
+      namespace: spiderpool
+    data:
+      conf.yml: |
+        ...
+        enableCleanOutdatedEndpoint: true
+        ...
+    ```
+
 ### IP Conflict Detection and Gateway Reachability Detection
 
 For Underlay networks, IP conflicts are unacceptable as they can cause serious issues. Spiderpool supports IP conflict detection and gateway reachability detection, which were previously implemented by the coordinator plugin but could cause some potential communication problems. Now, this is handled by IPAM.

--- a/pkg/types/k8s.go
+++ b/pkg/types/k8s.go
@@ -117,6 +117,7 @@ type SpiderpoolConfigmapConfig struct {
 	EnableKubevirtStaticIP                        bool                    `yaml:"enableKubevirtStaticIP"`
 	EnableSpiderSubnet                            bool                    `yaml:"enableSpiderSubnet"`
 	EnableAutoPoolForApplication                  bool                    `yaml:"enableAutoPoolForApplication"`
+	EnableCleanOutdatedEndpoint                   bool                    `yaml:"enableCleanOutdatedEndpoint"`
 	EnableIPConflictDetection                     bool                    `yaml:"enableIPConflictDetection"`
 	EnableGatewayDetection                        bool                    `yaml:"enableGatewayDetection"`
 	ClusterSubnetAutoPoolDefaultRedundantIPNumber int                     `yaml:"clusterSubnetAutoPoolDefaultRedundantIPNumber"`

--- a/pkg/workloadendpointmanager/workloadendpoint_manager.go
+++ b/pkg/workloadendpointmanager/workloadendpoint_manager.go
@@ -122,7 +122,6 @@ func (em *workloadEndpointManager) PatchIPAllocationResults(ctx context.Context,
 	}
 
 	logger := logutils.FromContext(ctx)
-
 	if endpoint == nil {
 		endpoint = &spiderpoolv2beta1.SpiderEndpoint{
 			ObjectMeta: metav1.ObjectMeta{
@@ -162,6 +161,7 @@ func (em *workloadEndpointManager) PatchIPAllocationResults(ctx context.Context,
 	}
 
 	if endpoint.Status.Current.UID != string(pod.UID) {
+		logger.Sugar().Infof("UID mismatch detected: endpoint %s/%s (UID: %s) does not match Pod UID (%s). This may occur when two Pods with identical namespace/name were created in rapid succession. Skipping endpoint patch", endpoint.Namespace, endpoint.Name, endpoint.Status.Current.UID, string(pod.UID))
 		return nil
 	}
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -461,6 +461,7 @@ helm_upgrade_spiderpool:
 		HELM_OPTION+=" --set ipam.spiderSubnet.autoPool.enable=true " ; \
 		HELM_OPTION+=" --set ipam.spiderSubnet.autoPool.defaultRedundantIPNumber=1 " ; \
 	fi ; \
+	HELM_OPTION+=" --set ipam.enableCleanOutdatedEndpoint=true " ; \
 	ALL_IMAGES=`helm template $(RELEASE_NAME) $(ROOT_DIR)/charts/spiderpool $${HELM_OPTION} | grep ' image: ' | tr -d '"' | awk -F 'image: ' '{print $$2}' | sort | uniq | tr '\n' ' '` ; \
 	echo "ALL_IMAGES: $${ALL_IMAGES} " ; \
 	for IMAGE in $${ALL_IMAGES}; do \

--- a/test/e2e/annotation/annotation_test.go
+++ b/test/e2e/annotation/annotation_test.go
@@ -625,7 +625,7 @@ var _ = Describe("test annotation", Label("annotation"), func() {
 		}
 	})
 
-	Context("run pods with multi-NIC ippools annotations successfully", Label("A00010"), func() {
+	Context("run pods with multi-NIC ippools annotations successfully", Serial, Label("A00010"), func() {
 		var v4PoolName, v6PoolName, v4PoolName1, v6PoolName1, newv4SubnetName, newv6SubnetName string
 		var v4Pool, v6Pool, v4Pool1, v6Pool1 *spiderpool.SpiderIPPool
 		var newv4SubnetObject, newv6SubnetObject *spiderpool.SpiderSubnet


### PR DESCRIPTION
# Thanks for contributing!

**Notice**:

* [ ] unite test or E2E test
* [x] do not forget essential code comment and log
* [x] document for the PR
* [x] release note label
  "release/none"
  "release/bug"
  "release/feature"
* [x] read about  Contribution notice: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>

**What issue(s) does this PR fix**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/spidernet-io/spiderpool/issues/4916

**Special notes for your reviewer**:

本 PR 主要涉及以下两个改动：

1. 修复 endpoint 残留导致 新 Pod 无法启动的问题。

- 对于无状态应用，分配 IP 时检查 Pod 其 endpoint 是否 uid 一致，不一致则清理掉 endpoint。有状态应用无改动。
- 如果 Pod 已经超过最大优雅删除时间，可能其 IP 资源已经通过 CNI Del 回收。在之前 GC 不会处理这种情况，该 PR 为了保障一些极端情况下 endpoint 不会回收，通过 trace_worker 中将 与 pod  uuid 不一致的 endpoint 清理掉。
- 在全局 GC 提供定时清理那些 Pod 已经不存在的 endpoint. 该功能可通过一个 flag 决定是否开启

2. 修复可能存在 endpoint 被清理导致丢失的问题。

- 在分配 IP时，如果不能复用 IP 分配，并且 endpoint 存在并且其 uuid 和 pod 不一致的情况下，endpoint 资源对象可能已经在之前步骤中被删除，此时需要置 endpoint 为 nil,确保 后续会创建一个新的 endpoint，而不会出现 endpoint 丢失的情况。

This PR mainly involves the following two changes:

Fix the issue where residual endpoints prevent new Pods from starting.
For stateless applications, during IP allocation, the Pod's endpoint is checked for UID consistency. If the UIDs do not match, the endpoint is cleaned up. There are no changes for stateful applications.
If a Pod has exceeded the maximum graceful deletion time, its IP resources may have already been reclaimed by CNI Del. Previously, GC would not handle this case. To ensure that endpoints are not left behind in some edge cases, this PR cleans up endpoints whose UUIDs do not match the Pod's in the trace_worker.
The global GC now provides periodic cleanup for endpoints whose Pods no longer exist. This feature can be enabled or disabled via a flag.
Fix a potential issue where endpoints could be lost after cleanup.
During IP allocation, if IP reuse is not possible and the endpoint exists but its UUID does not match the Pod's, the endpoint resource may have already been deleted in a previous step. In this case, the endpoint should be set to nil to ensure that a new endpoint will be created later, preventing the loss of the endpoint object.


**Release note**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
