### PR TITLE
Add custom runtime netns path

### DIFF
--- a/charts/spiderpool/templates/daemonset.yaml
+++ b/charts/spiderpool/templates/daemonset.yaml
@@ -234,7 +234,7 @@ spec:
         {{- end }}
           volumeMounts:
             - name: host-ns
-              mountPath: /var/run/netns
+              mountPath: /var/run
               mountPropagation: Bidirectional
             - name: config-path
               mountPath: /tmp/spiderpool/config-map
@@ -315,7 +315,7 @@ spec:
           # multus
         - name: host-ns
           hostPath:
-            path: /var/run/netns
+            path: "/var/run"
         {{- if .Values.multus.multusCNI.install }}
         - name: cni
           hostPath:


### PR DESCRIPTION
# Thanks for contributing!

**Notice**:

* [ ] unite test or E2E test
* [x] do not forget essential code comment and log
* [x] document for the PR
* [x] release note label
  "release/none"
  "release/bug"
  "release/feature"
* [x] read about  Contribution notice: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>

**What issue(s) does this PR fix**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/spidernet-io/spiderpool/issues/5100

**Special notes for your reviewer**:

优先方案：

目前看还是支持自定义 host container netns path 比较合适。从 `/proc` 下面列出有点是通用，但是缺点大于优点。例如前一秒列出，后一秒这个 proc 退出，该 proc 为 container 下的子进程，`/proc/<pid>/ns/net` 可能不存在，可能导致这次采集缺失。开源项目 tetragon 也是通过直接指定 runtime netns 的方式使用。

备选方案：

1. 列出所有 /proc 的 pid
2. 读取 /proc/<pid>/ns/net 的 netns，如果这个 netns 没有处理过，这继续（如果处理过，说明一个容器的多个 proc，则 skip）
3. 这样就可以读这个 netns 的一些数据（比如 rdma 的数据）

**Release note**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added support for specifying custom container runtime network namespace paths for RDMA metrics collection.
```
