### PR TITLE
Add custom runtime netns path

### DIFF
--- a/charts/spiderpool/templates/daemonset.yaml
+++ b/charts/spiderpool/templates/daemonset.yaml
@@ -111,16 +111,16 @@ spec:
           image: {{ include "spiderpool.multus.image" . | quote }}
           imagePullPolicy: IfNotPresent
           command:
-          - /install_multus
+            - /install_multus
           args:
-          - --type
-          - thin
+            - --type
+            - thin
           securityContext:
             privileged: true
           volumeMounts:
-          - mountPath: /host/opt/cni/bin
-            mountPropagation: Bidirectional
-            name: cni-bin-path
+            - mountPath: /host/opt/cni/bin
+              mountPropagation: Bidirectional
+              name: cni-bin-path
         {{- end }}
       containers:
         - name: {{ .Values.spiderpoolAgent.name | trunc 63 | trimSuffix "-" }}
@@ -235,7 +235,7 @@ spec:
           volumeMounts:
         {{- if .Values.spiderpoolAgent.prometheus.enabledRdmaMetric }}
             - name: host-ns
-              mountPath: /var/run/netns
+              mountPath: /var/run
               mountPropagation: Bidirectional
         {{- end }}
             - name: config-path
@@ -257,20 +257,20 @@ spec:
           image: {{ include "spiderpool.spiderpoolAgent.image" . | quote }}
           imagePullPolicy: {{ .Values.spiderpoolAgent.image.pullPolicy }}
           command:
-          - "/home/entrypoint.sh"
+            - "/home/entrypoint.sh"
           securityContext:
             privileged: true
           env:
-          - name: MULTUS_CLUSTER_NETWORK
-            valueFrom:
-              configMapKeyRef:
-                key: clusterNetwork
-                name: spiderpool-conf
-          - name: MULTUS_NAMESPACE
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.namespace
+            - name: MULTUS_CLUSTER_NETWORK
+              valueFrom:
+                configMapKeyRef:
+                  key: clusterNetwork
+                  name: spiderpool-conf
+            - name: MULTUS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
           resources:
             limits:
               cpu: 100m
@@ -318,7 +318,7 @@ spec:
       {{- if .Values.spiderpoolAgent.prometheus.enabledRdmaMetric }}
         - name: host-ns
           hostPath:
-            path: /var/run/netns
+            path: /var/run
       {{- end }}
       {{- if .Values.multus.multusCNI.install }}
         - name: cni

--- a/pkg/rdmametrics/ethtool/ethtool.go
+++ b/pkg/rdmametrics/ethtool/ethtool.go
@@ -3,9 +3,17 @@
 
 package ethtool
 
-import "github.com/safchain/ethtool"
+import (
+	"strconv"
+	"strings"
 
-func Stats(netIfName string) (map[string]uint64, error) {
+	"github.com/safchain/ethtool"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/spidernet-io/spiderpool/pkg/rdmametrics/oteltype"
+)
+
+func Stats(netIfName string) ([]oteltype.Metrics, error) {
 	tool, err := ethtool.NewEthtool()
 	if err != nil {
 		return nil, err
@@ -15,13 +23,79 @@ func Stats(netIfName string) (map[string]uint64, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	res := make([]oteltype.Metrics, 0)
+	for k, v := range stats {
+		if strings.Contains(k, "vport") {
+			res = append(res, oteltype.Metrics{Name: k, Value: int64(v)})
+			continue
+		}
+		if expectPriorityMetrics(k) {
+			name, priority, ok := extractNameWithPriority(k)
+			if ok {
+				res = append(res, oteltype.Metrics{
+					Name:  name,
+					Value: int64(v),
+					Labels: []attribute.KeyValue{{
+						Key: "priority", Value: attribute.IntValue(priority),
+					}},
+				})
+			}
+		}
+	}
+
 	speed, err := tool.CmdGetMapped(netIfName)
 	if err != nil {
 		return nil, err
 	}
+
 	// speed unknown = 4294967295
 	if val, ok := speed["speed"]; ok && val != 4294967295 {
-		stats["vport_speed_mbps"] = val
+		res = append(res, oteltype.Metrics{
+			Name:  "vport_speed_mbps",
+			Value: int64(val),
+		})
 	}
-	return stats, nil
+	return res, nil
+}
+
+func expectPriorityMetrics(s string) bool {
+	if len(s) == 14 {
+		if (strings.HasPrefix(s, "rx_prio") || strings.HasPrefix(s, "tx_prio")) && strings.HasSuffix(s, "_pause") {
+			return true
+		}
+	}
+	if len(s) == 17 {
+		if (strings.HasPrefix(s, "rx_prio") || strings.HasPrefix(s, "tx_prio")) && strings.HasSuffix(s, "_discards") {
+			return true
+		}
+	}
+	return false
+}
+
+func extractNameWithPriority(str string) (name string, priority int, ok bool) {
+	parts := strings.Split(str, "_")
+	if len(parts) != 3 {
+		return "", 0, false
+	}
+
+	name = parts[0] + "_" + parts[2]
+
+	rawPriority := parts[1]
+	if len(rawPriority) < 5 {
+		return "", 0, false
+	}
+
+	var err error
+
+	if strings.HasPrefix(rawPriority, "prio") {
+		priority, err = strconv.Atoi(strings.TrimPrefix(rawPriority, "prio"))
+		if err != nil {
+			return "", 0, false
+		}
+	} else {
+		return "", 0, false
+	}
+
+	return name, priority, true
 }

--- a/pkg/rdmametrics/metrics.go
+++ b/pkg/rdmametrics/metrics.go
@@ -6,10 +6,10 @@ package rdmametrics
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"unicode"
 
@@ -27,9 +27,10 @@ import (
 	"github.com/spidernet-io/spiderpool/pkg/logutils"
 	"github.com/spidernet-io/spiderpool/pkg/podownercache"
 	"github.com/spidernet-io/spiderpool/pkg/rdmametrics/ethtool"
+	"github.com/spidernet-io/spiderpool/pkg/rdmametrics/oteltype"
 )
 
-const netnsPath = "/var/run/netns"
+var netnsPathList = []string{"/var/run/netns", "/var/run/docker/netns"}
 
 var (
 	readDir                = os.ReadDir
@@ -76,25 +77,17 @@ var (
 		"rx_vport_rdma_multicast_bytes":   "The number of bytes received in multicast RDMA packets on the virtual port.",
 		"tx_vport_rdma_multicast_bytes":   "The number of bytes transmitted in multicast RDMA packets from the virtual port.",
 		"vport_speed_mbps":                "The speed of the virtual port expressed in megabits per second (Mbps).",
-	}
-
-	// skip to export these fields
-	// key and reason
-	skipRDMAStatsField = map[string]string{
-		"port":             "The field is attribute is used to identify the nic port",
-		"ifname":           "The field is attribute is used to identify the nic netnsPath",
-		"net_dev_name":     "The field is attribute is used to identify the nic net_dev_name",
-		"node_guid":        "The field is attribute is used to identify the nic node_guid",
-		"sys_image_guid":   "The field is attribute is used to identify the nic sys_image_guid",
-		"rdma_parent_name": "The field is attribute is used to identify the nic rdma_parent_name",
-		"is_root":          "The field is attribute is used to identify the nic is_root",
-	}
+		"rx_discards":                     "The number of packets discarded by the device.",
+		"tx_discards":                     "The number of packets discarded by the device.",
+		"rx_pause":                        "The number of packets dropped by the device.",
+		"tx_pause":                        "The number of packets dropped by the device.",
+		"device_tos":                      "RDMA device traffic class (TOS) value."}
 )
 
 type GetObservable func(string) (metric.Int64ObservableCounter, bool)
 
 type EthtoolImpl struct {
-	Stats func(netIfName string) (map[string]uint64, error)
+	Stats func(netIfName string) ([]oteltype.Metrics, error)
 }
 
 type NetlinkImpl struct {
@@ -109,6 +102,11 @@ type RDMADevice struct {
 	IsRoot       bool
 }
 
+type NetnsItem struct {
+	ID string
+	Fd string
+}
+
 func Register(ctx context.Context, meter metric.Meter, cache podownercache.CacheInterface) error {
 	log := logutils.Logger.Named("rdma-metrics-exporter")
 	nodeName, err := os.Hostname()
@@ -118,11 +116,11 @@ func Register(ctx context.Context, meter metric.Meter, cache podownercache.Cache
 	attributeNodeName := attribute.String("node_name", nodeName)
 	e := &exporter{
 		observableMap: make(map[string]metric.Int64ObservableCounter),
-		nodeName:      &attributeNodeName,
+		nodeName:      attributeNodeName,
 		meter:         meter,
-		netns: func(netnsID string, toRun func() error) error {
-			if netnsID != "" {
-				netns, err := ns.GetNS(filepath.Join(netnsPath, netnsID))
+		netns: func(netns NetnsItem, toRun func() error) error {
+			if netns.ID != "" {
+				netns, err := ns.GetNS(netns.Fd)
 				if err != nil {
 					return err
 				}
@@ -153,12 +151,12 @@ func Register(ctx context.Context, meter metric.Meter, cache podownercache.Cache
 }
 
 type exporter struct {
-	nodeName              *attribute.KeyValue
+	nodeName              attribute.KeyValue
 	meter                 metric.Meter
 	lock                  lock.Mutex
 	log                   *zap.Logger
 	ch                    chan struct{}
-	netns                 func(netnsID string, toRun func() error) error
+	netns                 func(netns NetnsItem, toRun func() error) error
 	netlinkImpl           NetlinkImpl
 	ethtool               EthtoolImpl
 	exec                  exec.Interface
@@ -239,7 +237,7 @@ func (e *exporter) Callback(ctx context.Context, observer metric.Observer) error
 		e.log.Error("failed to list node net ns", zap.Error(err))
 		return fmt.Errorf("failed to list node net ns: %w", err)
 	}
-	list = append(list, "")
+	list = append(list, NetnsItem{})
 
 	unRegistrationMetric := make([]string, 0)
 	getObservable := func(key string) (metric.Int64ObservableCounter, bool) {
@@ -254,12 +252,28 @@ func (e *exporter) Callback(ctx context.Context, observer metric.Observer) error
 		e.log.Error("failed to get node guid net device name map", zap.Error(err))
 		return fmt.Errorf("failed to get node guid net device name map: %w", err)
 	}
-	for _, netNsID := range list {
-		if err := e.processNetNS(netNsID, nodeGuidNetDeviceNameMap, observer, getObservable); err != nil {
-			e.log.Error("failed to process net ns", zap.String("net_ns_id", netNsID), zap.Error(err))
+	for _, netns := range list {
+		if err := e.processNetNS(netns, nodeGuidNetDeviceNameMap, observer, getObservable); err != nil {
+			e.log.Error("failed to process net ns", zap.String("net_ns_id", netns.ID), zap.Error(err))
 			continue
 		}
 	}
+
+	deviceTrafficClassList, err := GetDeviceTrafficClass(e.netlinkImpl)
+	if err != nil {
+		e.log.Error("failed to get device traffic class", zap.Error(err))
+	} else {
+		for _, item := range deviceTrafficClassList {
+			if observable, ok := getObservable("device_tos"); ok {
+				observer.ObserveInt64(observable, int64(item.TrafficClass), metric.WithAttributes(
+					e.nodeName,
+					attribute.String("ifname", item.IfName),
+					attribute.String("net_dev_name", item.NetDevName),
+				))
+			}
+		}
+	}
+
 	if len(unRegistrationMetric) > 0 {
 		e.updateUnregisteredMetrics(unRegistrationMetric)
 	}
@@ -282,125 +296,133 @@ func (e *exporter) updateUnregisteredMetrics(unRegistrationMetric []string) {
 	}
 }
 
-func (e *exporter) processNetNS(netNsID string,
+func (e *exporter) processNetNS(netns NetnsItem,
 	nodeGuidNetDeviceNameMap map[string]string,
 	observer metric.Observer, getObservable GetObservable) error {
-	podPrimaryIP, statsList, err := getRDMAStats(netNsID, e.netns, nodeGuidNetDeviceNameMap, e.netlinkImpl, e.exec, e.ethtool)
+
+	list := make([]oteltype.Metrics, 0)
+
+	err := e.netns(netns, func() error {
+		var rdmaStats []map[string]interface{}
+		cmd := e.exec.Command("rdma", "statistic", "-j")
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("error executing 'rdma statistic -j' command: %w", err)
+		}
+
+		if err := json.Unmarshal(output, &rdmaStats); err != nil {
+			return fmt.Errorf("failed to unmarshal rdma stats: %w", err)
+		}
+
+		netDevMap, err := getIfnameNetDevMap(e.netlinkImpl)
+		if err != nil {
+			return fmt.Errorf("failed to get ifname net dev map: %w", err)
+		}
+
+		for _, item := range rdmaStats {
+			ifName, ok := item["ifname"].(string)
+			if !ok {
+				continue
+			}
+			deviceInfo, ok := netDevMap[ifName]
+			if !ok {
+				continue
+			}
+			commonLabels := []attribute.KeyValue{
+				e.nodeName,
+				attribute.String("ifname", ifName),
+				attribute.String("net_dev_name", deviceInfo.NetDevName),
+				attribute.String("node_guid", deviceInfo.NodeGuid),
+				attribute.String("sys_image_guid", deviceInfo.SysImageGuid),
+				attribute.Bool("is_root", deviceInfo.IsRoot),
+			}
+			if rdmaParentName, ok := nodeGuidNetDeviceNameMap[deviceInfo.SysImageGuid]; ok {
+				commonLabels = append(commonLabels, attribute.String("rdma_parent_name", rdmaParentName))
+			}
+
+			// host netns, don't need get default ip to mapping pod metadata to metrics
+			if netns.ID != "" {
+				srcIP, err := getDefaultIP(e.exec)
+				if err != nil {
+					return err
+				}
+				if pod := e.cache.GetPodByIP(srcIP); pod != nil {
+					commonLabels = append(commonLabels, attribute.String("pod_namespace", pod.Namespace))
+					commonLabels = append(commonLabels, attribute.String("pod_name", pod.Name))
+					commonLabels = append(commonLabels, attribute.String("owner_api_version", pod.OwnerInfo.APIVersion))
+					commonLabels = append(commonLabels, attribute.String("owner_kind", pod.OwnerInfo.Kind))
+					commonLabels = append(commonLabels, attribute.String("owner_namespace", pod.OwnerInfo.Namespace))
+					commonLabels = append(commonLabels, attribute.String("owner_name", pod.OwnerInfo.Name))
+				}
+			}
+
+			for key, val := range item {
+				if key == "ifname" || key == "port" {
+					continue
+				}
+				if tmp, ok := val.(float64); ok {
+					list = append(list, oteltype.Metrics{
+						Name:   camelToSnake(key),
+						Value:  int64(tmp),
+						Labels: commonLabels,
+					})
+				}
+			}
+			stats, err := e.ethtool.Stats(deviceInfo.NetDevName)
+			if err == nil {
+				for _, stat := range stats {
+					stat.Labels = append(stat.Labels, commonLabels...)
+					list = append(list, stat)
+				}
+			}
+		}
+		return nil
+	})
 	if err != nil {
-		e.log.Error("failed to get RDMA stats", zap.String("net_ns_id", netNsID), zap.Error(err))
 		return err
 	}
-	if len(statsList) == 0 {
-		return nil
-	}
 
-	attributes := []*attribute.KeyValue{
-		e.nodeName,
-	}
-
-	if pod := e.cache.GetPodByIP(podPrimaryIP); pod != nil {
-		namespace := attribute.String("pod_namespace", pod.Namespace)
-		name := attribute.String("pod_name", pod.Name)
-		ownerAPIVersion := attribute.String("owner_api_version", pod.OwnerInfo.APIVersion)
-		ownerKind := attribute.String("owner_kind", pod.OwnerInfo.Kind)
-		ownerNamespace := attribute.String("owner_namespace", pod.OwnerInfo.Namespace)
-		ownerName := attribute.String("owner_name", pod.OwnerInfo.Name)
-		attributes = append(attributes, &namespace, &name, &ownerAPIVersion, &ownerKind, &ownerNamespace, &ownerName)
-	}
-	for _, stats := range statsList {
-		processStats(stats, observer, getObservable, attributes...)
+	for _, v := range list {
+		if observable, ok := getObservable(v.Name); ok {
+			observer.ObserveInt64(observable, v.Value, metric.WithAttributes(v.Labels...))
+		}
 	}
 	return nil
 }
 
-func getPodAttributes(item types.NamespacedName) (*attribute.KeyValue, *attribute.KeyValue) {
-	var attributeNamespace, attributeName *attribute.KeyValue
-	if item.Namespace != "" {
-		t := attribute.String("pod_namespace", item.Namespace)
-		attributeNamespace = &t
-	}
-	if item.Name != "" {
-		t := attribute.String("pod_name", item.Name)
-		attributeName = &t
-	}
-	return attributeNamespace, attributeName
-}
-
-func processStats(stats map[string]interface{}, observer metric.Observer,
-	getObservable GetObservable, attributes ...*attribute.KeyValue) {
-	nicExtAttributes := getIdentifyAttributes(stats)
-	attributes = append(attributes, nicExtAttributes...)
-
-	for key, val := range stats {
-		if _, skip := skipRDMAStatsField[key]; skip {
-			continue
-		}
-		if observable, ok := getObservable(key); ok {
-			if value, ok := val.(float64); ok {
-				observe(observer, observable, int(value), attributes...)
-				continue
-			}
-			if value, ok := val.(uint64); ok {
-				observe(observer, observable, int(value), attributes...)
-			}
-		}
-	}
-}
-
-func getIdentifyAttributes(stats map[string]interface{}) []*attribute.KeyValue {
-	res := make([]*attribute.KeyValue, 0)
-	if val, ok := stats["port"].(float64); ok {
-		res = append(res, &attribute.KeyValue{Key: "port", Value: attribute.IntValue(int(val))})
-	}
-	if val, ok := stats["ifname"].(string); ok {
-		res = append(res, &attribute.KeyValue{Key: "ifname", Value: attribute.StringValue(val)})
-	}
-	if val, ok := stats["net_dev_name"].(string); ok {
-		res = append(res, &attribute.KeyValue{Key: "net_dev_name", Value: attribute.StringValue(val)})
-	}
-	if val, ok := stats["node_guid"].(string); ok {
-		res = append(res, &attribute.KeyValue{Key: "node_guid", Value: attribute.StringValue(val)})
-	}
-	if val, ok := stats["sys_image_guid"].(string); ok {
-		res = append(res, &attribute.KeyValue{Key: "sys_image_guid", Value: attribute.StringValue(val)})
-	}
-	if val, ok := stats["rdma_parent_name"].(string); ok {
-		res = append(res, &attribute.KeyValue{Key: "rdma_parent_name", Value: attribute.StringValue(val)})
-	}
-	if val, ok := stats["is_root"].(bool); ok {
-		res = append(res, &attribute.KeyValue{Key: "is_root", Value: attribute.BoolValue(val)})
-	}
-	return res
-}
-
-func observe(observer metric.Observer, counter metric.Int64ObservableCounter, value int, attributes ...*attribute.KeyValue) {
-	list := make([]attribute.KeyValue, 0, len(attributes))
-	for _, item := range attributes {
-		if item != nil {
-			list = append(list, *item)
-		}
-	}
-	observer.ObserveInt64(counter, int64(value), metric.WithAttributes(list...))
-}
-
-func listNodeNetNS() ([]string, error) {
+func listNodeNetNS() ([]NetnsItem, error) {
 	mode, err := rdmaSystemGetNetnsMode()
 	if err != nil {
 		return nil, err
 	}
 	if mode != "exclusive" {
-		return []string{}, nil
+		return []NetnsItem{}, nil
 	}
 
-	dirEntries, err := readDir(netnsPath)
-	if err != nil {
-		return nil, err
+	netnsList := make([]NetnsItem, 0)
+
+	for _, path := range netnsPathList {
+		dirEntries, err := readDir(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return nil, err
+		}
+
+		for _, entry := range dirEntries {
+			// skip default netns, default netns is a host netns
+			if entry.Name() == "default" {
+				continue
+			}
+			fdFullPath := filepath.Join(path, entry.Name())
+			netnsList = append(netnsList, NetnsItem{
+				ID: entry.Name(),
+				Fd: fdFullPath,
+			})
+		}
 	}
 
-	netnsList := make([]string, 0, len(dirEntries))
-	for _, entry := range dirEntries {
-		netnsList = append(netnsList, entry.Name())
-	}
 	return netnsList, nil
 }
 
@@ -429,82 +451,7 @@ func getIPToPodMap(ctx context.Context, cli client.Client) (map[string]types.Nam
 	return res, err
 }
 
-func getRDMAStats(nsID string,
-	netnsDo func(nsID string, toRun func() error) error,
-	nodeGuidNetNameMap map[string]string,
-	nl NetlinkImpl,
-	e exec.Interface, ethtool EthtoolImpl) (string, []map[string]interface{}, error) {
-
-	var srcIP string
-	var rdmaStats []map[string]interface{}
-
-	err := netnsDo(nsID, func() error {
-		cmd := e.Command("rdma", "statistic", "-j")
-		output, err := cmd.CombinedOutput()
-		if err != nil {
-			return fmt.Errorf("error executing 'rdma statistic -j' command: %w", err)
-		}
-
-		if err := json.Unmarshal(output, &rdmaStats); err != nil {
-			return fmt.Errorf("failed to unmarshal rdma stats: %w", err)
-		}
-
-		netDevMap, err := getIfnameNetDevMap(nl)
-		if err != nil {
-			return fmt.Errorf("failed to get ifname net dev map: %w", err)
-		}
-
-		for i, item := range rdmaStats {
-			newMap := make(map[string]interface{})
-			for k, v := range item {
-				newMap[camelToSnake(k)] = v
-			}
-
-			// append more metrics
-			var ifname string
-			if val, ok := newMap["ifname"].(string); ok {
-				ifname = val
-			}
-			if ifname != "" {
-				if devName, ok := netDevMap[ifname]; ok {
-					newMap["net_dev_name"] = devName.NetDevName
-					newMap["node_guid"] = devName.NodeGuid
-					newMap["sys_image_guid"] = devName.SysImageGuid
-					newMap["is_root"] = devName.IsRoot
-					stats, err := ethtool.Stats(devName.NetDevName)
-					if err == nil {
-						for k, v := range stats {
-							if strings.Contains(k, "vport") {
-								newMap[k] = v
-							}
-						}
-					}
-					if rdmaParentName, ok := nodeGuidNetNameMap[devName.SysImageGuid]; ok {
-						newMap["rdma_parent_name"] = rdmaParentName
-					}
-				}
-			}
-			rdmaStats[i] = newMap
-		}
-
-		// host netns, don't need get default ip to mapping pod metadata to metrics
-		if nsID == "" {
-			return nil
-		}
-		srcIP, err = getDefaultIP(e)
-		if err != nil {
-			return err
-		}
-		return nil
-	})
-	if err != nil {
-		return "", nil, err
-	}
-
-	return srcIP, rdmaStats, nil
-}
-
-// map of node guid to rdma name
+// getNodeGuidNetDeviceNameMap get map of node guid to rdma name
 func getNodeGuidNetDeviceNameMap(nl NetlinkImpl) (map[string]string, error) {
 	list, err := getIfnameNetDevMap(nl)
 	if err != nil {
@@ -583,15 +530,12 @@ func getIfnameNetDevMap(nl NetlinkImpl) (map[string]RDMADevice, error) {
 
 // getDefaultIP returns the default IP address of the host/pod
 func getDefaultIP(e exec.Interface) (string, error) {
-	re := regexp.MustCompile(`\bsrc\s+(\S+)`)
-
 	// Check for IPv4 default route
 	cmd := e.Command("ip", "route", "get", "1.0.0.0")
 	output, err := cmd.CombinedOutput()
 	if err == nil {
-		match := re.FindStringSubmatch(string(output))
-		if len(match) > 0 {
-			return match[1], nil
+		if res, ok := extractSrcIPStringIndex(string(output)); ok {
+			return res, nil
 		}
 	}
 
@@ -599,13 +543,33 @@ func getDefaultIP(e exec.Interface) (string, error) {
 	cmd = e.Command("ip", "-6", "route", "get", "2001:4860:4860::8888")
 	output, err = cmd.CombinedOutput()
 	if err == nil {
-		match := re.FindStringSubmatch(string(output))
-		if len(match) > 0 {
-			return match[1], nil
+		if res, ok := extractSrcIPStringIndex(string(output)); ok {
+			return res, nil
 		}
 	}
 
 	return "", fmt.Errorf("failed to find default IP address: %w", err)
+}
+
+func extractSrcIPStringIndex(raw string) (string, bool) {
+	const marker = " src "
+	startIndex := strings.Index(raw, marker)
+
+	if startIndex == -1 {
+		return "", false
+	}
+
+	ipStartIndex := startIndex + len(marker)
+	if ipStartIndex >= len(raw) {
+		return "", false
+	}
+
+	endIndex := strings.Index(raw[ipStartIndex:], " ")
+
+	if endIndex == -1 {
+		return raw[ipStartIndex:], true
+	}
+	return raw[ipStartIndex : ipStartIndex+endIndex], true
 }
 
 // camelToSnake converts a camelCase string to snake_case

--- a/pkg/rdmametrics/metrics_test.go
+++ b/pkg/rdmametrics/metrics_test.go
@@ -5,7 +5,6 @@ package rdmametrics
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -16,7 +15,6 @@ import (
 	"time"
 
 	"github.com/vishvananda/netlink"
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/noop"
 	corev1 "k8s.io/api/core/v1"
@@ -30,6 +28,7 @@ import (
 
 	"github.com/spidernet-io/spiderpool/pkg/logutils"
 	"github.com/spidernet-io/spiderpool/pkg/podownercache"
+	"github.com/spidernet-io/spiderpool/pkg/rdmametrics/oteltype"
 )
 
 // Label(K00002)
@@ -227,7 +226,7 @@ func TestListNodeNetNS(t *testing.T) {
 		rdmaSystemGetNetnsModeError bool
 		dirEntries                  []os.DirEntry
 		readDirErr                  error
-		expected                    []string
+		expected                    []NetnsItem
 		expectError                 bool
 	}{
 		{
@@ -236,16 +235,33 @@ func TestListNodeNetNS(t *testing.T) {
 			expectError:                 true,
 		},
 		{
-			name:        "exclusive mode with entries",
-			mode:        "exclusive",
-			dirEntries:  []os.DirEntry{mockDirEntry("netns1"), mockDirEntry("netnsimpl")},
-			expected:    []string{"netns1", "netnsimpl"},
+			name:       "exclusive mode with entries",
+			mode:       "exclusive",
+			dirEntries: []os.DirEntry{mockDirEntry("netns1"), mockDirEntry("netnsimpl")},
+			expected: []NetnsItem{
+				{
+					ID: "netns1",
+					Fd: "/var/run/netns/netns1",
+				},
+				{
+					ID: "netnsimpl",
+					Fd: "/var/run/netns/netnsimpl",
+				},
+				{
+					ID: "netns1",
+					Fd: "/var/run/docker/netns/netns1",
+				},
+				{
+					ID: "netnsimpl",
+					Fd: "/var/run/docker/netns/netnsimpl",
+				},
+			},
 			expectError: false,
 		},
 		{
 			name:        "non-exclusive mode",
 			mode:        "non-exclusive",
-			expected:    []string{},
+			expected:    []NetnsItem{},
 			expectError: false,
 		},
 		{
@@ -421,482 +437,23 @@ func TestGetIPToPodMap_WithMockClient(t *testing.T) {
 	}
 }
 
-func TestGetPodAttributes(t *testing.T) {
-	tests := []struct {
-		name              string
-		input             types.NamespacedName
-		expectedNamespace *attribute.KeyValue
-		expectedName      *attribute.KeyValue
-	}{
-		{
-			name: "Both namespace and name are set",
-			input: types.NamespacedName{
-				Namespace: "default",
-				Name:      "pod1",
-			},
-			expectedNamespace: &attribute.KeyValue{Key: "pod_namespace", Value: attribute.StringValue("default")},
-			expectedName:      &attribute.KeyValue{Key: "pod_name", Value: attribute.StringValue("pod1")},
-		},
-		{
-			name: "Only namespace is set",
-			input: types.NamespacedName{
-				Namespace: "default",
-			},
-			expectedNamespace: &attribute.KeyValue{Key: "pod_namespace", Value: attribute.StringValue("default")},
-			expectedName:      nil,
-		},
-		{
-			name: "Only name is set",
-			input: types.NamespacedName{
-				Name: "pod1",
-			},
-			expectedNamespace: nil,
-			expectedName:      &attribute.KeyValue{Key: "pod_name", Value: attribute.StringValue("pod1")},
-		},
-		{
-			name:              "Neither namespace nor name is set",
-			input:             types.NamespacedName{},
-			expectedNamespace: nil,
-			expectedName:      nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			attributeNamespace, attributeName := getPodAttributes(tt.input)
-			if attributeNamespace != nil && tt.expectedNamespace != nil {
-				if *attributeNamespace != *tt.expectedNamespace {
-					t.Errorf("Expected namespace %v, but got %v", *tt.expectedNamespace, *attributeNamespace)
-				}
-			} else if attributeNamespace != tt.expectedNamespace {
-				t.Errorf("Expected namespace %v, but got %v", tt.expectedNamespace, attributeNamespace)
-			}
-
-			if attributeName != nil && tt.expectedName != nil {
-				if *attributeName != *tt.expectedName {
-					t.Errorf("Expected name %v, but got %v", *tt.expectedName, *attributeName)
-				}
-			} else if attributeName != tt.expectedName {
-				t.Errorf("Expected name %v, but got %v", tt.expectedName, attributeName)
-			}
-		})
-	}
-}
-
-func TestGetIdentifyAttributes(t *testing.T) {
-	tests := []struct {
-		name     string
-		stats    map[string]interface{}
-		expCount int
-	}{
-		{
-			name: "Valid port and ifname",
-			stats: map[string]interface{}{
-				"port":             float64(1),
-				"ifname":           "eth0",
-				"net_dev_name":     "net1",
-				"is_root":          true,
-				"node_guid":        "1d:c9:d1:fe:ff:ac:36:ae",
-				"sys_image_guid":   "b6:65:05:0c:9c:5c:f6:08",
-				"rdma_parent_name": "ib1",
-			},
-			expCount: 7,
-		},
-		{
-			name: "Missing port",
-			stats: map[string]interface{}{
-				"ifname": "eth1",
-			},
-
-			expCount: 1,
-		},
-		{
-			name: "Missing ifname",
-			stats: map[string]interface{}{
-				"port": float64(2),
-			},
-			expCount: 1,
-		},
-		{
-			name:     "Empty stats",
-			stats:    map[string]interface{}{},
-			expCount: 0,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			list := getIdentifyAttributes(tt.stats)
-			if len(list) != tt.expCount {
-				t.Errorf("Expected %d attributes, but got %d", tt.expCount, len(list))
-			}
-		})
-	}
-}
-
-func TestObserve(t *testing.T) {
-	tests := []struct {
-		name       string
-		counter    metric.Int64ObservableCounter
-		value      int
-		attributes []*attribute.KeyValue
-		expected   []attribute.KeyValue
-	}{
-		{
-			name:     "No attributes",
-			counter:  mustNewInt64ObservableCounter(noop.NewMeterProvider().Meter("test").Int64ObservableCounter("test_counter")),
-			value:    10,
-			expected: []attribute.KeyValue{},
-		},
-		{
-			name:    "Single attribute",
-			counter: mustNewInt64ObservableCounter(noop.NewMeterProvider().Meter("test").Int64ObservableCounter("test_counter")),
-			value:   20,
-			attributes: []*attribute.KeyValue{
-				ptr(attribute.String("key1", "value1")),
-			},
-			expected: []attribute.KeyValue{
-				attribute.String("key1", "value1"),
-			},
-		},
-		{
-			name:    "Multiple attributes",
-			counter: mustNewInt64ObservableCounter(noop.NewMeterProvider().Meter("test").Int64ObservableCounter("test_counter")),
-			value:   30,
-			attributes: []*attribute.KeyValue{
-				ptr(attribute.String("key1", "value1")),
-				ptr(attribute.Int("key2", 2)),
-			},
-			expected: []attribute.KeyValue{
-				attribute.String("key1", "value1"),
-				attribute.Int("key2", 2),
-			},
-		},
-		{
-			name:    "Nil attribute",
-			counter: mustNewInt64ObservableCounter(noop.NewMeterProvider().Meter("test").Int64ObservableCounter("test_counter")),
-			value:   40,
-			attributes: []*attribute.KeyValue{
-				nil,
-				ptr(attribute.String("key1", "value1")),
-			},
-			expected: []attribute.KeyValue{
-				attribute.String("key1", "value1"),
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			observe(noop.Observer{}, tt.counter, tt.value, tt.attributes...)
-		})
-	}
-}
-
-func mustNewInt64ObservableCounter(counter metric.Int64ObservableCounter, err error) metric.Int64ObservableCounter {
-	if err != nil {
-		panic(err)
-	}
-	return counter
-}
-
-func ptr(kv attribute.KeyValue) *attribute.KeyValue {
-	return &kv
-}
-
-func TestGetRDMAStats(t *testing.T) {
-	tests := []struct {
-		name          string
-		nsID          string
-		mockNetnsCli  func(netnsID string, toRun func() error) error
-		nl            NetlinkImpl
-		commandScript []testexec.FakeCommandAction
-		expectedIP    string
-		expectedStats string
-		expectedErr   bool
-		ethtoolImpl   EthtoolImpl
-	}{
-		{
-			name: "get net get from path should return error",
-			nsID: "test",
-			mockNetnsCli: func(netnsID string, toRun func() error) error {
-				return errors.New("mock error")
-			},
-			nl: NetlinkImpl{
-				RdmaLinkList: func() ([]*netlink.RdmaLink, error) {
-					return nil, nil
-				},
-				LinkList: nil,
-			},
-			expectedErr: true,
-		},
-		{
-			name: "get pod rdma stats error",
-			nsID: "test",
-			mockNetnsCli: func(netnsID string, toRun func() error) error {
-				return toRun()
-			},
-			commandScript: []testexec.FakeCommandAction{
-				func(cmd string, args ...string) exec.Cmd {
-					fakeCmd := &testexec.FakeCmd{}
-					fakeCmd.CombinedOutputScript = []testexec.FakeAction{
-						func() ([]byte, []byte, error) {
-							return nil, nil, errors.New("mock error")
-						},
-					}
-					return fakeCmd
-				},
-			},
-
-			expectedErr: true,
-		},
-
-		{
-			name: "get pod rdma stats error with unmarshal json",
-			nsID: "test",
-			mockNetnsCli: func(netnsID string, toRun func() error) error {
-				return toRun()
-			},
-			commandScript: []testexec.FakeCommandAction{
-				func(cmd string, args ...string) exec.Cmd {
-					fakeCmd := &testexec.FakeCmd{}
-					fakeCmd.CombinedOutputScript = []testexec.FakeAction{
-						func() ([]byte, []byte, error) {
-							return []byte("{\"rxWriteRequests\": 100}"), nil, nil
-						},
-					}
-					return fakeCmd
-				},
-				func(cmd string, args ...string) exec.Cmd {
-					fakeCmd := &testexec.FakeCmd{}
-					fakeCmd.CombinedOutputScript = []testexec.FakeAction{
-						func() ([]byte, []byte, error) {
-							return []byte("src 1.1.1.1"), nil, nil
-						},
-					}
-					return fakeCmd
-				},
-			},
-
-			expectedErr: true,
-		},
-
-		{
-			name: "get pod RDMA stats success",
-			nsID: "test",
-			ethtoolImpl: EthtoolImpl{Stats: func(netIfName string) (map[string]uint64, error) {
-				return map[string]uint64{
-					"rx_vport_rdma_unicast_bytes": 100,
-					"tx_vport_rdma_unicast_bytes": 100,
-				}, nil
-			}},
-			nl: NetlinkImpl{
-				RdmaLinkList: func() ([]*netlink.RdmaLink, error) {
-					rdmaList := []*netlink.RdmaLink{
-						{Attrs: netlink.RdmaLinkAttrs{
-							Name:     "mlx5_34",
-							NodeGuid: "1d:c9:d1:fe:ff:ac:36:ae",
-						}},
-						{Attrs: netlink.RdmaLinkAttrs{
-							Name:         "mlx5_6",
-							NodeGuid:     "b6:65:05:0c:9c:5c:f6:08",
-							SysImageGuid: "b6:65:05:0c:9c:5c:f6:00",
-						}},
-					}
-					return rdmaList, nil
-				},
-				LinkList: func() ([]netlink.Link, error) {
-					linkList := []netlink.Link{
-						&netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: ""}},
-						&netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: "mock-empty-addr", HardwareAddr: nil}},
-						&netlink.Device{LinkAttrs: netlink.LinkAttrs{
-							Name: "enp5s0f0v6",
-							HardwareAddr: func() net.HardwareAddr {
-								mac, _ := net.ParseMAC("ae:36:ac:d1:c9:1d")
-								return mac
-							}(),
-						}},
-						&netlink.IPoIB{LinkAttrs: netlink.LinkAttrs{
-							Name: "ibp13s0v7",
-							HardwareAddr: func() net.HardwareAddr {
-								mac, _ := net.ParseMAC("00:00:00:68:fe:80:00:00:00:00:00:00:08:f6:5c:9c:0c:05:65:b6")
-								return mac
-							}(),
-						}},
-					}
-					return linkList, nil
-				},
-			},
-			mockNetnsCli: func(netnsID string, toRun func() error) error {
-				return toRun()
-			},
-			commandScript: []testexec.FakeCommandAction{
-				func(cmd string, args ...string) exec.Cmd {
-					fakeCmd := &testexec.FakeCmd{}
-					fakeCmd.CombinedOutputScript = []testexec.FakeAction{
-						func() ([]byte, []byte, error) {
-							return []byte("[{\"rxWriteRequests\": 100,\"ifname\": \"mlx5_34\"}]"), nil, nil
-						},
-					}
-					return fakeCmd
-				},
-				func(cmd string, args ...string) exec.Cmd {
-					fakeCmd := &testexec.FakeCmd{}
-					fakeCmd.CombinedOutputScript = []testexec.FakeAction{
-						func() ([]byte, []byte, error) {
-							return []byte("src 192.168.1.1"), nil, nil
-						},
-					}
-					return fakeCmd
-				},
-			},
-			expectedIP:    "192.168.1.1",
-			expectedErr:   false,
-			expectedStats: "[{\"ifname\":\"mlx5_34\",\"is_root\":false,\"net_dev_name\":\"enp5s0f0v6\",\"node_guid\":\"1d:c9:d1:fe:ff:ac:36:ae\",\"rx_vport_rdma_unicast_bytes\":100,\"rx_write_requests\":100,\"sys_image_guid\":\"\",\"tx_vport_rdma_unicast_bytes\":100}]",
-		},
-
-		{
-			name: "get default ip return error",
-			nsID: "test",
-			nl: NetlinkImpl{
-				RdmaLinkList: func() ([]*netlink.RdmaLink, error) {
-					return nil, nil
-				},
-				LinkList: func() ([]netlink.Link, error) {
-					return nil, nil
-				},
-			},
-			mockNetnsCli: func(netnsID string, toRun func() error) error {
-				return toRun()
-			},
-			commandScript: []testexec.FakeCommandAction{
-				func(cmd string, args ...string) exec.Cmd {
-					fakeCmd := &testexec.FakeCmd{}
-					fakeCmd.CombinedOutputScript = []testexec.FakeAction{
-						func() ([]byte, []byte, error) {
-							return []byte("[{\"rxWriteRequests\": 100}]"), nil, nil
-						},
-					}
-					return fakeCmd
-				},
-				func(cmd string, args ...string) exec.Cmd {
-					fakeCmd := &testexec.FakeCmd{}
-					fakeCmd.CombinedOutputScript = []testexec.FakeAction{
-						func() ([]byte, []byte, error) {
-							return nil, nil, errors.New("mock error")
-						},
-					}
-					return fakeCmd
-				},
-				func(cmd string, args ...string) exec.Cmd {
-					fakeCmd := &testexec.FakeCmd{}
-					fakeCmd.CombinedOutputScript = []testexec.FakeAction{
-						func() ([]byte, []byte, error) {
-							return nil, nil, errors.New("mock error")
-						},
-					}
-					return fakeCmd
-				},
-			},
-			expectedIP:    "192.168.1.1",
-			expectedErr:   true,
-			expectedStats: "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			fakeExec := &testexec.FakeExec{CommandScript: tt.commandScript}
-			guidMapNetDeviceName := map[string]string{
-				"b6:65:05:0c:9c:5c:f6:00": "ib1",
-			}
-			ip, stats, err := getRDMAStats(tt.nsID, tt.mockNetnsCli, guidMapNetDeviceName, tt.nl, fakeExec, tt.ethtoolImpl)
-			if (err != nil) != tt.expectedErr {
-				t.Errorf("expected error: %v, but got: %v", tt.expectedErr, err)
-			}
-			if tt.expectedErr {
-				return
-			}
-			if ip != tt.expectedIP {
-				t.Errorf("expected IP %v, but got %v", tt.expectedIP, ip)
-			}
-
-			got, err := json.Marshal(stats)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !compareMaps(string(got), tt.expectedStats) {
-				raw, _ := json.Marshal(stats)
-				t.Errorf("expected stats %v, but got %v", tt.expectedStats, string(raw))
-			}
-		})
-	}
-}
-
-// compareMaps compares two slices of maps for equality
-func compareMaps(got, exp string) bool {
-	expList := make([]map[string]interface{}, 0)
-	err := json.Unmarshal([]byte(exp), &expList)
-	if err != nil {
-		panic(err)
-	}
-
-	gotList := make([]map[string]interface{}, 0)
-	err = json.Unmarshal([]byte(got), &gotList)
-	if err != nil {
-		panic(err)
-	}
-
-	if len(gotList) != len(expList) {
-		return false
-	}
-	for i := range gotList {
-		for key, value := range gotList[i] {
-			if expList[i][key] != value {
-				return false
-			}
-		}
-		for key, value := range expList[i] {
-			if gotList[i][key] != value {
-				return false
-			}
-		}
-	}
-	return true
-}
-
-func TestProcessStats(t *testing.T) {
-	stats := map[string]interface{}{
-		"port":              float64(1),
-		"ifname":            "eth0",
-		"rx_write_requests": float64(100),
-		"some_uint64":       uint64(100),
-	}
-	var attributes []*attribute.KeyValue
-
-	processStats(stats, noop.Observer{}, func(s string) (metric.Int64ObservableCounter, bool) {
-		return mustNewInt64ObservableCounter(noop.NewMeterProvider().Meter("test").Int64ObservableCounter("test_counter")), true
-	}, attributes...)
-
-	processStats(stats, noop.Observer{}, func(s string) (metric.Int64ObservableCounter, bool) {
-		return nil, false
-	}, attributes...)
-}
-
 func TestProcessNetNS(t *testing.T) {
 	tests := []struct {
 		name          string
-		netnsID       string
-		ipPodMap      map[string]types.NamespacedName
+		netnsID       NetnsItem
+		ipPodMap      map[string]podownercache.Pod
 		commandScript []testexec.FakeCommandAction
 		getObservable GetObservable
 		expectError   bool
 	}{
 		{
 			name:    "Empty netnsID and ipPodMap",
-			netnsID: "",
-			ipPodMap: map[string]types.NamespacedName{
-				"192.168.1.1": {Namespace: "default", Name: "demo"},
+			netnsID: NetnsItem{},
+			ipPodMap: map[string]podownercache.Pod{
+				"192.168.1.1": {
+					NamespacedName: types.NamespacedName{Namespace: "default", Name: "demo"},
+					OwnerInfo:      podownercache.OwnerInfo{},
+				},
 			},
 			commandScript: []testexec.FakeCommandAction{
 				func(cmd string, args ...string) exec.Cmd {
@@ -926,9 +483,12 @@ func TestProcessNetNS(t *testing.T) {
 
 		{
 			name:    "processNetNS call getRDMAStats get error",
-			netnsID: "",
-			ipPodMap: map[string]types.NamespacedName{
-				"192.168.1.1": {Namespace: "default", Name: "demo"},
+			netnsID: NetnsItem{},
+			ipPodMap: map[string]podownercache.Pod{
+				"192.168.1.1": {
+					NamespacedName: types.NamespacedName{Namespace: "default", Name: "demo"},
+					OwnerInfo:      podownercache.OwnerInfo{},
+				},
 			},
 			commandScript: []testexec.FakeCommandAction{
 				func(cmd string, args ...string) exec.Cmd {
@@ -949,9 +509,12 @@ func TestProcessNetNS(t *testing.T) {
 
 		{
 			name:    "processNetNS call getRDMAStats get empty stats",
-			netnsID: "",
-			ipPodMap: map[string]types.NamespacedName{
-				"192.168.1.1": {Namespace: "default", Name: "demo"},
+			netnsID: NetnsItem{},
+			ipPodMap: map[string]podownercache.Pod{
+				"192.168.1.1": {
+					NamespacedName: types.NamespacedName{Namespace: "default", Name: "demo"},
+					OwnerInfo:      podownercache.OwnerInfo{},
+				},
 			},
 			commandScript: []testexec.FakeCommandAction{
 				func(cmd string, args ...string) exec.Cmd {
@@ -978,6 +541,80 @@ func TestProcessNetNS(t *testing.T) {
 			},
 			expectError: false,
 		},
+
+		{
+			name:    "sriov",
+			netnsID: NetnsItem{ID: "12345"},
+			ipPodMap: map[string]podownercache.Pod{
+				"192.168.1.1": {
+					NamespacedName: types.NamespacedName{Namespace: "default", Name: "demo"},
+					OwnerInfo:      podownercache.OwnerInfo{},
+				},
+			},
+			commandScript: []testexec.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					fakeCmd := &testexec.FakeCmd{}
+					fakeCmd.CombinedOutputScript = []testexec.FakeAction{
+						func() ([]byte, []byte, error) {
+							res := `
+								[
+									{
+										"ifname": "mlx5_1",
+										"port": 1,
+										"rx_write_requests": 2331678,
+										"rx_read_requests": 1161608,
+										"rx_atomic_requests": 0,
+										"rx_dct_connect": 0,
+										"out_of_buffer": 0,
+										"out_of_sequence": 0,
+										"duplicate_request": 0,
+										"rnr_nak_retry_err": 0,
+										"packet_seq_err": 0,
+										"implied_nak_seq_err": 0,
+										"local_ack_timeout_err": 0,
+										"resp_local_length_error": 0,
+										"resp_cqe_error": 0,
+										"req_cqe_error": 0,
+										"req_remote_invalid_request": 0,
+										"req_remote_access_errors": 0,
+										"resp_remote_access_errors": 0,
+										"resp_cqe_flush_error": 0,
+										"req_cqe_flush_error": 0,
+										"req_transport_retries_exceeded": 0,
+										"req_rnr_retries_exceeded": 0,
+										"roce_adp_retrans": 0,
+										"roce_adp_retrans_to": 0,
+										"roce_slow_restart": 0,
+										"roce_slow_restart_cnps": 0,
+										"roce_slow_restart_trans": 0,
+										"rp_cnp_ignored": 0,
+										"rp_cnp_handled": 0,
+										"np_ecn_marked_roce_packets": 0,
+										"np_cnp_sent": 0,
+										"rx_icrc_encapsulated": 0
+									}
+								]
+								`
+							return []byte(res), nil, nil
+						},
+					}
+					return fakeCmd
+				},
+				func(cmd string, args ...string) exec.Cmd {
+					fakeCmd := &testexec.FakeCmd{}
+					fakeCmd.CombinedOutputScript = []testexec.FakeAction{
+						func() ([]byte, []byte, error) {
+							return []byte("1.1.1.1 via 10.193.78.1 dev ens29f1 src 192.168.1.1 uid 0"), nil, nil
+						},
+					}
+					return fakeCmd
+				},
+			},
+			getObservable: func(s string) (metric.Int64ObservableCounter, bool) {
+				return nil, true
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -989,21 +626,78 @@ func TestProcessNetNS(t *testing.T) {
 			}
 
 			e := &exporter{
-				cache: &FakeCache{},
+				cache: &FakeCache{
+					IPToPodMap: tt.ipPodMap,
+				},
 				meter: meter,
 				netlinkImpl: NetlinkImpl{
 					RdmaLinkList: func() ([]*netlink.RdmaLink, error) {
-						return nil, nil
+						rdmaList := []*netlink.RdmaLink{
+							{
+								Attrs: netlink.RdmaLinkAttrs{
+									Name:     "mlx5_34",
+									NodeGuid: "1d:c9:d1:fe:ff:ac:36:ae",
+								},
+							},
+							{
+								Attrs: netlink.RdmaLinkAttrs{
+									Name:         "mlx5_6",
+									NodeGuid:     "b6:65:05:0c:9c:5c:f6:08",
+									SysImageGuid: "b6:65:05:0c:9c:5c:f6:00",
+								},
+							},
+							{
+								Attrs: netlink.RdmaLinkAttrs{
+									Name:         "mlx5_1",
+									NodeGuid:     "ea:6d:2d:00:03:c0:63:9c",
+									SysImageGuid: "ea:6d:2d:00:03:c0:63:9c",
+								},
+							},
+						}
+						return rdmaList, nil
 					},
 					LinkList: func() ([]netlink.Link, error) {
-						return nil, nil
+						linkList := []netlink.Link{
+							&netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: ""}},
+							&netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: "mock-empty-addr", HardwareAddr: nil}},
+							&netlink.Device{LinkAttrs: netlink.LinkAttrs{
+								Name: "enp5s0f0v6",
+								HardwareAddr: func() net.HardwareAddr {
+									mac, _ := net.ParseMAC("ae:36:ac:d1:c9:1d")
+									return mac
+								}(),
+							}},
+							&netlink.IPoIB{LinkAttrs: netlink.LinkAttrs{
+								Name: "ibp13s0v7",
+								HardwareAddr: func() net.HardwareAddr {
+									mac, _ := net.ParseMAC("00:00:00:68:fe:80:00:00:00:00:00:00:08:f6:5c:9c:0c:05:65:b6")
+									return mac
+								}(),
+							}},
+							&netlink.Device{LinkAttrs: netlink.LinkAttrs{
+								Name: "ens841np0",
+								HardwareAddr: func() net.HardwareAddr {
+									mac, _ := net.ParseMAC("9c:63:c0:2d:6d:ea")
+									return mac
+								}(),
+							}},
+						}
+						return linkList, nil
 					},
 				},
-				netns: func(netnsID string, toRun func() error) error {
+				netns: func(netnsID NetnsItem, toRun func() error) error {
 					return toRun()
 				},
 				exec: fakeExec,
-				log:  logutils.Logger.Named("rdma-metrics-exporter"),
+				ethtool: EthtoolImpl{Stats: func(netIfName string) ([]oteltype.Metrics, error) {
+					return []oteltype.Metrics{
+						{
+							Name:  "vport_speed",
+							Value: int64(400000),
+						},
+					}, nil
+				}},
+				log: logutils.Logger.Named("rdma-metrics-exporter"),
 			}
 			observer := noop.Observer{}
 			guidMapNetDeviceName := map[string]string{
@@ -1030,7 +724,7 @@ func TestUpdateUnregisteredMetrics(t *testing.T) {
 		observableMap: make(map[string]metric.Int64ObservableCounter),
 		ch:            make(chan struct{}, 10),
 		meter:         meter,
-		netns: func(netnsID string, toRun func() error) error {
+		netns: func(netnsID NetnsItem, toRun func() error) error {
 			return toRun()
 		},
 		exec: fakeExec,
@@ -1093,7 +787,7 @@ func TestCallback(t *testing.T) {
 		},
 		ch:    make(chan struct{}, 10),
 		meter: meter,
-		netns: func(netnsID string, toRun func() error) error {
+		netns: func(netnsID NetnsItem, toRun func() error) error {
 			return toRun()
 		},
 		exec:  fakeExec,
@@ -1232,5 +926,175 @@ func TestGetIfnameNetDevMap(t *testing.T) {
 				t.Errorf("expected: %v, but got: %v", tt.exp, got)
 			}
 		}
+	}
+}
+
+func TestGetNodeGuidNetDeviceNameMap(t *testing.T) {
+	linkList := []netlink.Link{
+		&netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: ""}},
+		&netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: "mock-empty-addr", HardwareAddr: nil}},
+		&netlink.Device{LinkAttrs: netlink.LinkAttrs{
+			Name: "enp5s0f0v6",
+			HardwareAddr: func() net.HardwareAddr {
+				mac, _ := net.ParseMAC("ae:36:ac:d1:c9:1d")
+				return mac
+			}(),
+		}},
+		&netlink.IPoIB{LinkAttrs: netlink.LinkAttrs{
+			Name: "ibp13s0v7",
+			HardwareAddr: func() net.HardwareAddr {
+				mac, _ := net.ParseMAC("00:00:00:68:fe:80:00:00:00:00:00:00:08:f6:5c:9c:0c:05:65:b6")
+				return mac
+			}(),
+		}},
+		&netlink.Device{
+			LinkAttrs: netlink.LinkAttrs{
+				Name: "ens841np0",
+				HardwareAddr: func() net.HardwareAddr {
+					mac, _ := net.ParseMAC("9c:63:c0:2d:6d:ea")
+					return mac
+				}(),
+			},
+		},
+	}
+
+	rdmaList := []*netlink.RdmaLink{
+		{Attrs: netlink.RdmaLinkAttrs{
+			Name:     "mlx5_34",
+			NodeGuid: "1d:c9:d1:fe:ff:ac:36:ae",
+		}},
+		{Attrs: netlink.RdmaLinkAttrs{
+			Name:     "mlx5_6",
+			NodeGuid: "b6:65:05:0c:9c:5c:f6:08",
+		}},
+		{Attrs: netlink.RdmaLinkAttrs{
+			Name:         "mlx5_1",
+			NodeGuid:     "ea:6d:2d:00:03:c0:63:9c",
+			SysImageGuid: "ea:6d:2d:00:03:c0:63:9c",
+		}},
+	}
+
+	tests := []struct {
+		name   string
+		nl     NetlinkImpl
+		expErr bool
+		exp    map[string]string
+	}{
+		{
+			name: "call netlink.LinkList func get err",
+			nl: NetlinkImpl{
+				LinkList: func() ([]netlink.Link, error) {
+					return nil, fmt.Errorf("mock err")
+				},
+				RdmaLinkList: func() ([]*netlink.RdmaLink, error) {
+					return nil, fmt.Errorf("mock err")
+				},
+			},
+			expErr: true,
+		},
+		{
+			name: "call netlink.RdmaLinkList func get list",
+			nl: NetlinkImpl{
+				LinkList: func() ([]netlink.Link, error) {
+					return linkList, nil
+				},
+				RdmaLinkList: func() ([]*netlink.RdmaLink, error) {
+					return nil, fmt.Errorf("mock err")
+				},
+			},
+			expErr: true,
+		},
+		{
+			name: "success",
+			nl: NetlinkImpl{
+				LinkList: func() ([]netlink.Link, error) {
+					return linkList, nil
+				},
+				RdmaLinkList: func() ([]*netlink.RdmaLink, error) {
+					return rdmaList, nil
+				},
+			},
+			expErr: false,
+			exp: map[string]string{
+				"ea:6d:2d:00:03:c0:63:9c": "ens841np0",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getNodeGuidNetDeviceNameMap(tt.nl)
+			if (err != nil) != tt.expErr {
+				t.Errorf("expected error: %v, but got: %v", tt.expErr, err)
+			}
+			if tt.exp != nil {
+				eq := reflect.DeepEqual(tt.exp, got)
+				if !eq {
+					t.Errorf("expected: %v, but got: %v", tt.exp, got)
+				}
+			}
+		})
+	}
+}
+
+func TestExtractSrcIPStringIndex(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+		ok       bool
+	}{
+		{
+			name:     "Valid src IP with space after",
+			input:    "random data src 192.168.1.1 other data",
+			expected: "192.168.1.1",
+			ok:       true,
+		},
+		{
+			name:     "Valid src IP at the end of string",
+			input:    "random data src 192.168.1.1",
+			expected: "192.168.1.1",
+			ok:       true,
+		},
+		{
+			name:     "Marker not found",
+			input:    "random data without marker",
+			expected: "",
+			ok:       false,
+		},
+		{
+			name:     "Marker at the end",
+			input:    "random data src ",
+			expected: "",
+			ok:       false,
+		},
+		{
+			name:     "No space after IP",
+			input:    "random data src 192.168.1.1someotherdata",
+			expected: "192.168.1.1someotherdata",
+			ok:       true,
+		},
+		{
+			name:     "Empty input string",
+			input:    "",
+			expected: "",
+			ok:       false,
+		},
+		{
+			name:     "Short input without room for IP",
+			input:    " src",
+			expected: "",
+			ok:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, ok := extractSrcIPStringIndex(tt.input)
+			if result != tt.expected || ok != tt.ok {
+				t.Errorf("for input '%s', expected (%s, %v), got (%s, %v)",
+					tt.input, tt.expected, tt.ok, result, ok)
+			}
+		})
 	}
 }

--- a/pkg/rdmametrics/oteltype/types.go
+++ b/pkg/rdmametrics/oteltype/types.go
@@ -1,0 +1,12 @@
+// Copyright 2024 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+
+package oteltype
+
+import "go.opentelemetry.io/otel/attribute"
+
+type Metrics struct {
+	Name   string
+	Value  int64
+	Labels []attribute.KeyValue
+}

--- a/pkg/rdmametrics/tos.go
+++ b/pkg/rdmametrics/tos.go
@@ -1,0 +1,65 @@
+// Copyright 2025 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+
+package rdmametrics
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type DeviceTrafficClass struct {
+	NetDevName   string
+	IfName       string
+	TrafficClass int
+}
+
+const prefix = "Global tclass="
+
+var statFunc = os.Stat
+var readFileFunc = os.ReadFile
+
+func GetDeviceTrafficClass(impl NetlinkImpl) ([]DeviceTrafficClass, error) {
+	m, err := getIfnameNetDevMap(impl)
+	if err != nil {
+		return nil, err
+	}
+
+	res := make([]DeviceTrafficClass, 0)
+	for ifname, dev := range m {
+		if dev.IsRoot {
+			path := fmt.Sprintf("/sys/class/infiniband/%s/tc/1/traffic_class", ifname)
+
+			tos := 0
+
+			_, err := statFunc(path)
+
+			if !os.IsNotExist(err) {
+				data, err := readFileFunc(path)
+				if err != nil {
+					return nil, fmt.Errorf("failed to read traffic_class file %s: %w", path, err)
+				}
+
+				line := strings.TrimSpace(string(data))
+
+				if strings.HasPrefix(line, prefix) {
+					tosStr := strings.TrimPrefix(line, prefix)
+					tos, err = strconv.Atoi(tosStr)
+					if err != nil {
+						return nil, fmt.Errorf("invalid tclass value for %s: %w", ifname, err)
+					}
+				}
+			}
+
+			res = append(res, DeviceTrafficClass{
+				NetDevName:   dev.NetDevName,
+				IfName:       ifname,
+				TrafficClass: tos,
+			})
+		}
+	}
+
+	return res, nil
+}

--- a/pkg/rdmametrics/tos_test.go
+++ b/pkg/rdmametrics/tos_test.go
@@ -1,0 +1,118 @@
+// Copyright 2025 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+
+package rdmametrics
+
+import (
+	"github.com/vishvananda/netlink"
+	"net"
+	"os"
+	"reflect"
+	"testing"
+)
+
+// Label(K00002)
+
+func TestGetDeviceTrafficClass(t *testing.T) {
+	tests := []struct {
+		name         string
+		netlink      NetlinkImpl
+		want         []DeviceTrafficClass
+		wantErr      bool
+		statsFunc    func(name string) (os.FileInfo, error)
+		readFileFunc func(name string) ([]byte, error)
+	}{
+		{
+			name: "test",
+			netlink: NetlinkImpl{
+				RdmaLinkList: func() ([]*netlink.RdmaLink, error) {
+					rdmaList := []*netlink.RdmaLink{
+						{
+							Attrs: netlink.RdmaLinkAttrs{
+								Name:     "mlx5_34",
+								NodeGuid: "1d:c9:d1:fe:ff:ac:36:ae",
+							},
+						},
+						{
+							Attrs: netlink.RdmaLinkAttrs{
+								Name:         "mlx5_6",
+								NodeGuid:     "b6:65:05:0c:9c:5c:f6:08",
+								SysImageGuid: "b6:65:05:0c:9c:5c:f6:00",
+							},
+						},
+						{
+							Attrs: netlink.RdmaLinkAttrs{
+								Name:         "mlx5_1",
+								NodeGuid:     "ea:6d:2d:00:03:c0:63:9c",
+								SysImageGuid: "ea:6d:2d:00:03:c0:63:9c",
+							},
+						},
+					}
+					return rdmaList, nil
+				},
+				LinkList: func() ([]netlink.Link, error) {
+					linkList := []netlink.Link{
+						&netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: ""}},
+						&netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: "mock-empty-addr", HardwareAddr: nil}},
+						&netlink.Device{LinkAttrs: netlink.LinkAttrs{
+							Name: "enp5s0f0v6",
+							HardwareAddr: func() net.HardwareAddr {
+								mac, _ := net.ParseMAC("ae:36:ac:d1:c9:1d")
+								return mac
+							}(),
+						}},
+						&netlink.IPoIB{LinkAttrs: netlink.LinkAttrs{
+							Name: "ibp13s0v7",
+							HardwareAddr: func() net.HardwareAddr {
+								mac, _ := net.ParseMAC("00:00:00:68:fe:80:00:00:00:00:00:00:08:f6:5c:9c:0c:05:65:b6")
+								return mac
+							}(),
+						}},
+						&netlink.Device{LinkAttrs: netlink.LinkAttrs{
+							Name: "ens841np0",
+							HardwareAddr: func() net.HardwareAddr {
+								mac, _ := net.ParseMAC("9c:63:c0:2d:6d:ea")
+								return mac
+							}(),
+						}},
+					}
+					return linkList, nil
+				},
+			},
+			want: []DeviceTrafficClass{
+				{
+					NetDevName:   "ens841np0",
+					IfName:       "mlx5_1",
+					TrafficClass: 160,
+				},
+			},
+			wantErr: false,
+			readFileFunc: func(name string) ([]byte, error) {
+				if name == "/sys/class/infiniband/mlx5_1/tc/1/traffic_class" {
+					return []byte("Global tclass=160"), nil
+				}
+				return nil, os.ErrNotExist
+			},
+			statsFunc: func(name string) (os.FileInfo, error) {
+				if name == "/sys/class/infiniband/mlx5_1/tc/1/traffic_class" {
+					return nil, nil
+				}
+				return nil, os.ErrNotExist
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			statFunc = tt.statsFunc
+			readFileFunc = tt.readFileFunc
+			got, err := GetDeviceTrafficClass(tt.netlink)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetDeviceTrafficClass() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetDeviceTrafficClass() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Thanks for contributing!

**Notice**:

* [ ] unite test or E2E test
* [ ] do not forget essential code comment and log
* [ ] document for the PR
* [ ] release note label
  "release/none"
  "release/bug"
  "release/feature"
* [ ] read about  Contribution notice: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>

**What issue(s) does this PR fix**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added support for specifying custom container runtime network namespace paths for RDMA metrics collection.
```
