### PR TITLE
Revert "Optimize GitHub Actions to close duplicate PRs"

### DIFF
--- a/.github/workflows/auto-diff-k8s-ci.yaml
+++ b/.github/workflows/auto-diff-k8s-ci.yaml
@@ -170,7 +170,7 @@ jobs:
           commit-message: "robot updates kind node version in k8s matrix test"
           branch-suffix: timestamp
           committer: weizhoublue<weizhou.lan@daocloud.io>
-          branch: robot/update_doc
+          branch: robot/auto_update_kind_node_version
           delete-branch: true
           signoff: true
           base: main

--- a/.github/workflows/auto-update-authors.yaml
+++ b/.github/workflows/auto-update-authors.yaml
@@ -61,32 +61,6 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
 
-      - name: Close existing PRs with same title
-        if: ${{ env.SKIP_CREATE_PR != 'true' }}
-        run: |
-          PR_TITLE="robot updates Spiderpool authors on tag: ${{ env.REF }}"
-          echo "Checking for existing PRs with title: $PR_TITLE"
-          # Get list of open PRs with the same title
-          EXISTING_PRS=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls?state=open" | \
-            jq -r ".[] | select(.title == \"$PR_TITLE\") | .number")
-          # Close each existing PR
-          for PR_NUMBER in $EXISTING_PRS; do
-            echo "Closing existing PR #$PR_NUMBER"
-            # Add a comment before closing
-            curl -s -X POST \
-              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-              -H "Accept: application/vnd.github.v3+json" \
-              "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
-              -d '{"body":"Closing this PR as a newer version is available."}'
-            # Close the PR
-            curl -s -X PATCH \
-              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-              -H "Accept: application/vnd.github.v3+json" \
-              "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER" \
-              -d '{"state":"closed"}'
-          done
-
       # Allow auto-merge on general
       - name: Create Pull Request
         if: ${{ env.SKIP_CREATE_PR != 'true' }}
@@ -95,9 +69,8 @@ jobs:
         with:
           title: "robot updates Spiderpool authors on tag: ${{ env.REF }}"
           commit-message: "robot updates Spiderpool authors on tag: ${{ env.REF }}"
-          branch-suffix: timestamp
           committer: weizhoublue<weizhou.lan@daocloud.io>
-          branch: robot/update_doc
+          branch: robot/auto_update_authors
           delete-branch: true
           signoff: true
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-cniplugins-version.yaml
+++ b/.github/workflows/update-cniplugins-version.yaml
@@ -35,40 +35,13 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
 
-      - name: Close existing PRs with same title
-        if: ${{ env.updated == 'true' }}
-        run: |
-          PR_TITLE="robot updated CNI plugins version"
-          echo "Checking for existing PRs with title: $PR_TITLE"
-          # Get list of open PRs with the same title
-          EXISTING_PRS=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls?state=open" | \
-            jq -r ".[] | select(.title == \"$PR_TITLE\") | .number")
-          # Close each existing PR
-          for PR_NUMBER in $EXISTING_PRS; do
-            echo "Closing existing PR #$PR_NUMBER"
-            # Add a comment before closing
-            curl -s -X POST \
-              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-              -H "Accept: application/vnd.github.v3+json" \
-              "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
-              -d '{"body":"Closing this PR as a newer version is available."}'
-            # Close the PR
-            curl -s -X PATCH \
-              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-              -H "Accept: application/vnd.github.v3+json" \
-              "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER" \
-              -d '{"state":"closed"}'
-          done
-
       - name: Create Pull Request
         id: create_pr
         if: ${{ env.updated == 'true' }}
         uses: peter-evans/create-pull-request@v7.0.8
         with:
-          title: "robot updated CNI plugins version"
-          commit-message: "robot updated CNI plugins version"
-          branch-suffix: timestamp
+          title: "robot updated CNI plugins version "
+          commit-message: "robot updated CNI plugins version "
           branch: robot/update_cni_version
           committer: weizhoublue<weizhou.lan@daocloud.io>
           delete-branch: true

--- a/.github/workflows/update-golang-version.yaml
+++ b/.github/workflows/update-golang-version.yaml
@@ -69,32 +69,6 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
 
-      - name: Close existing PRs with same title
-        if: ${{ env.updated == 'true' }}
-        run: |
-          PR_TITLE="robot updated golang version"
-          echo "Checking for existing PRs with title: $PR_TITLE"
-          # Get list of open PRs with the same title
-          EXISTING_PRS=$(curl -s -H "Authorization: token ${{ secrets.WELAN_PAT }}" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls?state=open" | \
-            jq -r ".[] | select(.title == \"$PR_TITLE\") | .number")
-          # Close each existing PR
-          for PR_NUMBER in $EXISTING_PRS; do
-            echo "Closing existing PR #$PR_NUMBER"
-            # Add a comment before closing
-            curl -s -X POST \
-              -H "Authorization: token ${{ secrets.WELAN_PAT }}" \
-              -H "Accept: application/vnd.github.v3+json" \
-              "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
-              -d '{"body":"Closing this PR as a newer version is available."}'
-            # Close the PR
-            curl -s -X PATCH \
-              -H "Authorization: token ${{ secrets.WELAN_PAT }}" \
-              -H "Accept: application/vnd.github.v3+json" \
-              "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER" \
-              -d '{"state":"closed"}'
-          done
-
       - name: Create Pull Request
         id: create_pr
         if: ${{ env.updated == 'true' }}


### PR DESCRIPTION
# Thanks for contributing!

**Notice**:

* [ ] unite test or E2E test
* [ ] do not forget essential code comment and log
* [ ] document for the PR
* [ ] release note label
  "release/none"
  "release/bug"
  "release/feature"
* [ ] read about  Contribution notice: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>

**What issue(s) does this PR fix**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Why submit this PR? I noticed that PRs for updating the Go version are constantly being opened and closed, resulting in a large number of deprecated pull requests, which is very redundant and makes it inconvenient to view PRs that are actually being developed. peter-evans/create-pull-request ensures that multiple updates are completed within the same PR (as long as the branch name hasn't changed).

The issues and phenomena to be fixed are as follows:
<img width="1308" height="1213" alt="image" src="https://github.com/user-attachments/assets/910a4fe6-0d12-4ed8-96f4-347a16073e5a" />

**Special notes for your reviewer**:

**Release note**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
