### PR TITLE
Optimize GitHub Actions to prevent duplicate PRs

### DIFF
--- a/.github/workflows/auto-update-authors.yaml
+++ b/.github/workflows/auto-update-authors.yaml
@@ -61,6 +61,32 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
 
+      - name: Close existing PRs with same title
+        if: ${{ env.SKIP_CREATE_PR != 'true' }}
+        run: |
+          PR_TITLE="robot updates Spiderpool authors on tag: ${{ env.REF }}"
+          echo "Checking for existing PRs with title: $PR_TITLE"
+          # Get list of open PRs with the same title
+          EXISTING_PRS=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls?state=open" | \
+            jq -r ".[] | select(.title == \"$PR_TITLE\") | .number")
+          # Close each existing PR
+          for PR_NUMBER in $EXISTING_PRS; do
+            echo "Closing existing PR #$PR_NUMBER"
+            # Add a comment before closing
+            curl -s -X POST \
+              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+              -d '{"body":"Closing this PR as a newer version is available."}'
+            # Close the PR
+            curl -s -X PATCH \
+              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER" \
+              -d '{"state":"closed"}'
+          done
+
       # Allow auto-merge on general
       - name: Create Pull Request
         if: ${{ env.SKIP_CREATE_PR != 'true' }}

--- a/.github/workflows/update-cniplugins-version.yaml
+++ b/.github/workflows/update-cniplugins-version.yaml
@@ -35,13 +35,39 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
 
+      - name: Close existing PRs with same title
+        if: ${{ env.updated == 'true' }}
+        run: |
+          PR_TITLE="robot updated CNI plugins version"
+          echo "Checking for existing PRs with title: $PR_TITLE"
+          # Get list of open PRs with the same title
+          EXISTING_PRS=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls?state=open" | \
+            jq -r ".[] | select(.title == \"$PR_TITLE\") | .number")
+          # Close each existing PR
+          for PR_NUMBER in $EXISTING_PRS; do
+            echo "Closing existing PR #$PR_NUMBER"
+            # Add a comment before closing
+            curl -s -X POST \
+              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+              -d '{"body":"Closing this PR as a newer version is available."}'
+            # Close the PR
+            curl -s -X PATCH \
+              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER" \
+              -d '{"state":"closed"}'
+          done
+
       - name: Create Pull Request
         id: create_pr
         if: ${{ env.updated == 'true' }}
         uses: peter-evans/create-pull-request@v7.0.8
         with:
-          title: "robot updated CNI plugins version "
-          commit-message: "robot updated CNI plugins version "
+          title: "robot updated CNI plugins version"
+          commit-message: "robot updated CNI plugins version"
           branch-suffix: timestamp
           branch: robot/update_cni_version
           committer: weizhoublue<weizhou.lan@daocloud.io>

--- a/.github/workflows/update-golang-version.yaml
+++ b/.github/workflows/update-golang-version.yaml
@@ -69,6 +69,32 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
 
+      - name: Close existing PRs with same title
+        if: ${{ env.updated == 'true' }}
+        run: |
+          PR_TITLE="robot updated golang version"
+          echo "Checking for existing PRs with title: $PR_TITLE"
+          # Get list of open PRs with the same title
+          EXISTING_PRS=$(curl -s -H "Authorization: token ${{ secrets.WELAN_PAT }}" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls?state=open" | \
+            jq -r ".[] | select(.title == \"$PR_TITLE\") | .number")
+          # Close each existing PR
+          for PR_NUMBER in $EXISTING_PRS; do
+            echo "Closing existing PR #$PR_NUMBER"
+            # Add a comment before closing
+            curl -s -X POST \
+              -H "Authorization: token ${{ secrets.WELAN_PAT }}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+              -d '{"body":"Closing this PR as a newer version is available."}'
+            # Close the PR
+            curl -s -X PATCH \
+              -H "Authorization: token ${{ secrets.WELAN_PAT }}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER" \
+              -d '{"state":"closed"}'
+          done
+
       - name: Create Pull Request
         id: create_pr
         if: ${{ env.updated == 'true' }}


### PR DESCRIPTION
## 问题描述
当前GitHub Actions在更新CNI插件版本、Golang版本和作者信息时，会创建多个具有相同标题的PR，导致PR列表中出现重复项。

## 解决方案
为以下三个workflow添加了在创建新PR之前关闭相同标题现有PR的功能：

### 修改的workflow文件：
1. `.github/workflows/update-cniplugins-version.yaml` - 处理CNI插件版本更新
2. `.github/workflows/update-golang-version.yaml` - 处理Golang版本更新  
3. `.github/workflows/auto-update-authors.yaml` - 处理作者信息更新

### 实现细节
每个workflow都新增了一个步骤：
- **步骤名称**: "Close existing PRs with same title"
- **执行时机**: 仅在检测到需要更新时执行
- **功能**: 
  - 使用GitHub API查询具有相同标题的开放PR
  - 对每个找到的PR添加关闭评论
  - 将PR状态设置为closed
  - 使用适当的权限token（GITHUB_TOKEN或WELAN_PAT）

### 预期效果
- 每个标题类型只会保留最新的一个开放PR
- 旧的PR会被优雅关闭并附带说明
- 减少PR列表中的重复项，提高维护效率
- 保持原有功能不变，只是优化了PR管理

## 测试验证
- 所有修改的YAML文件都通过了语法验证
- 保持了原有workflow的功能完整性
- 新增的API调用遵循GitHub最佳实践

这个优化将显著减少重复PR的数量，使维护工作更加高效。