### PR TITLE
Fix markdown bold rendering

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -22,7 +22,7 @@ Spiderpool 提供了一个 Kubernetes 的 underlay 和 RDMA 网络解决方案, 
 
 Spiderpool 是一个 kubernetes 的 underlay 和 RDMA 网络解决方案，它增强了 [Macvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/macvlan)、
 [ipvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/ipvlan) 和
-[SR-IOV CNI](https://github.com/k8snetworkplumbingwg/sriov-cni) 的功能，满足了各种网络需求，使得 underlay 网络方案可应用在**裸金属、虚拟机和公有云环境**中，可为网络 I/O 密集性、低延时应用带来优秀的网络性能，包括**存储、中间件、AI 等应用**。详细的文档可参考[文档站](https://spidernet-io.github.io/spiderpool/)。
+[SR-IOV CNI](https://github.com/k8snetworkplumbingwg/sriov-cni) 的功能，满足了各种网络需求，使得 underlay 网络方案可应用在 **裸金属、虚拟机和公有云环境中**，可为网络 I/O 密集性、低延时应用带来优秀的网络性能，包括 **存储、中间件、AI 等应用**。详细的文档可参考[文档站](https://spidernet-io.github.io/spiderpool/)。
 
 ## 稳定版本
 

--- a/docs/README-zh_CN.md
+++ b/docs/README-zh_CN.md
@@ -20,7 +20,7 @@ Spiderpool 提供了一个 Kubernetes 的 underlay 和 RDMA 网络解决方案, 
 
 ## Spiderpool 介绍
 
-Spiderpool 是一个 kubernetes 的 underlay 和 RDMA 网络解决方案，它增强了 [Macvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/macvlan)、[ipvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/ipvlan) 和 [SR-IOV CNI](https://github.com/k8snetworkplumbingwg/sriov-cni) 的功能，满足了各种网络需求，使得 underlay 网络方案可应用在**裸金属、虚拟机和公有云环境**中，可为网络 I/O 密集性、低延时应用带来优秀的网络性能，包括**存储、中间件、AI 等应用**。详细的文档可参考[文档站](https://spidernet-io.github.io/spiderpool/)。
+Spiderpool 是一个 kubernetes 的 underlay 和 RDMA 网络解决方案，它增强了 [Macvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/macvlan)、[ipvlan CNI](https://github.com/containernetworking/plugins/tree/main/plugins/main/ipvlan) 和 [SR-IOV CNI](https://github.com/k8snetworkplumbingwg/sriov-cni) 的功能，满足了各种网络需求，使得 underlay 网络方案可应用在 **裸金属、虚拟机和公有云环境** 中，可为网络 I/O 密集性、低延时应用带来优秀的网络性能，包括 **存储、中间件、AI 等应用**。详细的文档可参考[文档站](https://spidernet-io.github.io/spiderpool/)。
 
 ## Underlay CNI 的优势
 


### PR DESCRIPTION
# Thanks for contributing!

**Notice**:

* [ ] unite test or E2E test
* [ ] do not forget essential code comment and log
* [x] document for the PR
* [ ] release note label
  "release/none"
  "release/bug"
  "release/feature"
* [x] read about  Contribution notice: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>

**What issue(s) does this PR fix**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

en:
Many Markdown parsers require that the bold ending marker ** should not be placed directly before a Chinese character.


zh:
很多 Markdown 解析器要求粗体结束符 ** 后面最好不要直接紧跟中文字符。

before:
<img width="798" height="145" alt="Screenshot 2025-11-20 at 14 27 36" src="https://github.com/user-attachments/assets/d82a8170-ad05-4d84-8fa6-14556ea99923" />



after:

<img width="890" height="144" alt="Screenshot 2025-11-20 at 14 26 51" src="https://github.com/user-attachments/assets/56694bf1-5317-4487-a1eb-29d7cb130718" />


**Release note**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix markdown bold rendering
```
