### PR TITLE
typo: fix log output format for endpoint reclamation in static Pods with changed IPs

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,8 +1,47 @@
-# Options for analysis running.
-run:
-  # Timeout for analysis, e.g. 30s, 5m.
-  # Default: 1m
-  timeout: 5m
+version: "2"
 
-  # skip-dirs:
-  #  - vendor
+linters:
+  enable:
+    - govet
+    - errcheck
+    - staticcheck
+    - ineffassign
+    - errorlint
+
+  settings:
+    errcheck:
+      # To disable the errcheck built-in exclude list.
+      # See `-excludeonly` option in https://github.com/kisielk/errcheck#excluding-functions for details.
+      # Default: false
+      disable-default-exclusions: true
+
+    staticcheck:
+      checks:
+        # Default checks https://golangci-lint.run/usage/linters/#staticcheck
+        - all
+        - -ST1000
+        - -ST1003
+        - -ST1006
+        - -ST1016
+        - -ST1020
+        - -ST1021
+        - -ST1022
+        - -ST1005
+        - -ST1008
+        - -ST1019
+        - -QF1001
+        - -QF1002
+        - -QF1003
+        - -QF1006
+        - -QF1007
+        - -QF1008
+        - -QF1012
+      dot-import-whitelist:
+        - "github.com/onsi/ginkgo/v2"
+        - "github.com/onsi/gomega"
+        - "fmt"
+
+formatters:
+  enable:
+    - gofmt
+    - gofumpt

--- a/cmd/coordinator/cmd/cni_types.go
+++ b/cmd/coordinator/cmd/cni_types.go
@@ -91,11 +91,11 @@ func ParseConfig(stdin []byte, coordinatorConfig *models.CoordinatorConfig) (*Co
 	conf := Config{}
 
 	if err = json.Unmarshal(stdin, &conf); err != nil {
-		return nil, fmt.Errorf("failed to parse config: %v", err)
+		return nil, fmt.Errorf("failed to parse config: %w", err)
 	}
 
 	if err = version.ParsePrevResult(&conf.NetConf); err != nil {
-		return nil, fmt.Errorf("failed to parse prevResult: %v", err)
+		return nil, fmt.Errorf("failed to parse prevResult: %w", err)
 	}
 
 	if err = coordinatorConfig.Validate(strfmt.Default); err != nil {

--- a/cmd/ifacer/cmd/cmd_add.go
+++ b/cmd/ifacer/cmd/cmd_add.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"net"
 
@@ -37,7 +38,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 		}
 
 		if err = createVlanDevice(conf); err != nil {
-			return fmt.Errorf("failed to createVlanDevice: %v", err)
+			return fmt.Errorf("failed to createVlanDevice: %w", err)
 		}
 
 		return types.PrintResult(result, conf.CNIVersion)
@@ -48,7 +49,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 
 		bond, err := createBondDevice(conf)
 		if err != nil {
-			return fmt.Errorf("failed to createBondDevice: %v", err)
+			return fmt.Errorf("failed to createBondDevice: %w", err)
 		}
 
 		if conf.VlanID == 0 {
@@ -64,14 +65,15 @@ func CmdAdd(args *skel.CmdArgs) error {
 		if err == nil {
 			if vlanLink.Attrs().Flags != net.FlagUp {
 				if err = netlink.LinkSetUp(vlanLink); err != nil {
-					return fmt.Errorf("failed to set %s up: %v", vlanLink.Attrs().Name, err)
+					return fmt.Errorf("failed to set %s up: %w", vlanLink.Attrs().Name, err)
 				}
 			}
 			return nil
 		}
 
-		if _, ok := err.(netlink.LinkNotFoundError); !ok {
-			return fmt.Errorf("failed to LinkByName %s: %v", vlanName, err)
+		var notFoundErr netlink.LinkNotFoundError
+		if !errors.As(err, &notFoundErr) {
+			return fmt.Errorf("failed to LinkByName %s: %w", vlanName, err)
 		}
 
 		// create vlan interface
@@ -95,7 +97,7 @@ func createBondDevice(conf *Ifacer) (*netlink.Bond, error) {
 	bondLink, err = netlink.LinkByName(conf.Bond.Name)
 	if err == nil && bondLink.Attrs().Flags != net.FlagUp {
 		if err = netlink.LinkSetUp(bondLink); err != nil {
-			return nil, fmt.Errorf("failed to set %s up: %v", bondLink.Attrs().Name, err)
+			return nil, fmt.Errorf("failed to set %s up: %w", bondLink.Attrs().Name, err)
 		}
 
 		if bondLink.Type() != "bond" {
@@ -108,8 +110,9 @@ func createBondDevice(conf *Ifacer) (*netlink.Bond, error) {
 		return nil, fmt.Errorf("createBondDevice failure: invalid bond device")
 	}
 
-	if _, ok := err.(netlink.LinkNotFoundError); !ok {
-		return nil, fmt.Errorf("failed to LinkByName %s: %v", conf.Bond.Name, err)
+	var notFoundErr netlink.LinkNotFoundError
+	if !errors.As(err, &notFoundErr) {
+		return nil, fmt.Errorf("failed to LinkByName %s: %w", conf.Bond.Name, err)
 	}
 
 	if err = validateBondMode(conf.Bond.Mode); err != nil {
@@ -173,7 +176,7 @@ func createVlanDevice(conf *Ifacer) error {
 
 	if parentLink.Attrs().Flags != net.FlagUp {
 		if err = netlink.LinkSetUp(parentLink); err != nil {
-			return fmt.Errorf("failed to set %s up: %v", parentLink.Attrs().Name, err)
+			return fmt.Errorf("failed to set %s up: %w", parentLink.Attrs().Name, err)
 		}
 	}
 
@@ -183,14 +186,15 @@ func createVlanDevice(conf *Ifacer) error {
 	if err == nil {
 		if vlanLink.Attrs().Flags != net.FlagUp {
 			if err = netlink.LinkSetUp(vlanLink); err != nil {
-				return fmt.Errorf("failed to set %s up: %v", vlanLink.Attrs().Name, err)
+				return fmt.Errorf("failed to set %s up: %w", vlanLink.Attrs().Name, err)
 			}
 		}
 		return nil
 	}
 
-	if _, ok := err.(netlink.LinkNotFoundError); !ok {
-		return fmt.Errorf("failed to LinkByName %s: %v", vlanIfName, err)
+	var notFoundErr netlink.LinkNotFoundError
+	if !errors.As(err, &notFoundErr) {
+		return fmt.Errorf("failed to LinkByName %s: %w", vlanIfName, err)
 	}
 
 	// we only create if vlanIf not present

--- a/cmd/ifacer/cmd/types.go
+++ b/cmd/ifacer/cmd/types.go
@@ -6,11 +6,12 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/containernetworking/cni/pkg/types"
-	"github.com/vishvananda/netlink"
 	"net"
 	"strconv"
 	"strings"
+
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/vishvananda/netlink"
 )
 
 var DefaultBondName = "sp_bond0"
@@ -32,7 +33,7 @@ func ParseConfig(stdin []byte) (*Ifacer, error) {
 	var err error
 	conf := Ifacer{}
 	if err = json.Unmarshal(stdin, &conf); err != nil {
-		return nil, fmt.Errorf("failed to parse config: %v", err)
+		return nil, fmt.Errorf("failed to parse config: %w", err)
 	}
 
 	if len(conf.Interfaces) == 0 {
@@ -72,7 +73,7 @@ func parseString2BondOptions(options string) (*BondOptions, error) {
 	options = strings.TrimSpace(options)
 	optionsList := strings.Split(options, ";")
 
-	var rawOptionsJsonStr string
+	var rawOptionsJSONStr string
 	for idx, option := range optionsList {
 		kv := strings.Split(option, "=")
 		if len(kv) != 2 {
@@ -92,16 +93,16 @@ func parseString2BondOptions(options string) (*BondOptions, error) {
 		}
 
 		if idx == 0 {
-			rawOptionsJsonStr = op
+			rawOptionsJSONStr = op
 		} else {
-			rawOptionsJsonStr = fmt.Sprintf("%s,%s", rawOptionsJsonStr, op)
+			rawOptionsJSONStr = fmt.Sprintf("%s,%s", rawOptionsJSONStr, op)
 		}
 	}
 
-	optionsJsonStr := fmt.Sprintf("{%s}", rawOptionsJsonStr)
+	optionsJSONStr := fmt.Sprintf("{%s}", rawOptionsJSONStr)
 
 	bondOptions := &BondOptions{}
-	if err := json.Unmarshal([]byte(optionsJsonStr), bondOptions); err != nil {
+	if err := json.Unmarshal([]byte(optionsJSONStr), bondOptions); err != nil {
 		return nil, fmt.Errorf("failed to convert options to BondOptions: %w", err)
 	}
 
@@ -136,16 +137,16 @@ func parseBondOptions2NetlinkBond(bondOptions *BondOptions, bond *netlink.Bond) 
 			bondOptionsFuncs = append(bondOptionsFuncs, AdActorSystemOption(hwAddr))
 		}
 
-		if len(bondOptions.ArpIpTargets) > 0 {
-			var arpIpTargets []net.IP
-			for _, arpIpTargetStr := range bondOptions.ArpIpTargets {
-				arpIpTarget := net.ParseIP(arpIpTargetStr)
-				if arpIpTarget == nil {
-					return fmt.Errorf("invalid bond arp_ip_target: %s", arpIpTargetStr)
+		if len(bondOptions.ArpIPTargets) > 0 {
+			var arpIPTargets []net.IP
+			for _, arpIPTargetStr := range bondOptions.ArpIPTargets {
+				arpIPTarget := net.ParseIP(arpIPTargetStr)
+				if arpIPTarget == nil {
+					return fmt.Errorf("invalid bond arp_ip_target: %s", arpIPTargetStr)
 				}
-				arpIpTargets = append(arpIpTargets, arpIpTarget)
+				arpIPTargets = append(arpIPTargets, arpIPTarget)
 			}
-			bondOptionsFuncs = append(bondOptionsFuncs, ArpIpTargetsOption(arpIpTargets))
+			bondOptionsFuncs = append(bondOptionsFuncs, ArpIPTargetsOption(arpIPTargets))
 		}
 		bondOptionsFuncs = GetAllIntBondOptions(bondOptions, bondOptionsFuncs)
 	}

--- a/cmd/ifacer/cmd/utils.go
+++ b/cmd/ifacer/cmd/utils.go
@@ -5,8 +5,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/vishvananda/netlink"
 	"net"
+
+	"github.com/vishvananda/netlink"
 )
 
 // BondOptions  for the bonding driver are supplied as parameters to the
@@ -20,7 +21,7 @@ type BondOptions struct {
 	AdUserPortKey   int      `json:"ad_user_port_key,omitempty"`
 	AllSlavesActive int      `json:"all_slaves_active,omitempty"`
 	ArpInterval     int      `json:"arp_interval,omitempty"`
-	ArpIpTargets    []string `json:"arp_ip_target,omitempty"`
+	ArpIPTargets    []string `json:"arp_ip_target,omitempty"`
 	ArpValidate     int      `json:"arp_validate,omitempty"`
 	ArpAllTargets   int      `json:"arp_all_targets,omitempty"`
 	DownDelay       int      `json:"downdelay,omitempty"`
@@ -86,9 +87,9 @@ func ArpIntervalOption(arpInterval int) BondOptionFunc {
 	}
 }
 
-func ArpIpTargetsOption(arpIpTargets []net.IP) BondOptionFunc {
+func ArpIPTargetsOption(arpIPTargets []net.IP) BondOptionFunc {
 	return func(bond *netlink.Bond) {
-		bond.ArpIpTargets = arpIpTargets
+		bond.ArpIpTargets = arpIPTargets
 	}
 }
 
@@ -261,20 +262,20 @@ func GetAllIntBondOptions(bondOptions *BondOptions, bondOptionFuncs []BondOption
 	return bondOptionFuncs
 }
 
-func getVlanIfaceName(master string, vlanId int) string {
-	return fmt.Sprintf("%s.%d", master, vlanId)
+func getVlanIfaceName(master string, vlanID int) string {
+	return fmt.Sprintf("%s.%d", master, vlanID)
 }
 
-func checkInterfaceWithSameVlan(vlanId int, vlanInterface string) error {
+func checkInterfaceWithSameVlan(vlanID int, vlanInterface string) error {
 	links, err := netlink.LinkList()
 	if err != nil {
-		return fmt.Errorf("failed to LinkList: %v", err)
+		return fmt.Errorf("failed to LinkList: %w", err)
 	}
 
 	for _, link := range links {
 		if link.Type() == "vlan" {
-			if vlan, ok := link.(*netlink.Vlan); ok && vlan.VlanId == vlanId && vlan.Name != vlanInterface {
-				return fmt.Errorf("cannot have multiple different vlan interfaces with the same vlanId %v on node at the same time", vlanId)
+			if vlan, ok := link.(*netlink.Vlan); ok && vlan.VlanId == vlanID && vlan.Name != vlanInterface {
+				return fmt.Errorf("cannot have multiple different vlan interfaces with the same vlanId %v on node at the same time", vlanID)
 			}
 		}
 	}

--- a/cmd/spiderpool-agent/cmd/command_root.go
+++ b/cmd/spiderpool-agent/cmd/command_root.go
@@ -13,8 +13,10 @@ import (
 	"github.com/spidernet-io/spiderpool/pkg/utils/cmdgenmd"
 )
 
-var binNameAgent = filepath.Base(os.Args[0])
-var logger = logutils.Logger.Named(binNameAgent)
+var (
+	binNameAgent = filepath.Base(os.Args[0])
+	logger       = logutils.Logger.Named(binNameAgent)
+)
 
 // rootCmd represents the base command.
 var rootCmd = &cobra.Command{

--- a/cmd/spiderpool-agent/cmd/config.go
+++ b/cmd/spiderpool-agent/cmd/config.go
@@ -58,8 +58,8 @@ var envInfo = []envConf{
 	{"SPIDERPOOL_POD_NAMESPACE", "", true, &agentContext.Cfg.AgentPodNamespace, nil, nil},
 	{"SPIDERPOOL_POD_NAME", "", true, &agentContext.Cfg.AgentPodName, nil, nil},
 	{"SPIDERPOOL_NODE_NAME", "", true, &agentContext.Cfg.NodeName, nil, nil},
-	{"SPIDERPOOL_HEALTH_PORT", "5710", true, &agentContext.Cfg.HttpPort, nil, nil},
-	{"SPIDERPOOL_METRIC_HTTP_PORT", "5711", true, &agentContext.Cfg.MetricHttpPort, nil, nil},
+	{"SPIDERPOOL_HEALTH_PORT", "5710", true, &agentContext.Cfg.HTTPPort, nil, nil},
+	{"SPIDERPOOL_METRIC_HTTP_PORT", "5711", true, &agentContext.Cfg.MetricHTTPPort, nil, nil},
 	{"SPIDERPOOL_GOPS_LISTEN_PORT", "5712", false, &agentContext.Cfg.GopsListenPort, nil, nil},
 	{"SPIDERPOOL_PYROSCOPE_PUSH_SERVER_ADDRESS", "", false, &agentContext.Cfg.PyroscopeAddress, nil, nil},
 	{"SPIDERPOOL_ENABLED_RELEASE_CONFLICT_IPS", "true", true, nil, &agentContext.Cfg.EnableReleaseConflictIPsForStateless, nil},
@@ -88,8 +88,8 @@ type Config struct {
 	NodeName                             string
 	EnableReleaseConflictIPsForStateless bool
 
-	HttpPort         string
-	MetricHttpPort   string
+	HTTPPort         string
+	MetricHTTPPort   string
 	GopsListenPort   string
 	PyroscopeAddress string
 
@@ -128,9 +128,9 @@ type AgentContext struct {
 	ClientSet *kubernetes.Clientset
 
 	// handler
-	HttpServer        *server.Server
+	HTTPServer        *server.Server
 	UnixServer        *server.Server
-	MetricsHttpServer *http.Server
+	MetricsHTTPServer *http.Server
 
 	// client
 	unixClient *client.SpiderpoolAgentAPI
@@ -191,12 +191,12 @@ func ParseConfiguration() error {
 func (ac *AgentContext) LoadConfigmap() error {
 	configmapBytes, err := os.ReadFile(ac.Cfg.ConfigPath)
 	if nil != err {
-		return fmt.Errorf("failed to read configmap file, error: %v", err)
+		return fmt.Errorf("failed to read configmap file, error: %w", err)
 	}
 
 	err = yaml.Unmarshal(configmapBytes, &ac.Cfg.SpiderpoolConfigmapConfig)
 	if nil != err {
-		return fmt.Errorf("failed to parse configmap, error: %v", err)
+		return fmt.Errorf("failed to parse configmap, error: %w", err)
 	}
 
 	if ac.Cfg.IpamUnixSocketPath == "" {

--- a/cmd/spiderpool-agent/cmd/daemon.go
+++ b/cmd/spiderpool-agent/cmd/daemon.go
@@ -218,12 +218,12 @@ func DaemonMain() {
 	if nil != err {
 		logger.Fatal(err.Error())
 	}
-	agentContext.HttpServer = srv
+	agentContext.HTTPServer = srv
 
 	go func() {
 		logger.Info("Starting spiderpool-agent OpenAPI HTTP server")
 		if err := srv.Serve(); nil != err {
-			if err == http.ErrServerClosed {
+			if errors.Is(err, http.ErrServerClosed) {
 				return
 			}
 			logger.Fatal(err.Error())
@@ -244,7 +244,7 @@ func DaemonMain() {
 	go func() {
 		logger.Info("Starting spiderpool-agent OpenAPI UNIX server")
 		if err := unixServer.Serve(); nil != err {
-			if err == net.ErrClosed {
+			if errors.Is(err, net.ErrClosed) {
 				return
 			}
 			logger.Fatal(err.Error())
@@ -277,16 +277,16 @@ func WatchSignal(sigCh chan os.Signal) {
 		}
 
 		// shut down agent http server
-		if nil != agentContext.HttpServer {
-			if err := agentContext.HttpServer.Shutdown(); nil != err {
-				logger.Sugar().Errorf("Failed to shutdown spiderpool-agent HTTP server: %v", err)
+		if nil != agentContext.HTTPServer {
+			if err := agentContext.HTTPServer.Shutdown(); nil != err {
+				logger.Sugar().Errorf("Failed to shutdown spiderpool-agent HTTP server: %w", err)
 			}
 		}
 
 		// shut down agent unix server
 		if nil != agentContext.UnixServer {
 			if err := agentContext.UnixServer.Shutdown(); nil != err {
-				logger.Sugar().Errorf("Failed to shut down spiderpool-agent UNIX server: %v", err)
+				logger.Sugar().Errorf("Failed to shut down spiderpool-agent UNIX server: %w", err)
 			}
 		}
 		// others...
@@ -325,7 +325,7 @@ func waitAPIServerReady(ctx context.Context) error {
 			Do(ctx).
 			Error()
 		if err != nil {
-			logger.Sugar().Debugf("API Server not ready: %v", err)
+			logger.Sugar().Debugf("API Server not ready: %w", err)
 			continue
 		}
 

--- a/cmd/spiderpool-agent/cmd/http_server.go
+++ b/cmd/spiderpool-agent/cmd/http_server.go
@@ -40,7 +40,7 @@ func newAgentOpenAPIHttpServer() (*agentOpenAPIServer.Server, error) {
 	// and the Http server uses for K8s or CLI command.
 	// In spider-agent openapi.yaml, we already set x-schemes with value 'unix', so we need set Http server's listener with value 'http'.
 	srv.EnabledListeners = agentOpenAPIClient.DefaultSchemes
-	port, err := strconv.Atoi(agentContext.Cfg.HttpPort)
+	port, err := strconv.Atoi(agentContext.Cfg.HTTPPort)
 	if nil != err {
 		return nil, err
 	}

--- a/cmd/spiderpool-agent/cmd/ipam.go
+++ b/cmd/spiderpool-agent/cmd/ipam.go
@@ -20,16 +20,16 @@ import (
 
 // Singleton.
 var (
-	unixPostAgentIpamIp    = &_unixPostAgentIpamIp{}
-	unixDeleteAgentIpamIp  = &_unixDeleteAgentIpamIp{}
+	unixPostAgentIpamIP    = &_unixPostAgentIpamIP{}
+	unixDeleteAgentIpamIP  = &_unixDeleteAgentIpamIP{}
 	unixPostAgentIpamIps   = &_unixPostAgentIpamIps{}
 	unixDeleteAgentIpamIps = &_unixDeleteAgentIpamIps{}
 )
 
-type _unixPostAgentIpamIp struct{}
+type _unixPostAgentIpamIP struct{}
 
 // Handle handles POST requests for /ipam/ip.
-func (g *_unixPostAgentIpamIp) Handle(params daemonset.PostIpamIPParams) middleware.Responder {
+func (g *_unixPostAgentIpamIP) Handle(params daemonset.PostIpamIPParams) middleware.Responder {
 	if err := params.IpamAddArgs.Validate(strfmt.Default); err != nil {
 		return daemonset.NewPostIpamIPFailure().WithPayload(models.Error(err.Error()))
 	}
@@ -69,10 +69,10 @@ func (g *_unixPostAgentIpamIp) Handle(params daemonset.PostIpamIPParams) middlew
 	return daemonset.NewPostIpamIPOK().WithPayload(resp)
 }
 
-type _unixDeleteAgentIpamIp struct{}
+type _unixDeleteAgentIpamIP struct{}
 
 // Handle handles DELETE requests for /ipam/ip.
-func (g *_unixDeleteAgentIpamIp) Handle(params daemonset.DeleteIpamIPParams) middleware.Responder {
+func (g *_unixDeleteAgentIpamIP) Handle(params daemonset.DeleteIpamIPParams) middleware.Responder {
 	if err := params.IpamDelArgs.Validate(strfmt.Default); err != nil {
 		return daemonset.NewDeleteIpamIPFailure().WithPayload(models.Error(err.Error()))
 	}

--- a/cmd/spiderpool-agent/cmd/metrics_server.go
+++ b/cmd/spiderpool-agent/cmd/metrics_server.go
@@ -63,7 +63,7 @@ func initAgentMetricsServer(ctx context.Context) {
 
 	if agentContext.Cfg.EnableMetric {
 		metricsSrv := &http.Server{
-			Addr:    fmt.Sprintf(":%s", agentContext.Cfg.MetricHttpPort),
+			Addr:    fmt.Sprintf(":%s", agentContext.Cfg.MetricHTTPPort),
 			Handler: metricController,
 		}
 
@@ -77,6 +77,6 @@ func initAgentMetricsServer(ctx context.Context) {
 			}
 		}()
 
-		agentContext.MetricsHttpServer = metricsSrv
+		agentContext.MetricsHTTPServer = metricsSrv
 	}
 }

--- a/cmd/spiderpool-agent/cmd/runtime_status.go
+++ b/cmd/spiderpool-agent/cmd/runtime_status.go
@@ -39,7 +39,7 @@ type _httpGetAgentReadiness struct {
 func (g *_httpGetAgentReadiness) Handle(params runtime.GetRuntimeReadinessParams) middleware.Responder {
 	_, err := g.unixClient.Connectivity.GetIpamHealthy(connectivity.NewGetIpamHealthyParams())
 	if nil != err {
-		logger.Sugar().Errorf("failed to check spiderpool-agent readiness probe, error: %v", err)
+		logger.Sugar().Errorf("failed to check spiderpool-agent readiness probe, error: %w", err)
 		return runtime.NewGetRuntimeReadinessInternalServerError()
 	}
 

--- a/cmd/spiderpool-agent/cmd/unix_server.go
+++ b/cmd/spiderpool-agent/cmd/unix_server.go
@@ -29,8 +29,8 @@ func newAgentOpenAPIUnixServer() (*agentOpenAPIServer.Server, error) {
 
 	// daemonset API
 	api.ConnectivityGetIpamHealthyHandler = unixGetAgentHealth
-	api.DaemonsetPostIpamIPHandler = unixPostAgentIpamIp
-	api.DaemonsetDeleteIpamIPHandler = unixDeleteAgentIpamIp
+	api.DaemonsetPostIpamIPHandler = unixPostAgentIpamIP
+	api.DaemonsetDeleteIpamIPHandler = unixDeleteAgentIpamIP
 	api.DaemonsetPostIpamIpsHandler = unixPostAgentIpamIps
 	api.DaemonsetDeleteIpamIpsHandler = unixDeleteAgentIpamIps
 	api.DaemonsetGetCoordinatorConfigHandler = unixGetCoordinatorConfig

--- a/cmd/spiderpool-controller/cmd/clean.go
+++ b/cmd/spiderpool-controller/cmd/clean.go
@@ -30,7 +30,6 @@ var cleanCmd = &cobra.Command{
 	Short: "Clean resources",
 	Long:  "Clean resources with specified parameters.",
 	Run: func(cmd *cobra.Command, args []string) {
-
 		validate, err := cmd.Flags().GetString("validate")
 		if err != nil {
 			logger.Fatal(err.Error())
@@ -171,7 +170,7 @@ func (c *CoreClient) cleanWebhookResources(ctx context.Context, resourceType, re
 			return nil
 		}
 
-		logger.Sugar().Errorf("failed to delete %s: %s, error: %v", resourceType, resourceName, err)
+		logger.Sugar().Errorf("failed to delete %s: %s, error: %w", resourceType, resourceName, err)
 		return err
 	}
 
@@ -235,7 +234,6 @@ func (c *CoreClient) cleanSpiderpoolResources(ctx context.Context, list client.O
 				logger.Sugar().Infof("succeeded to clean the finalizers of %s %v", resourceName, item.GetName())
 				return nil
 			})
-
 			if err != nil {
 				logger.Sugar().Errorf("failed to clean the finalizers of %s: %v, %v", resourceName, item.GetName(), err)
 				jobResult = multierror.Append(jobResult, err)
@@ -266,10 +264,10 @@ func (c *CoreClient) cleanCRDs(ctx context.Context) error {
 	err := c.List(ctx, crdList)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			logger.Sugar().Infof("CustomResourceDefinitionList does not exist, ignore it. error: %v", err)
+			logger.Sugar().Infof("CustomResourceDefinitionList does not exist, ignore it. error: %w", err)
 			return nil
 		}
-		logger.Sugar().Errorf("failed to list CustomResourceDefinitionList, error: %v", err)
+		logger.Sugar().Errorf("failed to list CustomResourceDefinitionList, error: %w", err)
 		return err
 	}
 

--- a/cmd/spiderpool-controller/cmd/command_root.go
+++ b/cmd/spiderpool-controller/cmd/command_root.go
@@ -12,8 +12,10 @@ import (
 	"github.com/spidernet-io/spiderpool/pkg/utils/cmdgenmd"
 )
 
-var binNameController = filepath.Base(os.Args[0])
-var logger = logutils.Logger.Named(binNameController)
+var (
+	binNameController = filepath.Base(os.Args[0])
+	logger            = logutils.Logger.Named(binNameController)
+)
 
 // rootCmd represents the base command.
 var rootCmd = &cobra.Command{

--- a/cmd/spiderpool-controller/cmd/config.go
+++ b/cmd/spiderpool-controller/cmd/config.go
@@ -58,8 +58,8 @@ var envInfo = []envConf{
 	{"SPIDERPOOL_ENABLED_METRIC", "false", false, nil, &controllerContext.Cfg.EnableMetric, nil},
 	{"SPIDERPOOL_ENABLED_DEBUG_METRIC", "false", false, nil, &controllerContext.Cfg.EnableDebugLevelMetric, nil},
 	{"SPIDERPOOL_METRIC_RENEW_PERIOD", "120", true, nil, nil, &controllerContext.Cfg.MetricRenewPeriod},
-	{"SPIDERPOOL_HEALTH_PORT", "5720", true, &controllerContext.Cfg.HttpPort, nil, nil},
-	{"SPIDERPOOL_METRIC_HTTP_PORT", "5721", true, &controllerContext.Cfg.MetricHttpPort, nil, nil},
+	{"SPIDERPOOL_HEALTH_PORT", "5720", true, &controllerContext.Cfg.HTTPPort, nil, nil},
+	{"SPIDERPOOL_METRIC_HTTP_PORT", "5721", true, &controllerContext.Cfg.MetricHTTPPort, nil, nil},
 	{"SPIDERPOOL_WEBHOOK_PORT", "5722", true, &controllerContext.Cfg.WebhookPort, nil, nil},
 	{"SPIDERPOOL_GOPS_LISTEN_PORT", "5724", false, &controllerContext.Cfg.GopsListenPort, nil, nil},
 	{"SPIDERPOOL_PYROSCOPE_PUSH_SERVER_ADDRESS", "", false, &controllerContext.Cfg.PyroscopeAddress, nil, nil},
@@ -115,8 +115,8 @@ type Config struct {
 
 	// flags
 	ConfigPath        string
-	TlsServerCertPath string
-	TlsServerKeyPath  string
+	TLSServerCertPath string
+	TLSServerKeyPath  string
 
 	// env
 	LogLevel               string
@@ -124,8 +124,8 @@ type Config struct {
 	EnableDebugLevelMetric bool
 	MetricRenewPeriod      int
 
-	HttpPort          string
-	MetricHttpPort    string
+	HTTPPort          string
+	MetricHTTPPort    string
 	WebhookPort       string
 	GopsListenPort    string
 	PyroscopeAddress  string
@@ -193,8 +193,8 @@ type ControllerContext struct {
 	Leader            election.SpiderLeaseElector
 
 	// handler
-	HttpServer        *server.Server
-	MetricsHttpServer *http.Server
+	HTTPServer        *server.Server
+	MetricsHTTPServer *http.Server
 
 	// webhook http client
 	webhookClient *http.Client
@@ -206,8 +206,8 @@ type ControllerContext struct {
 // BindControllerDaemonFlags bind controller cli daemon flags
 func (cc *ControllerContext) BindControllerDaemonFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&cc.Cfg.ConfigPath, "config-path", "/tmp/spiderpool/config-map/conf.yml", "spiderpool-controller configmap file")
-	flags.StringVar(&cc.Cfg.TlsServerCertPath, "tls-server-cert", "", "file path of server cert")
-	flags.StringVar(&cc.Cfg.TlsServerKeyPath, "tls-server-key", "", "file path of server key")
+	flags.StringVar(&cc.Cfg.TLSServerCertPath, "tls-server-cert", "", "file path of server cert")
+	flags.StringVar(&cc.Cfg.TLSServerKeyPath, "tls-server-key", "", "file path of server key")
 }
 
 // ParseConfiguration set the env to AgentConfiguration
@@ -255,22 +255,22 @@ func ParseConfiguration() error {
 
 // VerifyConfig after retrieve all config
 func (cc *ControllerContext) VerifyConfig() error {
-	dir := path.Dir(cc.Cfg.TlsServerCertPath)
+	dir := path.Dir(cc.Cfg.TLSServerCertPath)
 	_, err := os.Stat(dir)
 	if nil != err {
-		return fmt.Errorf("failed to get Cert path '%s', error: %v", dir, err)
+		return fmt.Errorf("failed to get Cert path '%s', error: %w", dir, err)
 	}
 
 	// cert file
-	_, err = os.Stat(cc.Cfg.TlsServerCertPath)
+	_, err = os.Stat(cc.Cfg.TLSServerCertPath)
 	if nil != err {
-		return fmt.Errorf("failed to check whether Cert file '%s' exists, error: %v", cc.Cfg.TlsServerCertPath, err)
+		return fmt.Errorf("failed to check whether Cert file '%s' exists, error: %w", cc.Cfg.TLSServerCertPath, err)
 	}
 
 	// key file
-	_, err = os.Stat(cc.Cfg.TlsServerKeyPath)
+	_, err = os.Stat(cc.Cfg.TLSServerKeyPath)
 	if nil != err {
-		return fmt.Errorf("failed to check whether Cert Key file '%s' exists, error: %v", cc.Cfg.TlsServerKeyPath, err)
+		return fmt.Errorf("failed to check whether Cert Key file '%s' exists, error: %w", cc.Cfg.TLSServerKeyPath, err)
 	}
 
 	return nil
@@ -280,12 +280,12 @@ func (cc *ControllerContext) VerifyConfig() error {
 func (cc *ControllerContext) LoadConfigmap() error {
 	configmapBytes, err := os.ReadFile(cc.Cfg.ConfigPath)
 	if nil != err {
-		return fmt.Errorf("failed to read configmap file, error: %v", err)
+		return fmt.Errorf("failed to read configmap file, error: %w", err)
 	}
 
 	err = yaml.Unmarshal(configmapBytes, &cc.Cfg.SpiderpoolConfigmapConfig)
 	if nil != err {
-		return fmt.Errorf("failed to parse configmap, error: %v", err)
+		return fmt.Errorf("failed to parse configmap, error: %w", err)
 	}
 
 	return nil

--- a/cmd/spiderpool-controller/cmd/crd_manager.go
+++ b/cmd/spiderpool-controller/cmd/crd_manager.go
@@ -60,7 +60,7 @@ func newCRDManager() (ctrl.Manager, error) {
 		HealthProbeBindAddress: "0",
 		WebhookServer: runtimeWebhook.NewServer(runtimeWebhook.Options{
 			Port:    port,
-			CertDir: path.Dir(controllerContext.Cfg.TlsServerCertPath),
+			CertDir: path.Dir(controllerContext.Cfg.TLSServerCertPath),
 		}),
 	})
 	if err != nil {

--- a/cmd/spiderpool-controller/cmd/http_server.go
+++ b/cmd/spiderpool-controller/cmd/http_server.go
@@ -38,7 +38,7 @@ func newControllerOpenAPIServer() (*controllerOpenAPIServer.Server, error) {
 
 	// customize server configurations.
 	srv.EnabledListeners = controllerOpenAPIClient.DefaultSchemes
-	port, err := strconv.Atoi(controllerContext.Cfg.HttpPort)
+	port, err := strconv.Atoi(controllerContext.Cfg.HTTPPort)
 	if nil != err {
 		return nil, err
 	}

--- a/cmd/spiderpool-controller/cmd/metrics_server.go
+++ b/cmd/spiderpool-controller/cmd/metrics_server.go
@@ -31,7 +31,7 @@ func initControllerMetricsServer(ctx context.Context) {
 
 	if controllerContext.Cfg.EnableMetric {
 		metricsSrv := &http.Server{
-			Addr:    fmt.Sprintf(":%s", controllerContext.Cfg.MetricHttpPort),
+			Addr:    fmt.Sprintf(":%s", controllerContext.Cfg.MetricHTTPPort),
 			Handler: metricController,
 		}
 
@@ -45,7 +45,7 @@ func initControllerMetricsServer(ctx context.Context) {
 			}
 		}()
 
-		controllerContext.MetricsHttpServer = metricsSrv
+		controllerContext.MetricsHTTPServer = metricsSrv
 	}
 }
 
@@ -62,7 +62,7 @@ func monitorMetrics(ctx context.Context) {
 		var poolList spiderpoolv2beta1.SpiderIPPoolList
 		err := client.List(ctx, &poolList)
 		if nil != err {
-			logger.Sugar().Errorf("failed to monitor metric TotalIPPoolCounts, error: %v", err)
+			logger.Sugar().Errorf("failed to monitor metric TotalIPPoolCounts, error: %w", err)
 			return
 		}
 		metric.TotalIPPoolCounts.Record(int64(len(poolList.Items)))
@@ -74,7 +74,7 @@ func monitorMetrics(ctx context.Context) {
 			var subnetList spiderpoolv2beta1.SpiderSubnetList
 			err := client.List(ctx, &subnetList)
 			if nil != err {
-				logger.Sugar().Errorf("failed to monitor metric TotalSubnetCounts, error: %v", err)
+				logger.Sugar().Errorf("failed to monitor metric TotalSubnetCounts, error: %w", err)
 				return
 			}
 			metric.TotalSubnetCounts.Record(int64(len(subnetList.Items)))

--- a/cmd/spiderpool-controller/cmd/runtime_status.go
+++ b/cmd/spiderpool-controller/cmd/runtime_status.go
@@ -37,7 +37,7 @@ type _httpGetControllerReadiness struct {
 // Handle handles GET requests for k8s readiness probe.
 func (g *_httpGetControllerReadiness) Handle(params runtime.GetRuntimeReadinessParams) middleware.Responder {
 	if err := openapi.WebhookHealthyCheck(g.webhookClient, g.Cfg.WebhookPort, nil); err != nil {
-		logger.Sugar().Errorf("failed to check spiderpool-controller readiness probe, error: %v", err)
+		logger.Sugar().Errorf("failed to check spiderpool-controller readiness probe, error: %w", err)
 		return runtime.NewGetRuntimeReadinessInternalServerError()
 	}
 
@@ -63,7 +63,7 @@ type _httpGetControllerLiveness struct {
 // Handle handles GET requests for k8s liveness probe.
 func (g *_httpGetControllerLiveness) Handle(params runtime.GetRuntimeLivenessParams) middleware.Responder {
 	if err := openapi.WebhookHealthyCheck(g.webhookClient, g.Cfg.WebhookPort, nil); err != nil {
-		logger.Sugar().Errorf("failed to check spiderpool controller liveness probe, error: %v", err)
+		logger.Sugar().Errorf("failed to check spiderpool controller liveness probe, error: %w", err)
 		return runtime.NewGetRuntimeLivenessInternalServerError()
 	}
 

--- a/cmd/spiderpool-init/cmd/config.go
+++ b/cmd/spiderpool-init/cmd/config.go
@@ -105,7 +105,7 @@ func parseENVAsDefault() InitDefaultConfig {
 	config := InitDefaultConfig{}
 	config.Namespace = strings.ReplaceAll(os.Getenv(ENVNamespace), "\"", "")
 	if len(config.Namespace) == 0 {
-		logger.Sugar().Fatalf("ENV %s %w", ENVNamespace, constant.ErrMissingRequiredParam)
+		logger.Sugar().Fatalf("ENV %s %v", ENVNamespace, constant.ErrMissingRequiredParam)
 	}
 	config.ControllerName = strings.ReplaceAll(os.Getenv(ENVSpiderpoolControllerName), "\"", "")
 	if len(config.ControllerName) == 0 {
@@ -165,7 +165,7 @@ func parseENVAsDefault() InitDefaultConfig {
 	if len(config.V4SubnetName) != 0 || len(config.V4IPPoolName) != 0 {
 		config.V4CIDR = strings.ReplaceAll(os.Getenv(ENVDefaultIPv4CIDR), "\"", "")
 		if len(config.V4CIDR) == 0 {
-			logger.Sugar().Fatalf("ENV %s %w, if you need to create a default IPv4 Subnet or IPPool", ENVDefaultIPv4CIDR, constant.ErrMissingRequiredParam)
+			logger.Sugar().Fatalf("ENV %s %v, if you need to create a default IPv4 Subnet or IPPool", ENVDefaultIPv4CIDR, constant.ErrMissingRequiredParam)
 		}
 		if err := spiderpoolip.IsCIDR(constant.IPv4, config.V4CIDR); err != nil {
 			logger.Sugar().Fatalf("ENV %s %s: %v", ENVDefaultIPv4CIDR, config.V4CIDR, err)
@@ -204,7 +204,7 @@ func parseENVAsDefault() InitDefaultConfig {
 	if len(config.V6SubnetName) != 0 || len(config.V6IPPoolName) != 0 {
 		config.V6CIDR = strings.ReplaceAll(os.Getenv(ENVDefaultIPv6CIDR), "\"", "")
 		if len(config.V6CIDR) == 0 {
-			logger.Sugar().Fatalf("ENV %s %w, if you need to create a default IPv6 Subnet or IPPool", ENVDefaultIPv6CIDR, constant.ErrMissingRequiredParam)
+			logger.Sugar().Fatalf("ENV %s %v, if you need to create a default IPv6 Subnet or IPPool", ENVDefaultIPv6CIDR, constant.ErrMissingRequiredParam)
 		}
 		if err := spiderpoolip.IsCIDR(constant.IPv6, config.V6CIDR); err != nil {
 			logger.Sugar().Fatalf("ENV %s %s: %v", ENVDefaultIPv6CIDR, config.V6CIDR, err)
@@ -296,7 +296,7 @@ func parseCNIFromConfig(cniConfigPath string) (string, string, error) {
 	if strings.HasSuffix(cniConfigPath, ".conflist") {
 		confList, err := libcni.ConfListFromFile(cniConfigPath)
 		if err != nil {
-			return "", "", fmt.Errorf("error loading CNI conflist file %s: %v", cniConfigPath, err)
+			return "", "", fmt.Errorf("error loading CNI conflist file %s: %w", cniConfigPath, err)
 		}
 		cniName = confList.Name
 		cniType = confList.Plugins[0].Network.Type
@@ -304,7 +304,7 @@ func parseCNIFromConfig(cniConfigPath string) (string, string, error) {
 	} else {
 		conf, err := libcni.ConfFromFile(cniConfigPath)
 		if err != nil {
-			return "", "", fmt.Errorf("error loading CNI config file %s: %v", cniConfigPath, err)
+			return "", "", fmt.Errorf("error loading CNI config file %s: %w", cniConfigPath, err)
 		}
 		cniName = conf.Network.Name
 		cniType = conf.Network.Type

--- a/cmd/spiderpool-init/cmd/multus.go
+++ b/cmd/spiderpool-init/cmd/multus.go
@@ -30,8 +30,8 @@ func fetchDefaultCNIName(defaultCNIName, cniDir string) (cniName, cniType string
 
 	defaultCNIConfPath, err := utils.GetDefaultCNIConfPath(cniDir)
 	if err != nil {
-		logger.Sugar().Errorf("failed to findDefaultCNIConf: %v", err)
-		return "", "", fmt.Errorf("failed to findDefaultCNIConf: %v", err)
+		logger.Sugar().Errorf("failed to findDefaultCNIConf: %w", err)
+		return "", "", fmt.Errorf("failed to findDefaultCNIConf: %w", err)
 	}
 	return parseCNIFromConfig(defaultCNIConfPath)
 }

--- a/cmd/spiderpool/cmd/cni_types.go
+++ b/cmd/spiderpool/cmd/cni_types.go
@@ -77,7 +77,7 @@ func LoadNetConf(argsStdin []byte) (*NetConf, error) {
 
 	err := json.Unmarshal(argsStdin, netConf)
 	if nil != err {
-		return nil, fmt.Errorf("failed to parse CNI network configuration: %v", err)
+		return nil, fmt.Errorf("failed to parse CNI network configuration: %w", err)
 	}
 
 	if netConf.IPAM.LogLevel == "" {

--- a/cmd/spiderpool/cmd/command_delete.go
+++ b/cmd/spiderpool/cmd/command_delete.go
@@ -43,12 +43,12 @@ func CmdDel(args *skel.CmdArgs) (err error) {
 
 	conf, err := LoadNetConf(args.StdinData)
 	if nil != err {
-		return fmt.Errorf("failed to load CNI network configuration: %v", err)
+		return fmt.Errorf("failed to load CNI network configuration: %w", err)
 	}
 
 	logger, err = SetupFileLogging(conf)
 	if nil != err {
-		return fmt.Errorf("failed to setup file logging: %v", err)
+		return fmt.Errorf("failed to setup file logging: %w", err)
 	}
 
 	logger = logger.Named(BinNamePlugin).With(
@@ -84,7 +84,7 @@ func CmdDel(args *skel.CmdArgs) (err error) {
 	logger.Debug("Send health check request to spiderpool-agent backend")
 	_, err = spiderpoolAgentAPI.Connectivity.GetIpamHealthy(connectivity.NewGetIpamHealthyParams())
 	if nil != err {
-		err := fmt.Errorf("%w, failed to check: %v", ErrAgentHealthCheck, err)
+		err := fmt.Errorf("%w, failed to check: %w", ErrAgentHealthCheck, err)
 		logger.Error(err.Error())
 		return err
 	}
@@ -106,7 +106,7 @@ func CmdDel(args *skel.CmdArgs) (err error) {
 	logger.Debug("Send IPAM request")
 	_, err = spiderpoolAgentAPI.Daemonset.DeleteIpamIP(params)
 	if nil != err {
-		logger.Sugar().Errorf("%v: %v", ErrDeleteIPAM, err)
+		logger.Sugar().Errorf("%v: %w", ErrDeleteIPAM, err)
 		return nil
 	}
 

--- a/cmd/spiderpool/cmd/command_test.go
+++ b/cmd/spiderpool/cmd/command_test.go
@@ -33,24 +33,30 @@ import (
 	"github.com/spidernet-io/spiderpool/pkg/openapi"
 )
 
-const ifName string = "eth0"
-const containerID string = "dummy"
-const CNITimeoutSec = 120
-const CNILogFilePath = "/tmp/spiderpool.log"
+const (
+	ifName         string = "eth0"
+	containerID    string = "dummy"
+	CNITimeoutSec         = 120
+	CNILogFilePath        = "/tmp/spiderpool.log"
+)
 
 const (
 	healthCheckRoute = "/v1/ipam/healthy"
 	ipamReqRoute     = "/v1/ipam/ip"
 )
 
-const CNIVersion010 = "0.1.0"
-const CNIVersion020 = "0.2.0"
+const (
+	CNIVersion010 = "0.1.0"
+	CNIVersion020 = "0.2.0"
+)
 
-var cniVersion string
-var args *skel.CmdArgs
-var netConf cmd.NetConf
-var sockPath string
-var nsPath string
+var (
+	cniVersion string
+	args       *skel.CmdArgs
+	netConf    cmd.NetConf
+	sockPath   string
+	nsPath     string
+)
 
 var addChan, delChan chan struct{}
 
@@ -81,7 +87,8 @@ var _ = Describe("spiderpool plugin", Label("unittest", "ipam_plugin_test"), fun
 			return netlink.LinkAdd(&netlink.Dummy{
 				LinkAttrs: netlink.LinkAttrs{
 					Name: ifName,
-				}})
+				},
+			})
 		})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -91,7 +98,7 @@ var _ = Describe("spiderpool plugin", Label("unittest", "ipam_plugin_test"), fun
 			Expect(err).NotTo(HaveOccurred())
 			err = os.RemoveAll(CNILogFilePath)
 			Expect(err).NotTo(HaveOccurred())
-			defer fakeNs.Close()
+			defer func() { _ = fakeNs.Close() }()
 		})
 
 		args = &skel.CmdArgs{
@@ -261,7 +268,7 @@ var _ = Describe("spiderpool plugin", Label("unittest", "ipam_plugin_test"), fun
 				// Routes
 				_, ipNet, _ := net.ParseCIDR("15.5.6.0/24")
 				expectResult.Routes = []*types.Route{{Dst: *ipNet, GW: net.ParseIP("1.2.3.2")}}
-				//Interfaces
+				// Interfaces
 				expectResult.Interfaces = []*current.Interface{{Name: ifName}}
 				return expectResult
 			}),
@@ -306,7 +313,7 @@ var _ = Describe("spiderpool plugin", Label("unittest", "ipam_plugin_test"), fun
 				expectResult.IPs = []*current.IPConfig{
 					{Gateway: net.ParseIP("10.1.0.2"), Address: net.IPNet{IP: net.ParseIP("10.1.0.6"), Mask: net.CIDRMask(24, 32)}},
 				}
-				//Interfaces
+				// Interfaces
 				expectResult.Interfaces = []*current.Interface{{Name: ifName}}
 				return expectResult
 			}),
@@ -339,7 +346,7 @@ var _ = Describe("spiderpool plugin", Label("unittest", "ipam_plugin_test"), fun
 				expectResult.IPs = []*current.IPConfig{
 					{Address: net.IPNet{IP: net.ParseIP("10.1.0.7"), Mask: net.CIDRMask(24, 32)}},
 				}
-				//Interfaces
+				// Interfaces
 				expectResult.Interfaces = []*current.Interface{{Name: ifName}}
 				return expectResult
 			}),

--- a/contrib/licensegen/licensegen.go
+++ b/contrib/licensegen/licensegen.go
@@ -18,12 +18,12 @@ func main() {
 		if stem := strings.TrimSuffix(base, ext); stem == "LICENSE" || stem == "COPYING" {
 			switch strings.TrimPrefix(strings.ToLower(ext), ".") {
 			case "", "code", "docs", "libyaml", "md", "txt":
-				fmt.Println("Name:", path)
+				_, _ = fmt.Println("Name:", path)
 				lb, err := os.ReadFile(path)
 				if err != nil {
 					log.Fatal(err)
 				}
-				fmt.Println("License:", string(lb))
+				_, _ = fmt.Println("License:", string(lb))
 			}
 		}
 		return nil

--- a/pkg/applicationcontroller/app_controller.go
+++ b/pkg/applicationcontroller/app_controller.go
@@ -146,7 +146,7 @@ func (sac *SubnetAppController) SetupInformer(ctx context.Context, client kubern
 			factory.Start(innerCtx.Done())
 			err = sac.Run(innerCtx.Done())
 			if nil != err {
-				logger.Sugar().Errorf("failed to run SpiderSubnet App controller, error: %v", err)
+				logger.Sugar().Errorf("failed to run SpiderSubnet App controller, error: %w", err)
 			}
 			logger.Error("SpiderSubnet App informer broken")
 		}
@@ -231,7 +231,7 @@ func (sac *SubnetAppController) controllerAddOrUpdateHandler() applicationinform
 			newAppReplicas = applicationinformers.GetAppReplicas(newObject.Spec.Replicas)
 			newSubnetConfig, err = applicationinformers.GetSubnetAnnoConfig(newObject.Spec.Template.Annotations, log)
 			if nil != err {
-				return fmt.Errorf("failed to get app subnet configuration, error: %v", err)
+				return fmt.Errorf("failed to get app subnet configuration, error: %w", err)
 			}
 
 			// default IPAM mode
@@ -247,7 +247,7 @@ func (sac *SubnetAppController) controllerAddOrUpdateHandler() applicationinform
 				oldAppReplicas = applicationinformers.GetAppReplicas(oldDeployment.Spec.Replicas)
 				oldSubnetConfig, err = applicationinformers.GetSubnetAnnoConfig(oldDeployment.Spec.Template.Annotations, log)
 				if nil != err {
-					return fmt.Errorf("failed to get old app subnet configuration, error: %v", err)
+					return fmt.Errorf("failed to get old app subnet configuration, error: %w", err)
 				}
 			}
 
@@ -271,7 +271,7 @@ func (sac *SubnetAppController) controllerAddOrUpdateHandler() applicationinform
 			newAppReplicas = applicationinformers.GetAppReplicas(newObject.Spec.Replicas)
 			newSubnetConfig, err = applicationinformers.GetSubnetAnnoConfig(newObject.Spec.Template.Annotations, log)
 			if nil != err {
-				return fmt.Errorf("failed to get app subnet configuration, error: %v", err)
+				return fmt.Errorf("failed to get app subnet configuration, error: %w", err)
 			}
 
 			// default IPAM mode
@@ -287,7 +287,7 @@ func (sac *SubnetAppController) controllerAddOrUpdateHandler() applicationinform
 				oldAppReplicas = applicationinformers.GetAppReplicas(oldReplicaSet.Spec.Replicas)
 				oldSubnetConfig, err = applicationinformers.GetSubnetAnnoConfig(oldReplicaSet.Spec.Template.Annotations, log)
 				if nil != err {
-					return fmt.Errorf("failed to get old app subnet configuration, error: %v", err)
+					return fmt.Errorf("failed to get old app subnet configuration, error: %w", err)
 				}
 			}
 
@@ -304,7 +304,7 @@ func (sac *SubnetAppController) controllerAddOrUpdateHandler() applicationinform
 			newAppReplicas = applicationinformers.GetAppReplicas(newObject.Spec.Replicas)
 			newSubnetConfig, err = applicationinformers.GetSubnetAnnoConfig(newObject.Spec.Template.Annotations, log)
 			if nil != err {
-				return fmt.Errorf("failed to get app subnet configuration, error: %v", err)
+				return fmt.Errorf("failed to get app subnet configuration, error: %w", err)
 			}
 
 			// default IPAM mode
@@ -320,7 +320,7 @@ func (sac *SubnetAppController) controllerAddOrUpdateHandler() applicationinform
 				oldAppReplicas = applicationinformers.GetAppReplicas(oldStatefulSet.Spec.Replicas)
 				oldSubnetConfig, err = applicationinformers.GetSubnetAnnoConfig(oldStatefulSet.Spec.Template.Annotations, log)
 				if nil != err {
-					return fmt.Errorf("failed to get old app subnet configuration, error: %v", err)
+					return fmt.Errorf("failed to get old app subnet configuration, error: %w", err)
 				}
 			}
 
@@ -344,7 +344,7 @@ func (sac *SubnetAppController) controllerAddOrUpdateHandler() applicationinform
 			newAppReplicas = applicationinformers.CalculateJobPodNum(newObject.Spec.Parallelism, newObject.Spec.Completions)
 			newSubnetConfig, err = applicationinformers.GetSubnetAnnoConfig(newObject.Spec.Template.Annotations, log)
 			if nil != err {
-				return fmt.Errorf("failed to get app subnet configuration, error: %v", err)
+				return fmt.Errorf("failed to get app subnet configuration, error: %w", err)
 			}
 
 			// default IPAM mode
@@ -360,7 +360,7 @@ func (sac *SubnetAppController) controllerAddOrUpdateHandler() applicationinform
 				oldAppReplicas = applicationinformers.CalculateJobPodNum(oldJob.Spec.Parallelism, oldJob.Spec.Completions)
 				oldSubnetConfig, err = applicationinformers.GetSubnetAnnoConfig(oldJob.Spec.Template.Annotations, log)
 				if nil != err {
-					return fmt.Errorf("failed to get old app subnet configuration, error: %v", err)
+					return fmt.Errorf("failed to get old app subnet configuration, error: %w", err)
 				}
 			}
 
@@ -377,7 +377,7 @@ func (sac *SubnetAppController) controllerAddOrUpdateHandler() applicationinform
 			newAppReplicas = applicationinformers.CalculateJobPodNum(newObject.Spec.JobTemplate.Spec.Parallelism, newObject.Spec.JobTemplate.Spec.Completions)
 			newSubnetConfig, err = applicationinformers.GetSubnetAnnoConfig(newObject.Spec.JobTemplate.Spec.Template.Annotations, log)
 			if nil != err {
-				return fmt.Errorf("failed to get app subnet configuration, error: %v", err)
+				return fmt.Errorf("failed to get app subnet configuration, error: %w", err)
 			}
 
 			// default IPAM mode
@@ -393,7 +393,7 @@ func (sac *SubnetAppController) controllerAddOrUpdateHandler() applicationinform
 				oldAppReplicas = applicationinformers.CalculateJobPodNum(oldCronJob.Spec.JobTemplate.Spec.Parallelism, oldCronJob.Spec.JobTemplate.Spec.Completions)
 				oldSubnetConfig, err = applicationinformers.GetSubnetAnnoConfig(oldCronJob.Spec.JobTemplate.Spec.Template.Annotations, log)
 				if nil != err {
-					return fmt.Errorf("failed to get old app subnet configuration, error: %v", err)
+					return fmt.Errorf("failed to get old app subnet configuration, error: %w", err)
 				}
 			}
 
@@ -410,7 +410,7 @@ func (sac *SubnetAppController) controllerAddOrUpdateHandler() applicationinform
 			newAppReplicas = int(newObject.Status.DesiredNumberScheduled)
 			newSubnetConfig, err = applicationinformers.GetSubnetAnnoConfig(newObject.Spec.Template.Annotations, log)
 			if nil != err {
-				return fmt.Errorf("failed to get app subnet configuration, error: %v", err)
+				return fmt.Errorf("failed to get app subnet configuration, error: %w", err)
 			}
 
 			// default IPAM mode
@@ -426,7 +426,7 @@ func (sac *SubnetAppController) controllerAddOrUpdateHandler() applicationinform
 				oldAppReplicas = int(oldDaemonSet.Status.DesiredNumberScheduled)
 				oldSubnetConfig, err = applicationinformers.GetSubnetAnnoConfig(oldDaemonSet.Spec.Template.Annotations, log)
 				if nil != err {
-					return fmt.Errorf("failed to get old app subnet configuration, error: %v", err)
+					return fmt.Errorf("failed to get old app subnet configuration, error: %w", err)
 				}
 			}
 
@@ -576,7 +576,7 @@ func (sac *SubnetAppController) processNextWorkItem() bool {
 func (sac *SubnetAppController) syncHandler(appKey appWorkQueueKey, log *zap.Logger) (err error) {
 	namespace, name, err := cache.SplitMetaNamespaceKey(appKey.MetaNamespaceKey)
 	if nil != err {
-		return fmt.Errorf("%w: failed to split meta namespace key '%+v', error: %v", constant.ErrWrongInput, appKey.MetaNamespaceKey, err)
+		return fmt.Errorf("%w: failed to split meta namespace key '%+v', error: %w", constant.ErrWrongInput, appKey.MetaNamespaceKey, err)
 	}
 
 	var app metav1.Object
@@ -688,7 +688,7 @@ func (sac *SubnetAppController) syncHandler(appKey appWorkQueueKey, log *zap.Log
 
 	subnetConfig, err = applicationinformers.GetSubnetAnnoConfig(podAnno, log)
 	if nil != err {
-		return fmt.Errorf("%w: failed to get pod annotation subnet config, error: %v", constant.ErrWrongInput, err)
+		return fmt.Errorf("%w: failed to get pod annotation subnet config, error: %w", constant.ErrWrongInput, err)
 	}
 
 	log.Debug("try to apply auto-created IPPool")
@@ -714,7 +714,8 @@ func (sac *SubnetAppController) syncHandler(appKey appWorkQueueKey, log *zap.Log
 
 // applyAutoIPPool try to create an IPPool or mark IPPool desired IP number with the give SpiderSubnet configuration
 func (sac *SubnetAppController) applyAutoIPPool(ctx context.Context, podSubnetConfig types.PodSubnetAnnoConfig,
-	podController types.PodTopController, appReplicas int) error {
+	podController types.PodTopController, appReplicas int,
+) error {
 	log := logutils.FromContext(ctx)
 
 	// retrieve application pools
@@ -833,7 +834,8 @@ func (sac *SubnetAppController) applyAutoIPPool(ctx context.Context, podSubnetCo
 // hasSubnetConfigChanged checks whether application subnet configuration changed and the application replicas changed or not.
 // The second parameter newSubnetConfig must not be nil.
 func hasSubnetConfigChanged(ctx context.Context, oldSubnetConfig, newSubnetConfig *types.PodSubnetAnnoConfig,
-	oldAppReplicas, newAppReplicas int) bool {
+	oldAppReplicas, newAppReplicas int,
+) bool {
 	// go to reconcile directly with new application
 	if oldSubnetConfig == nil {
 		return true
@@ -930,7 +932,7 @@ func (sac *SubnetAppController) controllerDeleteHandler() applicationinformers.A
 
 		err := sac.deleteAutoPools(logutils.IntoContext(ctx, log), app.GetUID())
 		if nil != err {
-			log.Sugar().Errorf("failed to clean up legacy IPPool, error: %v", err)
+			log.Sugar().Errorf("failed to clean up legacy IPPool, error: %w", err)
 			sac.enqueueApp(ctx, obj, appKind, app.GetUID())
 			return nil
 		}

--- a/pkg/applicationcontroller/app_controller_test.go
+++ b/pkg/applicationcontroller/app_controller_test.go
@@ -171,7 +171,6 @@ var _ = Describe("AppController", Label("app_controller_test"), func() {
 				},
 			},
 		}
-
 	})
 
 	Describe("run subnet app controller", func() {
@@ -893,5 +892,4 @@ var _ = Describe("AppController", Label("app_controller_test"), func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
-
 })

--- a/pkg/applicationcontroller/applicationcontroller_suite_test.go
+++ b/pkg/applicationcontroller/applicationcontroller_suite_test.go
@@ -26,8 +26,10 @@ func TestApplicationcontroller(t *testing.T) {
 	RunSpecs(t, "Applicationcontroller Suite", Label("ApplicationController", "unittest"))
 }
 
-var scheme *runtime.Scheme
-var subnetAppControllerConfig SubnetAppControllerConfig
+var (
+	scheme                    *runtime.Scheme
+	subnetAppControllerConfig SubnetAppControllerConfig
+)
 
 type subnetApplicationController struct {
 	*SubnetAppController

--- a/pkg/applicationcontroller/applicationinformers/applicationinformers_suite_test.go
+++ b/pkg/applicationcontroller/applicationinformers/applicationinformers_suite_test.go
@@ -23,6 +23,7 @@ func TestApplicationinformers(t *testing.T) {
 var fakeReconcileFunc AppInformersAddOrUpdateFunc = func(ctx context.Context, oldObj, newObj interface{}) error {
 	return constant.ErrUnknown
 }
+
 var fakeCleanupFunc APPInformersDelFunc = func(ctx context.Context, obj interface{}) error {
 	return constant.ErrUnknown
 }

--- a/pkg/applicationcontroller/applicationinformers/controller.go
+++ b/pkg/applicationcontroller/applicationinformers/controller.go
@@ -12,8 +12,10 @@ import (
 
 var controllersLogger *zap.Logger
 
-type AppInformersAddOrUpdateFunc func(ctx context.Context, oldObj, newObj interface{}) error
-type APPInformersDelFunc func(ctx context.Context, obj interface{}) error
+type (
+	AppInformersAddOrUpdateFunc func(ctx context.Context, oldObj, newObj interface{}) error
+	APPInformersDelFunc         func(ctx context.Context, obj interface{}) error
+)
 
 type Controller struct {
 	reconcileFunc AppInformersAddOrUpdateFunc

--- a/pkg/applicationcontroller/applicationinformers/cronjob_informer.go
+++ b/pkg/applicationcontroller/applicationinformers/cronjob_informer.go
@@ -29,20 +29,20 @@ func (c *Controller) AddCronJobHandler(informer cache.SharedIndexInformer) error
 func (c *Controller) onCronJobAdd(obj interface{}) {
 	err := c.reconcileFunc(logutils.IntoContext(context.TODO(), controllersLogger), nil, obj)
 	if nil != err {
-		controllersLogger.Sugar().Errorf("onCronJobAdd: %v", err)
+		controllersLogger.Sugar().Errorf("onCronJobAdd: %w", err)
 	}
 }
 
 func (c *Controller) onCronJobUpdate(oldObj interface{}, newObj interface{}) {
 	err := c.reconcileFunc(logutils.IntoContext(context.TODO(), controllersLogger), oldObj, newObj)
 	if nil != err {
-		controllersLogger.Sugar().Errorf("onCronJobUpdate: %v", err)
+		controllersLogger.Sugar().Errorf("onCronJobUpdate: %w", err)
 	}
 }
 
 func (c *Controller) onCronJobDelete(obj interface{}) {
 	err := c.cleanupFunc(logutils.IntoContext(context.TODO(), controllersLogger), obj)
 	if nil != err {
-		controllersLogger.Sugar().Errorf("onCronJobDelete: %v", err)
+		controllersLogger.Sugar().Errorf("onCronJobDelete: %w", err)
 	}
 }

--- a/pkg/applicationcontroller/applicationinformers/daemonset_informer.go
+++ b/pkg/applicationcontroller/applicationinformers/daemonset_informer.go
@@ -29,20 +29,20 @@ func (c *Controller) AddDaemonSetHandler(informer cache.SharedIndexInformer) err
 func (c *Controller) onDaemonSetAdd(obj interface{}) {
 	err := c.reconcileFunc(logutils.IntoContext(context.TODO(), controllersLogger), nil, obj)
 	if nil != err {
-		controllersLogger.Sugar().Errorf("onDaemonSetAdd: %v", err)
+		controllersLogger.Sugar().Errorf("onDaemonSetAdd: %w", err)
 	}
 }
 
 func (c *Controller) onDaemonSetUpdate(oldObj interface{}, newObj interface{}) {
 	err := c.reconcileFunc(logutils.IntoContext(context.TODO(), controllersLogger), oldObj, newObj)
 	if nil != err {
-		controllersLogger.Sugar().Errorf("onDaemonSetUpdate: %v", err)
+		controllersLogger.Sugar().Errorf("onDaemonSetUpdate: %w", err)
 	}
 }
 
 func (c *Controller) onDaemonSetDelete(obj interface{}) {
 	err := c.cleanupFunc(logutils.IntoContext(context.TODO(), controllersLogger), obj)
 	if nil != err {
-		controllersLogger.Sugar().Errorf("onDaemonSetDelete: %v", err)
+		controllersLogger.Sugar().Errorf("onDaemonSetDelete: %w", err)
 	}
 }

--- a/pkg/applicationcontroller/applicationinformers/deployment_informer.go
+++ b/pkg/applicationcontroller/applicationinformers/deployment_informer.go
@@ -29,20 +29,20 @@ func (c *Controller) AddDeploymentHandler(informer cache.SharedIndexInformer) er
 func (c *Controller) onDeploymentAdd(obj interface{}) {
 	err := c.reconcileFunc(logutils.IntoContext(context.TODO(), controllersLogger), nil, obj)
 	if nil != err {
-		controllersLogger.Sugar().Errorf("onDeploymentAdd: %v", err)
+		controllersLogger.Sugar().Errorf("onDeploymentAdd: %w", err)
 	}
 }
 
 func (c *Controller) onDeploymentUpdate(oldObj interface{}, newObj interface{}) {
 	err := c.reconcileFunc(logutils.IntoContext(context.TODO(), controllersLogger), oldObj, newObj)
 	if nil != err {
-		controllersLogger.Sugar().Errorf("onDeploymentUpdate: %v", err)
+		controllersLogger.Sugar().Errorf("onDeploymentUpdate: %w", err)
 	}
 }
 
 func (c *Controller) onDeploymentDelete(obj interface{}) {
 	err := c.cleanupFunc(logutils.IntoContext(context.TODO(), controllersLogger), obj)
 	if nil != err {
-		controllersLogger.Sugar().Errorf("onDeploymentDelete: %v", err)
+		controllersLogger.Sugar().Errorf("onDeploymentDelete: %w", err)
 	}
 }

--- a/pkg/applicationcontroller/applicationinformers/job_informer.go
+++ b/pkg/applicationcontroller/applicationinformers/job_informer.go
@@ -29,20 +29,20 @@ func (c *Controller) AddJobController(informer cache.SharedIndexInformer) error 
 func (c *Controller) onJobAdd(obj interface{}) {
 	err := c.reconcileFunc(logutils.IntoContext(context.TODO(), controllersLogger), nil, obj)
 	if nil != err {
-		controllersLogger.Sugar().Errorf("onJobAdd: %v", err)
+		controllersLogger.Sugar().Errorf("onJobAdd: %w", err)
 	}
 }
 
 func (c *Controller) onJobUpdate(oldObj interface{}, newObj interface{}) {
 	err := c.reconcileFunc(logutils.IntoContext(context.TODO(), controllersLogger), oldObj, newObj)
 	if nil != err {
-		controllersLogger.Sugar().Errorf("onJobUpdate: %v", err)
+		controllersLogger.Sugar().Errorf("onJobUpdate: %w", err)
 	}
 }
 
 func (c *Controller) onJobDelete(obj interface{}) {
 	err := c.cleanupFunc(logutils.IntoContext(context.TODO(), controllersLogger), obj)
 	if nil != err {
-		controllersLogger.Sugar().Errorf("onJobDelete: %v", err)
+		controllersLogger.Sugar().Errorf("onJobDelete: %w", err)
 	}
 }

--- a/pkg/applicationcontroller/applicationinformers/replicaset_informer.go
+++ b/pkg/applicationcontroller/applicationinformers/replicaset_informer.go
@@ -29,20 +29,20 @@ func (c *Controller) AddReplicaSetHandler(informer cache.SharedIndexInformer) er
 func (c *Controller) onReplicaSetAdd(obj interface{}) {
 	err := c.reconcileFunc(logutils.IntoContext(context.TODO(), controllersLogger), nil, obj)
 	if nil != err {
-		controllersLogger.Sugar().Errorf("onReplicaSetAdd: %v", err)
+		controllersLogger.Sugar().Errorf("onReplicaSetAdd: %w", err)
 	}
 }
 
 func (c *Controller) onReplicaSetUpdate(oldObj interface{}, newObj interface{}) {
 	err := c.reconcileFunc(logutils.IntoContext(context.TODO(), controllersLogger), oldObj, newObj)
 	if nil != err {
-		controllersLogger.Sugar().Errorf("onReplicaSetUpdate: %v", err)
+		controllersLogger.Sugar().Errorf("onReplicaSetUpdate: %w", err)
 	}
 }
 
 func (c *Controller) onReplicaSetDelete(obj interface{}) {
 	err := c.cleanupFunc(logutils.IntoContext(context.TODO(), controllersLogger), obj)
 	if nil != err {
-		controllersLogger.Sugar().Errorf("onReplicaSetDelete: %v", err)
+		controllersLogger.Sugar().Errorf("onReplicaSetDelete: %w", err)
 	}
 }

--- a/pkg/applicationcontroller/applicationinformers/statefulset_informer.go
+++ b/pkg/applicationcontroller/applicationinformers/statefulset_informer.go
@@ -29,20 +29,20 @@ func (c *Controller) AddStatefulSetHandler(informer cache.SharedIndexInformer) e
 func (c *Controller) onStatefulSetAdd(obj interface{}) {
 	err := c.reconcileFunc(logutils.IntoContext(context.TODO(), controllersLogger), nil, obj)
 	if nil != err {
-		controllersLogger.Sugar().Errorf("onStatefulSetAdd: %v", err)
+		controllersLogger.Sugar().Errorf("onStatefulSetAdd: %w", err)
 	}
 }
 
 func (c *Controller) onStatefulSetUpdate(oldObj interface{}, newObj interface{}) {
 	err := c.reconcileFunc(logutils.IntoContext(context.TODO(), controllersLogger), oldObj, newObj)
 	if nil != err {
-		controllersLogger.Sugar().Errorf("onStatefulSetUpdate: %v", err)
+		controllersLogger.Sugar().Errorf("onStatefulSetUpdate: %w", err)
 	}
 }
 
 func (c *Controller) onStatefulSetDelete(obj interface{}) {
 	err := c.cleanupFunc(logutils.IntoContext(context.TODO(), controllersLogger), obj)
 	if nil != err {
-		controllersLogger.Sugar().Errorf("onStatefulSetDelete: %v", err)
+		controllersLogger.Sugar().Errorf("onStatefulSetDelete: %w", err)
 	}
 }

--- a/pkg/applicationcontroller/applicationinformers/utils.go
+++ b/pkg/applicationcontroller/applicationinformers/utils.go
@@ -187,7 +187,7 @@ func GetSubnetAnnoConfig(podAnnotations map[string]string, log *zap.Logger) (*ty
 		log.Sugar().Debugf("found SpiderSubnet feature annotation '%s' value '%s'", constant.AnnoSpiderSubnets, subnets)
 		err := json.Unmarshal([]byte(subnets), &subnetAnnoConfig.MultipleSubnets)
 		if nil != err {
-			return nil, fmt.Errorf("failed to parse anntation '%s' value '%s', error: %v", constant.AnnoSpiderSubnets, subnets, err)
+			return nil, fmt.Errorf("failed to parse anntation '%s' value '%s', error: %w", constant.AnnoSpiderSubnets, subnets, err)
 		}
 	} else {
 		// annotation: ipam.spidernet.io/subnet
@@ -197,7 +197,7 @@ func GetSubnetAnnoConfig(podAnnotations map[string]string, log *zap.Logger) (*ty
 			subnetAnnoConfig.SingleSubnet = new(types.AnnoSubnetItem)
 			err := json.Unmarshal([]byte(subnet), &subnetAnnoConfig.SingleSubnet)
 			if nil != err {
-				return nil, fmt.Errorf("failed to parse anntation '%s' value '%s', error: %v", constant.AnnoSpiderSubnet, subnet, err)
+				return nil, fmt.Errorf("failed to parse anntation '%s' value '%s', error: %w", constant.AnnoSpiderSubnet, subnet, err)
 			}
 		} else {
 			log.Debug("no SpiderSubnet feature annotation found, use default IPAM mode")
@@ -332,7 +332,7 @@ func GetPoolIPNumber(str string) (isFlexible bool, ipNum int, err error) {
 
 		ipNum, err = strconv.Atoi(tmp)
 		if nil != err {
-			return false, -1, fmt.Errorf("%w: %v", errInvalidInput(str), err)
+			return false, -1, fmt.Errorf("%w: %w", errInvalidInput(str), err)
 		}
 
 		return found, ipNum, nil
@@ -413,7 +413,7 @@ func ShouldReclaimIPPool(anno map[string]string) (bool, error) {
 	if ok {
 		parseBool, err := strconv.ParseBool(reclaimPool)
 		if nil != err {
-			return false, fmt.Errorf("failed to parse spider subnet '%s', error: %v", constant.AnnoSpiderSubnetReclaimIPPool, err)
+			return false, fmt.Errorf("failed to parse spider subnet '%s', error: %w", constant.AnnoSpiderSubnetReclaimIPPool, err)
 		}
 		return parseBool, nil
 	}

--- a/pkg/applicationcontroller/applicationinformers/utils_test.go
+++ b/pkg/applicationcontroller/applicationinformers/utils_test.go
@@ -222,7 +222,7 @@ var _ = Describe("Utils", func() {
 	})
 
 	Context("GetSubnetAnnoConfig", Label("unittest", "GetSubnetAnnoConfig"), func() {
-		var log = logutils.Logger.Named("test")
+		log := logutils.Logger.Named("test")
 		defaultSubnetsAnno := `[{"interface":"eth0","ipv4":["default-v4-subnet"],"ipv6":["default-v6-subnet"]}]`
 
 		It("failed to Unmarshal subnets", func() {

--- a/pkg/constant/errors.go
+++ b/pkg/constant/errors.go
@@ -1,6 +1,5 @@
 // Copyright 2022 Authors of spidernet-io
 // SPDX-License-Identifier: Apache-2.0
-
 package constant
 
 import (

--- a/pkg/constant/k8s.go
+++ b/pkg/constant/k8s.go
@@ -36,8 +36,15 @@ const (
 	KindServiceCIDR = "ServiceCIDR"
 )
 
-var K8sKinds = []string{KindPod, KindDeployment, KindReplicaSet, KindDaemonSet, KindStatefulSet, KindJob, KindCronJob}
-var K8sAPIVersions = []string{corev1.SchemeGroupVersion.String(), appsv1.SchemeGroupVersion.String(), batchv1.SchemeGroupVersion.String()}
+var K8sKinds = []string{
+	KindPod, KindDeployment, KindReplicaSet, KindDaemonSet, KindStatefulSet, KindJob, KindCronJob,
+}
+
+var K8sAPIVersions = []string{
+	corev1.SchemeGroupVersion.String(),
+	appsv1.SchemeGroupVersion.String(),
+	batchv1.SchemeGroupVersion.String(),
+}
 var AutoPoolPodAffinities = []string{AutoPoolPodAffinityAppAPIGroup, AutoPoolPodAffinityAppAPIVersion, AutoPoolPodAffinityAppKind, AutoPoolPodAffinityAppNS, AutoPoolPodAffinityAppName}
 
 const (
@@ -100,7 +107,7 @@ const (
 	// Coordinator
 	AnnoDefaultRouteInterface = AnnotationPre + "/default-route-nic"
 
-	//dra
+	// dra
 	DraAnnotationPre  = "dra.spidernet.io"
 	AnnoDraCdiVersion = AnnotationPre + "/cdi-version"
 

--- a/pkg/coordinatormanager/coordinator_informer.go
+++ b/pkg/coordinatormanager/coordinator_informer.go
@@ -180,7 +180,7 @@ func (cc *CoordinatorController) SetupInformer(
 			k8sInformerFactory.Start(innerCtx.Done())
 			spiderInformerFactory.Start(innerCtx.Done())
 			if err := cc.run(logutils.IntoContext(innerCtx, InformerLogger), 1); err != nil {
-				InformerLogger.Sugar().Errorf("failed to run Coordinator informer: %v", err)
+				InformerLogger.Sugar().Errorf("failed to run Coordinator informer: %w", err)
 				innerCancel()
 			}
 			InformerLogger.Info("Coordinator informer down")
@@ -276,7 +276,6 @@ func (cc *CoordinatorController) addServiceCIDRHandler(serviceCIDRInformer cache
 			logger.Debug(messageEnqueueCoordiantor)
 		},
 	})
-
 	if err != nil {
 		return err
 	}
@@ -417,7 +416,7 @@ func (cc *CoordinatorController) processNextWorkItem(ctx context.Context) bool {
 	)
 
 	if err := cc.syncHandler(logutils.IntoContext(ctx, logger)); err != nil {
-		logger.Sugar().Warnf("Failed to handle, requeuing: %v", err)
+		logger.Sugar().Warnf("Failed to handle, requeuing: %w", err)
 		cc.Workqueue.AddRateLimited(obj)
 		return true
 	}
@@ -439,7 +438,7 @@ func (cc *CoordinatorController) syncHandler(ctx context.Context) (err error) {
 	if !reflect.DeepEqual(coordCopy.Status, coord.Status) {
 		logger.Sugar().Infof("Patching coordinator's status from %v to %v", coord.Status, coordCopy.Status)
 		if err = cc.Client.Status().Patch(ctx, coordCopy, client.MergeFrom(coord)); err != nil {
-			logger.Sugar().Errorf("failed to patch spidercoordinator phase: %v", err.Error())
+			logger.Sugar().Errorf("failed to patch spidercoordinator phase: %w", err.Error())
 			return err
 		}
 		logger.Sugar().Infof("Success to patch coordinator's status to %v", coordCopy.Status)
@@ -477,7 +476,7 @@ func (cc *CoordinatorController) updatePodAndServerCIDR(ctx context.Context, log
 			// Success to get ClusterCIDR from kubeadm-config
 			logger.Sugar().Infof("Success get CIDR from kubeadm-config: PodCIDR=%v, ServiceCIDR=%v", k8sPodCIDR, k8sServiceCIDR)
 		} else {
-			logger.Sugar().Warnf("Failed get CIDR from kubeadm-config: %v", err)
+			logger.Sugar().Warnf("Failed get CIDR from kubeadm-config: %w", err)
 		}
 	}
 
@@ -488,7 +487,7 @@ func (cc *CoordinatorController) updatePodAndServerCIDR(ctx context.Context, log
 		listOptions := client.MatchingLabels{"component": "kube-controller-manager"}
 
 		if err := cc.APIReader.List(ctx, &podList, listOptions); err != nil {
-			logger.Sugar().Errorf("failed to get kube-controller-manager Pod with label \"component: kube-controller-manager\": %v", err)
+			logger.Sugar().Errorf("failed to get kube-controller-manager Pod with label \"component: kube-controller-manager\": %w", err)
 			event.EventRecorder.Eventf(
 				coordCopy,
 				corev1.EventTypeWarning,
@@ -589,7 +588,7 @@ func (cc *CoordinatorController) WatchCalicoIPPools(ctx context.Context, logger 
 	go func() {
 		logger.Info("Starting Calico IPPool controller")
 		if err := calicoController.Start(ctx); err != nil {
-			logger.Sugar().Errorf("Failed to start Calico IPPool controller: %v", err)
+			logger.Sugar().Errorf("Failed to start Calico IPPool controller: %w", err)
 		}
 		logger.Info("Shutdown Calico IPPool controller")
 	}()
@@ -630,7 +629,6 @@ func (cc *CoordinatorController) WatchCiliumIPPools(ctx context.Context, logger 
 			logger.Debug(messageEnqueueCoordiantor)
 		},
 	})
-
 	if err != nil {
 		return err
 	}

--- a/pkg/coordinatormanager/coordinator_webhook.go
+++ b/pkg/coordinatormanager/coordinator_webhook.go
@@ -21,8 +21,7 @@ import (
 
 var WebhookLogger *zap.Logger
 
-type CoordinatorWebhook struct {
-}
+type CoordinatorWebhook struct{}
 
 func (cw *CoordinatorWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	if WebhookLogger == nil {
@@ -49,7 +48,7 @@ func (cw *CoordinatorWebhook) Default(ctx context.Context, obj runtime.Object) e
 	logger.Sugar().Debugf("Request Coordinator: %+v", *coord)
 
 	if err := mutateCoordinator(logutils.IntoContext(ctx, logger), coord); err != nil {
-		logger.Sugar().Errorf("Failed to mutate Coordinator: %v", err)
+		logger.Sugar().Errorf("Failed to mutate Coordinator: %w", err)
 	}
 
 	return nil
@@ -68,7 +67,7 @@ func (cw *CoordinatorWebhook) ValidateCreate(ctx context.Context, obj runtime.Ob
 	logger.Sugar().Debugf("Request Coordinator: %+v", *coord)
 
 	if errs := validateCreateCoordinator(coord); len(errs) != 0 {
-		logger.Sugar().Errorf("Failed to create Coordinator: %v", errs.ToAggregate().Error())
+		logger.Sugar().Errorf("Failed to create Coordinator: %w", errs.ToAggregate().Error())
 		return nil, apierrors.NewInvalid(
 			schema.GroupKind{Group: constant.SpiderpoolAPIGroup, Kind: constant.KindSpiderCoordinator},
 			coord.Name,
@@ -92,7 +91,7 @@ func (cw *CoordinatorWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj
 	logger.Sugar().Debugf("Request new Coordinator: %+v", *newCoord)
 
 	if errs := validateUpdateCoordinator(oldCoord, newCoord); len(errs) != 0 {
-		logger.Sugar().Errorf("Failed to update Coordinator: %v", errs.ToAggregate().Error())
+		logger.Sugar().Errorf("Failed to update Coordinator: %w", errs.ToAggregate().Error())
 		return nil, apierrors.NewInvalid(
 			schema.GroupKind{Group: constant.SpiderpoolAPIGroup, Kind: constant.KindSpiderCoordinator},
 			newCoord.Name,

--- a/pkg/election/lease_election.go
+++ b/pkg/election/lease_election.go
@@ -46,7 +46,8 @@ type SpiderLeader struct {
 
 // NewLeaseElector will return a SpiderLeaseElector object
 func NewLeaseElector(leaseLockNS, leaseLockName, leaseLockIdentity string,
-	leaseDuration, leaseRenewDeadline, leaseRetryPeriod, leaderRetryElectGap *time.Duration) (SpiderLeaseElector, error) {
+	leaseDuration, leaseRenewDeadline, leaseRetryPeriod, leaderRetryElectGap *time.Duration,
+) (SpiderLeaseElector, error) {
 	if len(leaseLockNS) == 0 {
 		return nil, fmt.Errorf("failed to new lease elector: Lease Lock Namespace must be specified")
 	}

--- a/pkg/election/lease_election_test.go
+++ b/pkg/election/lease_election_test.go
@@ -23,11 +23,13 @@ var _ = Describe("Leader Election", Label("unittest", "election_test"), func() {
 		leaderRetryElectGap *time.Duration
 	}
 
-	var globalParams *newLeaseElectorParams
-	var leaseDuration = 15 * time.Second
-	var renewDeadline = 2 * time.Second
-	var retryPeriod = 1 * time.Second
-	var retryElectGap = 5 * time.Second
+	var (
+		globalParams  *newLeaseElectorParams
+		leaseDuration = 15 * time.Second
+		renewDeadline = 2 * time.Second
+		retryPeriod   = 1 * time.Second
+		retryElectGap = 5 * time.Second
+	)
 
 	BeforeEach(func() {
 		globalParams = new(newLeaseElectorParams)

--- a/pkg/errgroup/errgroup.go
+++ b/pkg/errgroup/errgroup.go
@@ -92,7 +92,7 @@ func (g *Group) Go(srcNs, targetNs ns.NetNS, f func() error) {
 		// switch to pod's netns
 		if err := targetNs.Set(); err != nil {
 			g.errOnce.Do(func() {
-				g.err = fmt.Errorf("failed to switch to pod's netns: %v", err)
+				g.err = fmt.Errorf("failed to switch to pod's netns: %w", err)
 				if g.cancel != nil {
 					g.cancel(g.err)
 				}

--- a/pkg/gcmanager/gc_manager.go
+++ b/pkg/gcmanager/gc_manager.go
@@ -89,7 +89,8 @@ func NewGCManager(clientSet *kubernetes.Clientset, config *GarbageCollectionConf
 	stsManager statefulsetmanager.StatefulSetManager,
 	kubevirtMgr kubevirtmanager.KubevirtManager,
 	nodeMgr nodemanager.NodeManager,
-	spiderControllerLeader election.SpiderLeaseElector) (GCManager, error) {
+	spiderControllerLeader election.SpiderLeaseElector,
+) (GCManager, error) {
 	if clientSet == nil {
 		return nil, fmt.Errorf("k8s ClientSet must be specified")
 	}

--- a/pkg/gcmanager/tracePod_worker.go
+++ b/pkg/gcmanager/tracePod_worker.go
@@ -128,7 +128,7 @@ func (s *SpiderGC) releaseIPPoolIPExecutor(ctx context.Context, workerIndex int)
 				tickets := podUsedIPs.Pools()
 				err = s.gcLimiter.AcquireTicket(ctx, tickets...)
 				if nil != err {
-					log.Sugar().Errorf("failed to get IP GC limiter tickets, error: %v", err)
+					log.Sugar().Errorf("failed to get IP GC limiter tickets, error: %w", err)
 				}
 				defer s.gcLimiter.ReleaseTicket(ctx, tickets...)
 

--- a/pkg/ip/cidr.go
+++ b/pkg/ip/cidr.go
@@ -19,7 +19,7 @@ func ParseCIDR(version types.IPVersion, subnet string) (*net.IPNet, error) {
 	}
 	_, ipNet, err := net.ParseCIDR(subnet)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse CIDR '%s': %v", subnet, err)
+		return nil, fmt.Errorf("failed to parse CIDR '%s': %w", subnet, err)
 	}
 	return ipNet, nil
 }

--- a/pkg/ip/iprange.go
+++ b/pkg/ip/iprange.go
@@ -104,11 +104,7 @@ func ConvertIPsToIPRanges(version types.IPVersion, ips []net.IP) ([]string, erro
 
 	var ipRanges []string
 	var start, end int
-	for {
-		if start == len(ips) {
-			break
-		}
-
+	for start < len(ips) {
 		if end+1 < len(ips) && ips[end+1].Equal(NextIP(ips[end])) {
 			end++
 			continue

--- a/pkg/ipam/pool_selections.go
+++ b/pkg/ipam/pool_selections.go
@@ -33,7 +33,7 @@ func (i *ipam) getPoolCandidates(ctx context.Context, addArgs *models.IpamAddArg
 		if i.config.EnableAutoPoolForApplication {
 			fromSubnet, err := i.getPoolFromSubnetAnno(ctx, pod, *addArgs.IfName, addArgs.CleanGateway, podController)
 			if nil != err {
-				return nil, fmt.Errorf("failed to get IPPool candidates from Subnet: %v", err)
+				return nil, fmt.Errorf("failed to get IPPool candidates from Subnet: %w", err)
 			}
 			if fromSubnet != nil {
 				return ToBeAllocateds{fromSubnet}, nil
@@ -319,7 +319,7 @@ func (i *ipam) getPoolFromPodAnnoPools(ctx context.Context, anno, currentNIC str
 	errPrefix := fmt.Errorf("%w, invalid format of Pod annotation '%s'", constant.ErrWrongInput, constant.AnnoPodIPPools)
 	err := json.Unmarshal([]byte(anno), &annoPodIPPools)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", errPrefix, err)
+		return nil, fmt.Errorf("%w: %w", errPrefix, err)
 	}
 
 	for index := range annoPodIPPools {
@@ -346,7 +346,7 @@ func (i *ipam) getPoolFromPodAnnoPools(ctx context.Context, anno, currentNIC str
 	// validate and mutate the IPPools annotation value
 	err = validateAndMutateMultipleNICAnnotations(annoPodIPPools, currentNIC)
 	if nil != err {
-		return nil, fmt.Errorf("%w: %v", errPrefix, err)
+		return nil, fmt.Errorf("%w: %w", errPrefix, err)
 	}
 
 	var tt ToBeAllocateds
@@ -380,7 +380,7 @@ func (i *ipam) getPoolFromPodAnnoPool(ctx context.Context, anno, nic string, cle
 	var annoPodIPPool types.AnnoPodIPPoolValue
 	errPrefix := fmt.Errorf("%w, invalid format of Pod annotation '%s'", constant.ErrWrongInput, constant.AnnoPodIPPool)
 	if err := json.Unmarshal([]byte(anno), &annoPodIPPool); err != nil {
-		return nil, fmt.Errorf("%w: %v", errPrefix, err)
+		return nil, fmt.Errorf("%w: %w", errPrefix, err)
 	}
 
 	// check IPv4 PoolName wildcard

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -61,9 +61,9 @@ func (c *PoolCandidate) String() string {
 
 type PoolNameToIPPool map[string]*spiderpoolv2beta1.SpiderIPPool
 
-func (ptp *PoolNameToIPPool) IPPools() []*spiderpoolv2beta1.SpiderIPPool {
+func (pp *PoolNameToIPPool) IPPools() []*spiderpoolv2beta1.SpiderIPPool {
 	var ipPools []*spiderpoolv2beta1.SpiderIPPool
-	for _, p := range *ptp {
+	for _, p := range *pp {
 		ipPools = append(ipPools, p)
 	}
 

--- a/pkg/ipam/utils.go
+++ b/pkg/ipam/utils.go
@@ -35,12 +35,12 @@ func getCustomRoutes(pod *corev1.Pod) ([]*models.Route, error) {
 	errPrefix := fmt.Errorf("%w, invalid format of Pod annotation '%s'", constant.ErrWrongInput, constant.AnnoPodRoutes)
 	err := json.Unmarshal([]byte(anno), &annoPodRoutes)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", errPrefix, err)
+		return nil, fmt.Errorf("%w: %w", errPrefix, err)
 	}
 
 	for _, route := range annoPodRoutes {
 		if err := spiderpoolip.IsRouteWithoutIPVersion(route.Dst, route.Gw); err != nil {
-			return nil, fmt.Errorf("%w: %v", errPrefix, err)
+			return nil, fmt.Errorf("%w: %w", errPrefix, err)
 		}
 	}
 

--- a/pkg/ippoolmanager/ippool_informer.go
+++ b/pkg/ippoolmanager/ippool_informer.go
@@ -117,7 +117,7 @@ func (ic *IPPoolController) SetupInformer(ctx context.Context, client crdclients
 			factory.Start(innerCtx.Done())
 
 			if err := ic.Run(innerCtx.Done()); nil != err {
-				informerLogger.Sugar().Errorf("failed to run ippool controller, error: %v", err)
+				informerLogger.Sugar().Errorf("failed to run ippool controller, error: %w", err)
 			}
 			informerLogger.Error("SpiderIPPool informer broken")
 		}
@@ -139,7 +139,6 @@ func (ic *IPPoolController) addEventHandlers(poolInformer informers.SpiderIPPool
 			ic.enqueueIPPool(newObj)
 		},
 		DeleteFunc: func(obj interface{}) {
-
 		},
 	})
 	if nil != err {
@@ -230,7 +229,7 @@ func (ic *IPPoolController) processNextWorkItem() bool {
 			// discard some wrong input items
 			if errors.Is(err, constant.ErrWrongInput) {
 				ic.poolWorkqueue.Forget(obj)
-				return fmt.Errorf("failed to process IPPool '%s', error: %v, discarding it", pool.Name, err)
+				return fmt.Errorf("failed to process IPPool '%s', error: %w, discarding it", pool.Name, err)
 			}
 
 			if apierrors.IsConflict(err) {
@@ -298,7 +297,7 @@ func (ic *IPPoolController) handleIPPool(ctx context.Context, pool *spiderpoolv2
 // syncHandler will calculate and update the provided SpiderIPPool status AllocatedIPCount or TotalIPCount.
 // And it will also remove finalizer once the IPPool is dying and no longer being used.
 func (ic *IPPoolController) syncHandler(ctx context.Context, pool *spiderpoolv2beta1.SpiderIPPool) error {
-	//remove finalizer to delete the dying IPPool when the IPPool is no longer being used
+	// remove finalizer to delete the dying IPPool when the IPPool is no longer being used
 	if pool.DeletionTimestamp != nil && pool.Status.AllocatedIPs == nil {
 		err := ic.removeFinalizer(ctx, pool)
 		if client.IgnoreNotFound(err) != nil {
@@ -319,7 +318,7 @@ func (ic *IPPoolController) syncHandler(ctx context.Context, pool *spiderpoolv2b
 
 	subnet, err := spiderpoolip.NewCIDR(pool.Spec.Subnet, pool.Spec.IPs, pool.Spec.ExcludeIPs)
 	if err != nil {
-		return fmt.Errorf("%w: failed to calculate SpiderIPPool '%s' total IP count, error: %v", constant.ErrWrongInput, pool.Name, err)
+		return fmt.Errorf("%w: failed to calculate SpiderIPPool '%s' total IP count, error: %w", constant.ErrWrongInput, pool.Name, err)
 	}
 	total := subnet.TotalIPInt()
 	if pool.Status.TotalIPCount == nil || *pool.Status.TotalIPCount != int64(total) {

--- a/pkg/ippoolmanager/ippool_informer_test.go
+++ b/pkg/ippoolmanager/ippool_informer_test.go
@@ -196,13 +196,13 @@ var _ = Describe("IPPool-informer", Label("unittest"), Ordered, func() {
 				control.enqueueIPPool(tmpPool)
 			})
 		})
-
 	})
-
 })
 
-var scheme *runtime.Scheme
-var poolControllerConfig IPPoolControllerConfig
+var (
+	scheme               *runtime.Scheme
+	poolControllerConfig IPPoolControllerConfig
+)
 
 type poolController struct {
 	*IPPoolController

--- a/pkg/ippoolmanager/ippool_manager.go
+++ b/pkg/ippoolmanager/ippool_manager.go
@@ -403,7 +403,7 @@ func (im *ipPoolManager) ParseWildcardPoolNameList(ctx context.Context, poolName
 				for _, tmpPool := range poolList.Items {
 					isMatch, err := filepath.Match(tmpStr, tmpPool.Name)
 					if nil != err {
-						return nil, false, fmt.Errorf("failed to match wildcard: IPv%d PoolName pattern '%s', character '%s', error: %v", ipVersion, tmpStr, tmpPool.Name, err)
+						return nil, false, fmt.Errorf("failed to match wildcard: IPv%d PoolName pattern '%s', character '%s', error: %w", ipVersion, tmpStr, tmpPool.Name, err)
 					}
 					// wildcard matches
 					if isMatch {

--- a/pkg/ippoolmanager/ippool_manager_suite_test.go
+++ b/pkg/ippoolmanager/ippool_manager_suite_test.go
@@ -26,16 +26,20 @@ import (
 	reservedipmanagermock "github.com/spidernet-io/spiderpool/pkg/reservedipmanager/mock"
 )
 
-var mockCtrl *gomock.Controller
-var mockLeaderElector *electionmock.MockSpiderLeaseElector
-var mockRIPManager *reservedipmanagermock.MockReservedIPManager
+var (
+	mockCtrl          *gomock.Controller
+	mockLeaderElector *electionmock.MockSpiderLeaseElector
+	mockRIPManager    *reservedipmanagermock.MockReservedIPManager
+)
 
-var scheme *runtime.Scheme
-var fakeClient client.Client
-var tracker k8stesting.ObjectTracker
-var fakeAPIReader client.Reader
-var ipPoolManager ippoolmanager.IPPoolManager
-var ipPoolWebhook *ippoolmanager.IPPoolWebhook
+var (
+	scheme        *runtime.Scheme
+	fakeClient    client.Client
+	tracker       k8stesting.ObjectTracker
+	fakeAPIReader client.Reader
+	ipPoolManager ippoolmanager.IPPoolManager
+	ipPoolWebhook *ippoolmanager.IPPoolWebhook
+)
 
 func TestIPPoolManager(t *testing.T) {
 	mockCtrl = gomock.NewController(t)

--- a/pkg/ippoolmanager/ippool_mutate.go
+++ b/pkg/ippoolmanager/ippool_mutate.go
@@ -52,7 +52,7 @@ func (iw *IPPoolWebhook) mutateIPPool(ctx context.Context, ipPool *spiderpoolv2b
 
 	cidr, err := spiderpoolip.CIDRToLabelValue(*ipPool.Spec.IPVersion, ipPool.Spec.Subnet)
 	if err != nil {
-		return fmt.Errorf("failed to parse 'spec.subnet' %s as a valid label value: %v", ipPool.Spec.Subnet, err)
+		return fmt.Errorf("failed to parse 'spec.subnet' %s as a valid label value: %w", ipPool.Spec.Subnet, err)
 	}
 
 	if v, ok := ipPool.Labels[constant.LabelIPPoolCIDR]; !ok || v != cidr {
@@ -66,7 +66,7 @@ func (iw *IPPoolWebhook) mutateIPPool(ctx context.Context, ipPool *spiderpoolv2b
 	if iw.EnableSpiderSubnet {
 		subnet, err := iw.setControllerSubnet(ctx, ipPool)
 		if err != nil {
-			return apierrors.NewInternalError(fmt.Errorf("failed to set the reference of the controller Subnet: %v", err))
+			return apierrors.NewInternalError(fmt.Errorf("failed to set the reference of the controller Subnet: %w", err))
 		}
 
 		// inherit gateway,vlan,routes from corresponding SpiderSubnet if not set
@@ -78,7 +78,7 @@ func (iw *IPPoolWebhook) mutateIPPool(ctx context.Context, ipPool *spiderpoolv2b
 	if len(ipPool.Spec.IPs) > 1 {
 		mergedIPs, err := spiderpoolip.MergeIPRanges(*ipPool.Spec.IPVersion, ipPool.Spec.IPs)
 		if err != nil {
-			return fmt.Errorf("failed to merge 'spec.ips': %v", err)
+			return fmt.Errorf("failed to merge 'spec.ips': %w", err)
 		}
 
 		ips := ipPool.Spec.IPs
@@ -89,7 +89,7 @@ func (iw *IPPoolWebhook) mutateIPPool(ctx context.Context, ipPool *spiderpoolv2b
 	if len(ipPool.Spec.ExcludeIPs) > 1 {
 		mergedExcludeIPs, err := spiderpoolip.MergeIPRanges(*ipPool.Spec.IPVersion, ipPool.Spec.ExcludeIPs)
 		if err != nil {
-			return fmt.Errorf("failed to merge 'spec.excludeIPs': %v", err)
+			return fmt.Errorf("failed to merge 'spec.excludeIPs': %w", err)
 		}
 
 		excludeIPs := ipPool.Spec.ExcludeIPs
@@ -110,7 +110,7 @@ func (iw *IPPoolWebhook) setControllerSubnet(ctx context.Context, ipPool *spider
 
 	cidr, err := spiderpoolip.CIDRToLabelValue(*ipPool.Spec.IPVersion, ipPool.Spec.Subnet)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse CIDR %s as a valid label value: %v", ipPool.Spec.Subnet, err)
+		return nil, fmt.Errorf("failed to parse CIDR %s as a valid label value: %w", ipPool.Spec.Subnet, err)
 	}
 
 	var subnetList spiderpoolv2beta1.SpiderSubnetList
@@ -119,7 +119,7 @@ func (iw *IPPoolWebhook) setControllerSubnet(ctx context.Context, ipPool *spider
 		&subnetList,
 		client.MatchingLabels{constant.LabelSubnetCIDR: cidr},
 	); err != nil {
-		return nil, fmt.Errorf("failed to list Subnets: %v", err)
+		return nil, fmt.Errorf("failed to list Subnets: %w", err)
 	}
 
 	if len(subnetList.Items) == 0 {
@@ -129,7 +129,7 @@ func (iw *IPPoolWebhook) setControllerSubnet(ctx context.Context, ipPool *spider
 	subnet := subnetList.Items[0].DeepCopy()
 	if !metav1.IsControlledBy(ipPool, subnet) {
 		if err := ctrl.SetControllerReference(subnet, ipPool, iw.Client.Scheme()); err != nil {
-			return nil, fmt.Errorf("failed to set owner reference: %v", err)
+			return nil, fmt.Errorf("failed to set owner reference: %w", err)
 		}
 		logger.Sugar().Infof("Set owner reference as Subnet %s", subnet.Name)
 	}

--- a/pkg/ippoolmanager/ippool_subnet_validate.go
+++ b/pkg/ippoolmanager/ippool_subnet_validate.go
@@ -56,7 +56,7 @@ func (iw *IPPoolWebhook) validateSubnetTotalIPsContainsIPPoolTotalIPs(ctx contex
 
 	poolTotalIPs, err := spiderpoolip.AssembleTotalIPs(*ipPool.Spec.IPVersion, ipPool.Spec.IPs, ipPool.Spec.ExcludeIPs)
 	if err != nil {
-		return field.InternalError(ipsField, fmt.Errorf("failed to assemble the total IP addresses of the IPPool %s: %v", ipPool.Name, err))
+		return field.InternalError(ipsField, fmt.Errorf("failed to assemble the total IP addresses of the IPPool %s: %w", ipPool.Name, err))
 	}
 	if len(poolTotalIPs) == 0 {
 		return nil
@@ -64,12 +64,12 @@ func (iw *IPPoolWebhook) validateSubnetTotalIPsContainsIPPoolTotalIPs(ctx contex
 
 	var subnet spiderpoolv2beta1.SpiderSubnet
 	if err := iw.APIReader.Get(ctx, apitypes.NamespacedName{Name: owner.Name}, &subnet); err != nil {
-		return field.InternalError(subnetField, fmt.Errorf("failed to get controller Subnet %s: %v", owner.Name, err))
+		return field.InternalError(subnetField, fmt.Errorf("failed to get controller Subnet %s: %w", owner.Name, err))
 	}
 
 	subnetTotalIPs, err := spiderpoolip.AssembleTotalIPs(*subnet.Spec.IPVersion, subnet.Spec.IPs, subnet.Spec.ExcludeIPs)
 	if err != nil {
-		return field.InternalError(ipsField, fmt.Errorf("failed to assemble the total IP addresses of the Subnet %s: %v", subnet.Name, err))
+		return field.InternalError(ipsField, fmt.Errorf("failed to assemble the total IP addresses of the Subnet %s: %w", subnet.Name, err))
 	}
 
 	outIPs := spiderpoolip.IPsDiffSet(poolTotalIPs, subnetTotalIPs, false)
@@ -93,7 +93,7 @@ func validateNewAutoPoolTotalIPsWithinSubnet(pool *spiderpoolv2beta1.SpiderIPPoo
 
 	poolTotalIPs, err := spiderpoolip.AssembleTotalIPs(*pool.Spec.IPVersion, pool.Spec.IPs, pool.Spec.ExcludeIPs)
 	if nil != err {
-		return field.InternalError(ipsField, fmt.Errorf("failed to assemble the total IP addresses of the Subnet %s: %v", subnet.Name, err))
+		return field.InternalError(ipsField, fmt.Errorf("failed to assemble the total IP addresses of the Subnet %s: %w", subnet.Name, err))
 	}
 	sort.Slice(poolTotalIPs, func(i, j int) bool {
 		return bytes.Compare(poolTotalIPs[i].To16(), poolTotalIPs[j].To16()) < 0
@@ -101,14 +101,14 @@ func validateNewAutoPoolTotalIPsWithinSubnet(pool *spiderpoolv2beta1.SpiderIPPoo
 
 	subnetAllocatedIPPools, err := convert.UnmarshalSubnetAllocatedIPPools(subnet.Status.ControlledIPPools)
 	if nil != err {
-		return field.InternalError(subnetField, fmt.Errorf("failed unsharmal SpiderSubnet %s Status.ControlledIPPools: %v", subnet.Name, err))
+		return field.InternalError(subnetField, fmt.Errorf("failed unsharmal SpiderSubnet %s Status.ControlledIPPools: %w", subnet.Name, err))
 	}
 	if subnetAllocatedIPPools != nil {
 		subnetPoolAllocation, ok := subnetAllocatedIPPools[pool.Name]
 		if ok {
 			subnetPoolIPs, err := spiderpoolip.ParseIPRanges(*subnet.Spec.IPVersion, subnetPoolAllocation.IPs)
 			if nil != err {
-				return field.InternalError(subnetField, fmt.Errorf("failed to parse SpiderSubnet %s controlledIPPool %s IPs: %v ", subnet.Name, pool.Name, err))
+				return field.InternalError(subnetField, fmt.Errorf("failed to parse SpiderSubnet %s controlledIPPool %s IPs: %w ", subnet.Name, pool.Name, err))
 			}
 			sort.Slice(subnetPoolIPs, func(i, j int) bool {
 				return bytes.Compare(subnetPoolIPs[i].To16(), subnetPoolIPs[j].To16()) < 0

--- a/pkg/ippoolmanager/ippool_validate.go
+++ b/pkg/ippoolmanager/ippool_validate.go
@@ -119,12 +119,12 @@ func (iw *IPPoolWebhook) validateIPPoolSpec(ctx context.Context, ipPool *spiderp
 func validateIPPoolIPInUse(ipPool *spiderpoolv2beta1.SpiderIPPool) *field.Error {
 	allocatedRecords, err := convert.UnmarshalIPPoolAllocatedIPs(ipPool.Status.AllocatedIPs)
 	if err != nil {
-		return field.InternalError(ipsField, fmt.Errorf("failed to unmarshal the allocated IP records of IPPool %s: %v", ipPool.Name, err))
+		return field.InternalError(ipsField, fmt.Errorf("failed to unmarshal the allocated IP records of IPPool %s: %w", ipPool.Name, err))
 	}
 
 	totalIPs, err := spiderpoolip.AssembleTotalIPs(*ipPool.Spec.IPVersion, ipPool.Spec.IPs, ipPool.Spec.ExcludeIPs)
 	if err != nil {
-		return field.InternalError(ipsField, fmt.Errorf("failed to assemble the total IP addresses of the IPPool %s: %v", ipPool.Name, err))
+		return field.InternalError(ipsField, fmt.Errorf("failed to assemble the total IP addresses of the IPPool %s: %w", ipPool.Name, err))
 	}
 
 	totalIPsMap := map[string]bool{}
@@ -157,7 +157,8 @@ func (iw *IPPoolWebhook) validateIPPoolIPVersion(version *types.IPVersion) *fiel
 		return field.NotSupported(
 			ipVersionField,
 			version,
-			[]string{strconv.FormatInt(constant.IPv4, 10),
+			[]string{
+				strconv.FormatInt(constant.IPv4, 10),
 				strconv.FormatInt(constant.IPv6, 10),
 			},
 		)
@@ -194,7 +195,7 @@ func (iw *IPPoolWebhook) validateIPPoolCIDR(ctx context.Context, ipPool *spiderp
 
 	var ipPoolList spiderpoolv2beta1.SpiderIPPoolList
 	if err := iw.APIReader.List(ctx, &ipPoolList); err != nil {
-		return field.InternalError(subnetField, fmt.Errorf("failed to list IPPools: %v", err))
+		return field.InternalError(subnetField, fmt.Errorf("failed to list IPPools: %w", err))
 	}
 
 	for _, pool := range ipPoolList.Items {
@@ -211,7 +212,7 @@ func (iw *IPPoolWebhook) validateIPPoolCIDR(ctx context.Context, ipPool *spiderp
 
 			overlap, err := spiderpoolip.IsCIDROverlap(*ipPool.Spec.IPVersion, ipPool.Spec.Subnet, pool.Spec.Subnet)
 			if err != nil {
-				return field.InternalError(subnetField, fmt.Errorf("failed to compare whether 'spec.subnet' overlaps: %v", err))
+				return field.InternalError(subnetField, fmt.Errorf("failed to compare whether 'spec.subnet' overlaps: %w", err))
 			}
 
 			if overlap {
@@ -235,7 +236,7 @@ func (iw *IPPoolWebhook) validateIPPoolAvailableIPs(ctx context.Context, ipPool 
 
 	cidr, err := spiderpoolip.CIDRToLabelValue(*ipPool.Spec.IPVersion, ipPool.Spec.Subnet)
 	if err != nil {
-		return field.InternalError(ipsField, fmt.Errorf("failed to parse CIDR %s as a valid label value: %v", ipPool.Spec.Subnet, err))
+		return field.InternalError(ipsField, fmt.Errorf("failed to parse CIDR %s as a valid label value: %w", ipPool.Spec.Subnet, err))
 	}
 
 	var ipPoolList spiderpoolv2beta1.SpiderIPPoolList
@@ -244,7 +245,7 @@ func (iw *IPPoolWebhook) validateIPPoolAvailableIPs(ctx context.Context, ipPool 
 		&ipPoolList,
 		client.MatchingLabels{constant.LabelIPPoolCIDR: cidr},
 	); err != nil {
-		return field.InternalError(ipsField, fmt.Errorf("failed to list IPPools: %v", err))
+		return field.InternalError(ipsField, fmt.Errorf("failed to list IPPools: %w", err))
 	}
 
 	for _, pool := range ipPoolList.Items {

--- a/pkg/ippoolmanager/ippool_webhook.go
+++ b/pkg/ippoolmanager/ippool_webhook.go
@@ -62,7 +62,7 @@ func (iw *IPPoolWebhook) Default(ctx context.Context, obj runtime.Object) error 
 	logger.Sugar().Debugf("Request IPPool: %+v", *ipPool)
 
 	if err := iw.mutateIPPool(logutils.IntoContext(ctx, logger), ipPool); err != nil {
-		logger.Sugar().Errorf("Failed to mutate IPPool: %v", err)
+		logger.Sugar().Errorf("Failed to mutate IPPool: %w", err)
 	}
 
 	return nil
@@ -125,7 +125,7 @@ func (iw *IPPoolWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runt
 	}
 
 	if errs := iw.validateUpdateIPPoolWhileEnableSpiderSubnet(logutils.IntoContext(ctx, logger), oldIPPool, newIPPool); len(errs) != 0 {
-		logger.Sugar().Errorf("Failed to update IPPool: %v", errs.ToAggregate().Error())
+		logger.Sugar().Errorf("Failed to update IPPool: %w", errs.ToAggregate().Error())
 		return nil, apierrors.NewInvalid(
 			schema.GroupKind{Group: constant.SpiderpoolAPIGroup, Kind: constant.KindSpiderIPPool},
 			newIPPool.Name,

--- a/pkg/ippoolmanager/ippool_webhook_test.go
+++ b/pkg/ippoolmanager/ippool_webhook_test.go
@@ -1228,7 +1228,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 								"key": "value",
 							},
 							MatchExpressions: []metav1.LabelSelectorRequirement{
-								{Key: "key",
+								{
+									Key:      "key",
 									Operator: metav1.LabelSelectorOpIn,
 									Values:   []string{"value"},
 								},

--- a/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/spidercoordinator_types.go
+++ b/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/spidercoordinator_types.go
@@ -9,7 +9,6 @@ import (
 
 // CoordinationSpec defines the desired state of SpiderCoordinator.
 type CoordinatorSpec struct {
-
 	// Mode mode specifies the mode in which the coordinator runs,
 	// and the configurable values include auto (default), underlay,
 	// overlay, disabled.

--- a/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/types_string.go
+++ b/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/types_string.go
@@ -16,7 +16,8 @@ func (in *SpiderIPPool) String() string {
 		return "nil"
 	}
 
-	s := strings.Join([]string{`&SpiderIPPool{`,
+	s := strings.Join([]string{
+		`&SpiderIPPool{`,
 		`ObjectMeta:` + strings.Replace(fmt.Sprintf("%v", in.ObjectMeta), `&`, ``, 1) + `,`,
 		`Spec:` + strings.Replace(strings.Replace(in.Spec.String(), "IPPoolSpec", "IPPoolSpec", 1), `&`, ``, 1) + `,`,
 		`Status:` + strings.Replace(strings.Replace(in.Status.String(), "IPPoolStatus", "IPPoolStatus", 1), `&`, ``, 1) + `,`,
@@ -31,7 +32,8 @@ func (in *IPPoolSpec) String() string {
 		return "nil"
 	}
 
-	s := strings.Join([]string{`&IPPoolSpec{`,
+	s := strings.Join([]string{
+		`&IPPoolSpec{`,
 		`IPVersion:` + stringutil.ValueToStringGenerated(in.IPVersion) + `,`,
 		`Subnet:` + fmt.Sprintf("%v", in.Subnet) + `,`,
 		`IPs:` + fmt.Sprintf("%v", in.IPs) + `,`,
@@ -57,7 +59,8 @@ func (in *IPPoolStatus) String() string {
 		return "nil"
 	}
 
-	s := strings.Join([]string{`&IPPoolStatus{`,
+	s := strings.Join([]string{
+		`&IPPoolStatus{`,
 		`AllocatedIPs:` + stringutil.ValueToStringGenerated(in.AllocatedIPs) + `,`,
 		`TotalIPCount:` + stringutil.ValueToStringGenerated(in.TotalIPCount) + `,`,
 		`AllocatedIPCount:` + stringutil.ValueToStringGenerated(in.AllocatedIPCount) + `,`,
@@ -72,7 +75,8 @@ func (in *SpiderEndpoint) String() string {
 		return "nil"
 	}
 
-	s := strings.Join([]string{`&SpiderEndpoint{`,
+	s := strings.Join([]string{
+		`&SpiderEndpoint{`,
 		`ObjectMeta:` + strings.Replace(fmt.Sprintf("%v", in.ObjectMeta), `&`, ``, 1) + `,`,
 		`Status:` + in.Status.String() + `,`,
 		`}`,
@@ -86,7 +90,8 @@ func (in *WorkloadEndpointStatus) String() string {
 		return "nil"
 	}
 
-	s := strings.Join([]string{`&WorkloadEndpointStatus{`,
+	s := strings.Join([]string{
+		`&WorkloadEndpointStatus{`,
 		`Current:` + fmt.Sprintf("%v", in.Current.String()) + `,`,
 		`OwnerControllerType:` + fmt.Sprintf("%v", in.OwnerControllerType) + `,`,
 		`OwnerControllerName:` + fmt.Sprintf("%v", in.OwnerControllerName) + `,`,
@@ -107,7 +112,8 @@ func (in *PodIPAllocation) String() string {
 	}
 	repeatedStringForIPs += "}"
 
-	s := strings.Join([]string{`&PodIPAllocation{`,
+	s := strings.Join([]string{
+		`&PodIPAllocation{`,
 		`UID:` + fmt.Sprintf("%+v", in.UID) + `,`,
 		`Node:` + fmt.Sprintf("%+v", in.Node) + `,`,
 		`IPs:` + repeatedStringForIPs + `,`,
@@ -122,7 +128,8 @@ func (in *IPAllocationDetail) String() string {
 		return "nil"
 	}
 
-	s := strings.Join([]string{`&IPAllocationDetail{`,
+	s := strings.Join([]string{
+		`&IPAllocationDetail{`,
 		`NIC:` + fmt.Sprintf("%v", in.NIC) + `,`,
 		`IPv4:` + stringutil.ValueToStringGenerated(in.IPv4) + `,`,
 		`IPv6:` + stringutil.ValueToStringGenerated(in.IPv6) + `,`,
@@ -144,7 +151,8 @@ func (in *SpiderReservedIP) String() string {
 		return "nil"
 	}
 
-	s := strings.Join([]string{`&SpiderReservedIP{`,
+	s := strings.Join([]string{
+		`&SpiderReservedIP{`,
 		`ObjectMeta:` + strings.Replace(fmt.Sprintf("%v", in.ObjectMeta), `&`, ``, 1) + `,`,
 		`Spec:` + strings.Replace(strings.Replace(in.Spec.String(), "ReservedIPSpec", "ReservedIPSpec", 1), `&`, ``, 1) + `,`,
 		`}`,
@@ -158,7 +166,8 @@ func (in *ReservedIPSpec) String() string {
 		return "nil"
 	}
 
-	s := strings.Join([]string{`&ReservedIPSpec{`,
+	s := strings.Join([]string{
+		`&ReservedIPSpec{`,
 		`IPVersion:` + stringutil.ValueToStringGenerated(in.IPVersion) + `,`,
 		`IPs:` + fmt.Sprintf("%v", in.IPs) + `,`,
 		`}`,
@@ -172,7 +181,8 @@ func (in *SpiderSubnet) String() string {
 		return "nil"
 	}
 
-	s := strings.Join([]string{`&SpiderSubnet{`,
+	s := strings.Join([]string{
+		`&SpiderSubnet{`,
 		`ObjectMeta:` + strings.Replace(fmt.Sprintf("%v", in.ObjectMeta), `&`, ``, 1) + `,`,
 		`Spec:` + strings.Replace(strings.Replace(in.Spec.String(), "SubnetSpec", "SubnetSpec", 1), `&`, ``, 1) + `,`,
 		`Status:` + strings.Replace(strings.Replace(in.Status.String(), "SubnetStatus", "SubnetStatus", 1), `&`, ``, 1) + `,`,
@@ -187,7 +197,8 @@ func (in *SubnetSpec) String() string {
 		return "nil"
 	}
 
-	s := strings.Join([]string{`&SubnetSpec{`,
+	s := strings.Join([]string{
+		`&SubnetSpec{`,
 		`IPVersion:` + stringutil.ValueToStringGenerated(in.IPVersion) + `,`,
 		`Subnet:` + fmt.Sprintf("%v", in.Subnet) + `,`,
 		`IPs:` + fmt.Sprintf("%v", in.IPs) + `,`,
@@ -205,7 +216,8 @@ func (in *SubnetStatus) String() string {
 		return "nil"
 	}
 
-	s := strings.Join([]string{`SubnetStatus{`,
+	s := strings.Join([]string{
+		`SubnetStatus{`,
 		`ControlledIPPools:` + stringutil.ValueToStringGenerated(in.ControlledIPPools) + `,`,
 		`TotalIPCount:` + stringutil.ValueToStringGenerated(in.TotalIPCount) + `,`,
 		`AllocatedIPCount:` + stringutil.ValueToStringGenerated(in.AllocatedIPCount) + `,`,

--- a/pkg/lock/lock_fast.go
+++ b/pkg/lock/lock_fast.go
@@ -15,7 +15,7 @@ type internalRWMutex struct {
 }
 
 func (i *internalRWMutex) UnlockIgnoreTime() {
-	i.RWMutex.Unlock()
+	i.Unlock()
 }
 
 type internalMutex struct {
@@ -23,5 +23,5 @@ type internalMutex struct {
 }
 
 func (i *internalMutex) UnlockIgnoreTime() {
-	i.Mutex.Unlock()
+	i.Unlock()
 }

--- a/pkg/logutils/log_test.go
+++ b/pkg/logutils/log_test.go
@@ -51,14 +51,14 @@ var _ = Describe("Log", Label("unittest", "log_test"), func() {
 		})
 
 		It("wrong output mode only", func() {
-			_, err := logutils.NewLoggerWithOption(logutils.JsonLogFormat, logutils.OUTPUT_STDOUT|logutils.OUTPUT_STDERR,
+			_, err := logutils.NewLoggerWithOption(logutils.JSONLogFormat, logutils.OutputStdout|logutils.OutputStderr,
 				nil, false, false, false, logutils.DebugLevel)
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("wrong params", func() {
 			// If fortmat and outputMode all wrong, then it will return the default config logger
-			logger, err := logutils.NewLoggerWithOption(logutils.ConsoleLogFormat+logutils.JsonLogFormat, logutils.OUTPUT_STDOUT|logutils.OUTPUT_FILE|logutils.OUTPUT_STDOUT|logutils.OUTPUT_STDERR,
+			logger, err := logutils.NewLoggerWithOption(logutils.ConsoleLogFormat+logutils.JSONLogFormat, logutils.OutputStdout|logutils.OutputFile|logutils.OutputStdout|logutils.OutputStderr,
 				&badFileLoggerConf, true, true, true, logutils.WarnLevel)
 			Expect(err).NotTo(HaveOccurred())
 			logger.Warn("hi.")

--- a/pkg/metric/metrics_instance.go
+++ b/pkg/metric/metrics_instance.go
@@ -15,63 +15,65 @@ import (
 	"github.com/spidernet-io/spiderpool/pkg/rdmametrics"
 )
 
-const metricPrefix = "spiderpool_"
-const debugPrefix = "debug_"
+const (
+	metricPrefix = "spiderpool_"
+	debugPrefix  = "debug_"
+)
 
 const (
 	// spiderpool agent ipam allocation metrics name
-	ipam_allocation_counts                        = metricPrefix + "ipam_allocation_counts"
-	ipam_allocation_failure_counts                = metricPrefix + "ipam_allocation_failure_counts"
-	ipam_allocation_update_ippool_conflict_counts = metricPrefix + "ipam_allocation_update_ippool_conflict_counts"
-	ipam_allocation_err_internal_counts           = metricPrefix + "ipam_allocation_err_internal_counts"
-	ipam_allocation_err_no_available_pool_counts  = metricPrefix + "ipam_allocation_err_no_available_pool_counts"
-	ipam_allocation_err_retries_exhausted_counts  = metricPrefix + "ipam_allocation_err_retries_exhausted_counts"
-	ipam_allocation_err_ip_used_out_counts        = metricPrefix + "ipam_allocation_err_ip_used_out_counts"
+	ipamAllocationCountsName                     = metricPrefix + "ipamAllocationCountsName"
+	ipamAllocationFailureCountsName              = metricPrefix + "ipamAllocationFailureCountsName"
+	ipamAllocationUpdateIPPoolConflictCountsName = metricPrefix + "ipamAllocationUpdateIPPoolConflictCountsName"
+	ipamAllocationErrInternalCountsName          = metricPrefix + "ipamAllocationErrInternalCountsName"
+	ipamAllocationErrNoAvailablePoolCountsName   = metricPrefix + "ipamAllocationErrNoAvailablePoolCountsName"
+	ipamAllocationErrRetriesExhaustedCountsName  = metricPrefix + "ipamAllocationErrRetriesExhaustedCountsName"
+	ipamAllocationErrIPUsedOutCountsName         = metricPrefix + "ipamAllocationErrIPUsedOutCountsName"
 
-	ipam_allocation_average_duration_seconds = metricPrefix + "ipam_allocation_average_duration_seconds"
-	ipam_allocation_max_duration_seconds     = metricPrefix + "ipam_allocation_max_duration_seconds"
-	ipam_allocation_min_duration_seconds     = metricPrefix + "ipam_allocation_min_duration_seconds"
-	ipam_allocation_latest_duration_seconds  = metricPrefix + "ipam_allocation_latest_duration_seconds"
-	ipam_allocation_duration_seconds         = metricPrefix + "ipam_allocation_duration_seconds"
+	ipamAllocationAverageDurationSecondsName = metricPrefix + "ipamAllocationAverageDurationSecondsName"
+	ipamAllocationMaxDurationSecondsName     = metricPrefix + "ipamAllocationMaxDurationSecondsName"
+	ipamAllocationMinDurationSecondsName     = metricPrefix + "ipamAllocationMinDurationSecondsName"
+	ipamAllocationLatestDurationSecondsName  = metricPrefix + "ipamAllocationLatestDurationSecondsName"
+	ipamAllocationDurationSecondsName        = metricPrefix + "ipamAllocationDurationSecondsName"
 
-	ipam_allocation_average_limit_duration_seconds = metricPrefix + "ipam_allocation_average_limit_duration_seconds"
-	ipam_allocation_max_limit_duration_seconds     = metricPrefix + "ipam_allocation_max_limit_duration_seconds"
-	ipam_allocation_min_limit_duration_seconds     = metricPrefix + "ipam_allocation_min_limit_duration_seconds"
-	ipam_allocation_latest_limit_duration_seconds  = metricPrefix + "ipam_allocation_latest_limit_duration_seconds"
-	ipam_allocation_limit_duration_seconds         = metricPrefix + "ipam_allocation_limit_duration_seconds"
+	ipamAllocationAverageLimitDurationSecondsName = metricPrefix + "ipamAllocationAverageLimitDurationSecondsName"
+	ipamAllocationMaxLimitDurationSecondsName     = metricPrefix + "ipamAllocationMaxLimitDurationSecondsName"
+	ipamAllocationMinLimitDurationSecondsName     = metricPrefix + "ipamAllocationMinLimitDurationSecondsName"
+	ipamAllocationLatestLimitDurationSecondsName  = metricPrefix + "ipamAllocationLatestLimitDurationSecondsName"
+	ipamAllocationLimitDurationSecondsName        = metricPrefix + "ipamAllocationLimitDurationSecondsName"
 
 	// spiderpool agent ipam release metrics name
-	ipam_release_counts                        = metricPrefix + "ipam_release_counts"
-	ipam_release_failure_counts                = metricPrefix + "ipam_release_failure_counts"
-	ipam_release_update_ippool_conflict_counts = metricPrefix + "ipam_release_update_ippool_conflict_counts"
-	ipam_release_err_internal_counts           = metricPrefix + "ipam_release_err_internal_counts"
-	ipam_release_err_retries_exhausted_counts  = metricPrefix + "ipam_release_err_retries_exhausted_counts"
+	ipamReleaseCountsName                     = metricPrefix + "ipamReleaseCountsName"
+	ipamReleaseFailureCountsName              = metricPrefix + "ipamReleaseFailureCountsName"
+	ipamReleaseUpdateIPPoolConflictCountsName = metricPrefix + "ipamReleaseUpdateIPPoolConflictCountsName"
+	ipamReleaseErrInternalCountsName          = metricPrefix + "ipamReleaseErrInternalCountsName"
+	ipamReleaseErrRetriesExhaustedCountsName  = metricPrefix + "ipamReleaseErrRetriesExhaustedCountsName"
 
-	ipam_release_average_duration_seconds = metricPrefix + "ipam_release_average_duration_seconds"
-	ipam_release_max_duration_seconds     = metricPrefix + "ipam_release_max_duration_seconds"
-	ipam_release_min_duration_seconds     = metricPrefix + "ipam_release_min_duration_seconds"
-	ipam_release_latest_duration_seconds  = metricPrefix + "ipam_release_latest_duration_seconds"
-	ipam_release_duration_seconds         = metricPrefix + "ipam_release_duration_seconds"
+	ipamReleaseAverageDurationSecondsName = metricPrefix + "ipamReleaseAverageDurationSecondsName"
+	ipamReleaseMaxDurationSecondsName     = metricPrefix + "ipamReleaseMaxDurationSecondsName"
+	ipamReleaseMinDurationSecondsName     = metricPrefix + "ipamReleaseMinDurationSecondsName"
+	ipamReleaseLatestDurationSecondsName  = metricPrefix + "ipamReleaseLatestDurationSecondsName"
+	ipamReleaseDurationSecondsName        = metricPrefix + "ipamReleaseDurationSecondsName"
 
-	ipam_release_average_limit_duration_seconds = metricPrefix + "ipam_release_average_limit_duration_seconds"
-	ipam_release_max_limit_duration_seconds     = metricPrefix + "ipam_release_max_limit_duration_seconds"
-	ipam_release_min_limit_duration_seconds     = metricPrefix + "ipam_release_min_limit_duration_seconds"
-	ipam_release_latest_limit_duration_seconds  = metricPrefix + "ipam_release_latest_limit_duration_seconds"
-	ipam_release_limit_duration_seconds         = metricPrefix + "ipam_release_limit_duration_seconds"
+	ipamReleaseAverageLimitDurationSecondsName = metricPrefix + "ipamReleaseAverageLimitDurationSecondsName"
+	ipamReleaseMaxLimitDurationSecondsName     = metricPrefix + "ipamReleaseMaxLimitDurationSecondsName"
+	ipamReleaseMinLimitDurationSecondsName     = metricPrefix + "ipamReleaseMinLimitDurationSecondsName"
+	ipamReleaseLatestLimitDurationSecondsName  = metricPrefix + "ipamReleaseLatestLimitDurationSecondsName"
+	ipamReleaseLimitDurationSecondsName        = metricPrefix + "ipamReleaseLimitDurationSecondsName"
 
 	// spiderpool controller IP GC metrics name
-	ip_gc_counts         = metricPrefix + "ip_gc_counts"
-	ip_gc_failure_counts = metricPrefix + "ip_gc_failure_counts"
+	ipGCCCountsName       = metricPrefix + "ipGCCCountsName"
+	ipGCFailureCountsName = metricPrefix + "ipGCFailureCountsName"
 
 	// spiderpool IPPool and Subnet metrics and these include some debug level metrics
-	total_ippool_counts                   = metricPrefix + "total_ippool_counts"
-	ippool_total_ip_counts                = metricPrefix + debugPrefix + "ippool_total_ip_counts"
-	ippool_available_ip_counts            = metricPrefix + debugPrefix + "ippool_available_ip_counts"
-	total_subnet_counts                   = metricPrefix + "total_subnet_counts"
-	subnet_ippool_counts                  = metricPrefix + debugPrefix + "subnet_ippool_counts"
-	subnet_total_ip_counts                = metricPrefix + debugPrefix + "subnet_total_ip_counts"
-	subnet_available_ip_counts            = metricPrefix + debugPrefix + "subnet_available_ip_counts"
-	auto_pool_waited_for_available_counts = metricPrefix + debugPrefix + "auto_pool_waited_for_available_counts"
+	totalIPPoolCountsName                = metricPrefix + "totalIPPoolCountsName"
+	ippoolTotalIPCountsName              = metricPrefix + debugPrefix + "ippoolTotalIPCountsName"
+	ippoolAvailableIPCountsName          = metricPrefix + debugPrefix + "ippoolAvailableIPCountsName"
+	totalSubnetCountsName                = metricPrefix + "totalSubnetCountsName"
+	subnetIPPoolCountsName               = metricPrefix + debugPrefix + "subnetIPPoolCountsName"
+	subnetTotalIPCountsName              = metricPrefix + debugPrefix + "subnetTotalIPCountsName"
+	subnetAvailableIPCountsName          = metricPrefix + debugPrefix + "subnetAvailableIPCountsName"
+	autoPoolWaitedForAvailableCountsName = metricPrefix + debugPrefix + "autoPoolWaitedForAvailableCountsName"
 )
 
 var (
@@ -145,7 +147,7 @@ func (a *asyncFloat64Gauge) initGauge(metricName string, description string, isD
 
 	tmpGauge, err := newMetricFloat64Gauge(metricName, description, isDebugLevel)
 	if nil != err {
-		return fmt.Errorf("failed to new spiderpool metric '%s', error: %v", metricName, err)
+		return fmt.Errorf("failed to new spiderpool metric '%s', error: %w", metricName, err)
 	}
 
 	a.gaugeMetric = tmpGauge
@@ -157,7 +159,7 @@ func (a *asyncFloat64Gauge) initGauge(metricName string, description string, isD
 		return nil
 	}, a.gaugeMetric)
 	if nil != err {
-		return fmt.Errorf("failed to register callback for spiderpool metric '%s', error: %v", metricName, err)
+		return fmt.Errorf("failed to register callback for spiderpool metric '%s', error: %w", metricName, err)
 	}
 
 	return nil
@@ -191,7 +193,7 @@ func (a *asyncInt64Gauge) initGauge(metricName string, description string, isDeb
 
 	tmpGauge, err := newMetricInt64Gauge(metricName, description, isDebugLevel)
 	if nil != err {
-		return fmt.Errorf("failed to new spiderpool metric '%s', error: %v", metricName, err)
+		return fmt.Errorf("failed to new spiderpool metric '%s', error: %w", metricName, err)
 	}
 
 	a.gaugeMetric = tmpGauge
@@ -203,7 +205,7 @@ func (a *asyncInt64Gauge) initGauge(metricName string, description string, isDeb
 		return nil
 	}, a.gaugeMetric)
 	if nil != err {
-		return fmt.Errorf("failed to register callback for spiderpool metric '%s', error: %v", metricName, err)
+		return fmt.Errorf("failed to register callback for spiderpool metric '%s', error: %w", metricName, err)
 	}
 
 	return nil
@@ -240,9 +242,9 @@ func InitSpiderpoolAgentMetrics(ctx context.Context, cache podownercache.CacheIn
 		return err
 	}
 
-	autoPoolWaitedForAvailableCounts, err := newMetricInt64Counter(auto_pool_waited_for_available_counts, "ipam waited for auto-created IPPool available counts", false)
+	autoPoolWaitedForAvailableCounts, err := newMetricInt64Counter(autoPoolWaitedForAvailableCountsName, "ipam waited for auto-created IPPool available counts", false)
 	if nil != err {
-		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %v", auto_pool_waited_for_available_counts, err)
+		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %w", autoPoolWaitedForAvailableCountsName, err)
 	}
 	AutoPoolWaitedForAvailableCounts = autoPoolWaitedForAvailableCounts
 
@@ -267,115 +269,115 @@ func InitSpiderpoolControllerMetrics(ctx context.Context) error {
 // initSpiderpoolAgentAllocationMetrics will init spiderpool-agent IPAM allocation metrics
 func initSpiderpoolAgentAllocationMetrics(ctx context.Context) error {
 	// spiderpool agent ipam allocation total counts, metric type "int64 counter"
-	allocationTotalCounts, err := newMetricInt64Counter(ipam_allocation_counts, "spiderpool agent ipam allocation total counts", false)
+	allocationTotalCounts, err := newMetricInt64Counter(ipamAllocationCountsName, "spiderpool agent ipam allocation total counts", false)
 	if nil != err {
-		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %v", ipam_allocation_counts, err)
+		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %w", ipamAllocationCountsName, err)
 	}
 	IpamAllocationTotalCounts = allocationTotalCounts
 	IpamAllocationTotalCounts.Add(ctx, 0)
 
 	// spiderpool agent ipam allocation failure counts, metric type "int64 counter"
-	allocationFailureCounts, err := newMetricInt64Counter(ipam_allocation_failure_counts, "spiderpool agent ipam allocation failure counts", false)
+	allocationFailureCounts, err := newMetricInt64Counter(ipamAllocationFailureCountsName, "spiderpool agent ipam allocation failure counts", false)
 	if nil != err {
-		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %v", ipam_allocation_failure_counts, err)
+		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %w", ipamAllocationFailureCountsName, err)
 	}
 	IpamAllocationFailureCounts = allocationFailureCounts
 	IpamAllocationFailureCounts.Add(ctx, 0)
 
 	// spiderpool agent ipam allocation update IPPool conflict counts, metric type "int64 counter"
-	allocationUpdateIPPoolConflictCounts, err := newMetricInt64Counter(ipam_allocation_update_ippool_conflict_counts, "spiderpool agent ipam allocation update IPPool conflict counts", false)
+	allocationUpdateIPPoolConflictCounts, err := newMetricInt64Counter(ipamAllocationUpdateIPPoolConflictCountsName, "spiderpool agent ipam allocation update IPPool conflict counts", false)
 	if nil != err {
-		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %v", ipam_allocation_update_ippool_conflict_counts, err)
+		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %w", ipamAllocationUpdateIPPoolConflictCountsName, err)
 	}
 	IpamAllocationUpdateIPPoolConflictCounts = allocationUpdateIPPoolConflictCounts
 
 	// spiderpool agent ipam allocation internal error counts, metric type "int64 counter"
-	allocationErrInternalCounts, err := newMetricInt64Counter(ipam_allocation_err_internal_counts, "spiderpool agent ipam allocation internal error counts", false)
+	allocationErrInternalCounts, err := newMetricInt64Counter(ipamAllocationErrInternalCountsName, "spiderpool agent ipam allocation internal error counts", false)
 	if nil != err {
-		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %v", ipam_allocation_err_internal_counts, err)
+		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %w", ipamAllocationErrInternalCountsName, err)
 	}
 	IpamAllocationErrInternalCounts = allocationErrInternalCounts
 
 	// spiderpool agent ipam allocation no available IPPool error counts, metric type "int64 counter"
-	allocationErrNoAvailablePoolCounts, err := newMetricInt64Counter(ipam_allocation_err_no_available_pool_counts, "spiderpool agent ipam allocation no available IPPool error counts", false)
+	allocationErrNoAvailablePoolCounts, err := newMetricInt64Counter(ipamAllocationErrNoAvailablePoolCountsName, "spiderpool agent ipam allocation no available IPPool error counts", false)
 	if nil != err {
-		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %v", ipam_allocation_err_no_available_pool_counts, err)
+		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %w", ipamAllocationErrNoAvailablePoolCountsName, err)
 	}
 	IpamAllocationErrNoAvailablePoolCounts = allocationErrNoAvailablePoolCounts
 
 	// spiderpool agent ipam allocation retries exhausted error counts, metric type "int64 counter"
-	allocationErrRetriesExhaustedCounts, err := newMetricInt64Counter(ipam_allocation_err_retries_exhausted_counts, "spiderpool agent ipam allocation retries exhausted error counts", false)
+	allocationErrRetriesExhaustedCounts, err := newMetricInt64Counter(ipamAllocationErrRetriesExhaustedCountsName, "spiderpool agent ipam allocation retries exhausted error counts", false)
 	if nil != err {
-		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %v", ipam_allocation_err_retries_exhausted_counts, err)
+		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %w", ipamAllocationErrRetriesExhaustedCountsName, err)
 	}
 	IpamAllocationErrRetriesExhaustedCounts = allocationErrRetriesExhaustedCounts
 
 	// spiderpool agent ipam allocation IP addresses used out error counts, metric type "int64 counter"
-	allocationErrIPUsedOutCounts, err := newMetricInt64Counter(ipam_allocation_err_ip_used_out_counts, "spiderpool agent ipam allocation IP addresses used out error counts", false)
+	allocationErrIPUsedOutCounts, err := newMetricInt64Counter(ipamAllocationErrIPUsedOutCountsName, "spiderpool agent ipam allocation IP addresses used out error counts", false)
 	if nil != err {
-		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %v", ipam_allocation_err_ip_used_out_counts, err)
+		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %w", ipamAllocationErrIPUsedOutCountsName, err)
 	}
 	IpamAllocationErrIPUsedOutCounts = allocationErrIPUsedOutCounts
 
 	// spiderpool agent ipam average allocation duration, metric type "float64 gauge"
-	err = ipamAllocationAverageDurationSeconds.initGauge(ipam_allocation_average_duration_seconds, "spiderpool agent ipam average allocation duration", false)
+	err = ipamAllocationAverageDurationSeconds.initGauge(ipamAllocationAverageDurationSecondsName, "spiderpool agent ipam average allocation duration", false)
 	if nil != err {
 		return err
 	}
 
 	// spiderpool agent ipam maximum allocation duration, metric type "float64 gauge"
-	err = ipamAllocationMaxDurationSeconds.initGauge(ipam_allocation_max_duration_seconds, "spiderpool agent ipam maximum allocation duration", false)
+	err = ipamAllocationMaxDurationSeconds.initGauge(ipamAllocationMaxDurationSecondsName, "spiderpool agent ipam maximum allocation duration", false)
 	if nil != err {
 		return err
 	}
 
 	// spiderpool agent ipam minimum allocation duration, metric type "float64 gauge"
-	err = ipamAllocationMinDurationSeconds.initGauge(ipam_allocation_min_duration_seconds, "spiderpool agent ipam minimum allocation duration", false)
+	err = ipamAllocationMinDurationSeconds.initGauge(ipamAllocationMinDurationSecondsName, "spiderpool agent ipam minimum allocation duration", false)
 	if nil != err {
 		return err
 	}
 
 	// spiderpool agent ipam latest allocation duration, metric type "float64 gauge"
-	err = ipamAllocationLatestDurationSeconds.initGauge(ipam_allocation_latest_duration_seconds, "spiderpool agent ipam latest allocation duration", false)
+	err = ipamAllocationLatestDurationSeconds.initGauge(ipamAllocationLatestDurationSecondsName, "spiderpool agent ipam latest allocation duration", false)
 	if nil != err {
 		return err
 	}
 
 	// spiderpool agent ipam allocation duration bucket, metric type "float64 histogram"
-	allocationHistogram, err := newMetricFloat64Histogram(ipam_allocation_duration_seconds, "histogram of spiderpool agent ipam allocation duration", false)
+	allocationHistogram, err := newMetricFloat64Histogram(ipamAllocationDurationSecondsName, "histogram of spiderpool agent ipam allocation duration", false)
 	if nil != err {
-		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %v", ipam_allocation_duration_seconds, err)
+		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %w", ipamAllocationDurationSecondsName, err)
 	}
 	ipamAllocationDurationSecondsHistogram = allocationHistogram
 
 	// spiderpool agent ipam average allocation limit duration, metric type "float64 gauge"
-	err = ipamAllocationAverageLimitDurationSeconds.initGauge(ipam_allocation_average_limit_duration_seconds, "spiderpool agent ipam average allocation limit duration", false)
+	err = ipamAllocationAverageLimitDurationSeconds.initGauge(ipamAllocationAverageLimitDurationSecondsName, "spiderpool agent ipam average allocation limit duration", false)
 	if nil != err {
 		return err
 	}
 
 	// spiderpool agent ipam maximum allocation limit duration, metric type "float64 gauge"
-	err = ipamAllocationMaxLimitDurationSeconds.initGauge(ipam_allocation_max_limit_duration_seconds, "spiderpool agent ipam maximum allocation limit duration", false)
+	err = ipamAllocationMaxLimitDurationSeconds.initGauge(ipamAllocationMaxLimitDurationSecondsName, "spiderpool agent ipam maximum allocation limit duration", false)
 	if nil != err {
 		return err
 	}
 
 	// spiderpool agent ipam minimum allocation limit duration, metric type "float64 gauge"
-	err = ipamAllocationMinLimitDurationSeconds.initGauge(ipam_allocation_min_limit_duration_seconds, "spiderpool agent ipam minimum allocation limit duration", false)
+	err = ipamAllocationMinLimitDurationSeconds.initGauge(ipamAllocationMinLimitDurationSecondsName, "spiderpool agent ipam minimum allocation limit duration", false)
 	if nil != err {
 		return err
 	}
 
 	// spiderpool agent ipam latest allocation limit duration, metric type "float64 gauge"
-	err = ipamAllocationLatestLimitDurationSeconds.initGauge(ipam_allocation_latest_limit_duration_seconds, "spiderpool agent ipam latest allocation limit duration", false)
+	err = ipamAllocationLatestLimitDurationSeconds.initGauge(ipamAllocationLatestLimitDurationSecondsName, "spiderpool agent ipam latest allocation limit duration", false)
 	if nil != err {
 		return err
 	}
 
 	// spiderpool agent ipam allocation limit duration bucket, metric type "float64 histogram"
-	allocationLimitHistogram, err := newMetricFloat64Histogram(ipam_allocation_limit_duration_seconds, "histogram of spiderpool agent ipam allocation limit duration", false)
+	allocationLimitHistogram, err := newMetricFloat64Histogram(ipamAllocationLimitDurationSecondsName, "histogram of spiderpool agent ipam allocation limit duration", false)
 	if nil != err {
-		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %v", ipam_allocation_limit_duration_seconds, err)
+		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %w", ipamAllocationLimitDurationSecondsName, err)
 	}
 	ipamAllocationLimitDurationSecondsHistogram = allocationLimitHistogram
 
@@ -385,101 +387,101 @@ func initSpiderpoolAgentAllocationMetrics(ctx context.Context) error {
 // initSpiderpoolAgentReleaseMetrics will init spiderpool-agent IPAM release metrics
 func initSpiderpoolAgentReleaseMetrics(ctx context.Context) error {
 	// spiderpool agent ipam release total counts, metric type "int64 counter"
-	releaseTotalCounts, err := newMetricInt64Counter(ipam_release_counts, "spiderpool agent ipam release total counts", false)
+	releaseTotalCounts, err := newMetricInt64Counter(ipamReleaseCountsName, "spiderpool agent ipam release total counts", false)
 	if nil != err {
-		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %v", ipam_release_counts, err)
+		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %w", ipamReleaseCountsName, err)
 	}
 	IpamReleaseTotalCounts = releaseTotalCounts
 	IpamReleaseTotalCounts.Add(ctx, 0)
 
 	// spiderpool agent ipam release failure counts, metric type "int64 counter"
-	releaseFailureCounts, err := newMetricInt64Counter(ipam_release_failure_counts, "spiderpool agent ipam release failure counts", false)
+	releaseFailureCounts, err := newMetricInt64Counter(ipamReleaseFailureCountsName, "spiderpool agent ipam release failure counts", false)
 	if nil != err {
-		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %v", ipam_release_failure_counts, err)
+		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %w", ipamReleaseFailureCountsName, err)
 	}
 	IpamReleaseFailureCounts = releaseFailureCounts
 	IpamReleaseFailureCounts.Add(ctx, 0)
 
 	// spiderpool agent ipam release update IPPool conflict counts, metric type "int64 counter"
-	releaseUpdateIPPoolConflictCounts, err := newMetricInt64Counter(ipam_release_update_ippool_conflict_counts, "spiderpool agent ipam release update IPPool conflict counts", false)
+	releaseUpdateIPPoolConflictCounts, err := newMetricInt64Counter(ipamReleaseUpdateIPPoolConflictCountsName, "spiderpool agent ipam release update IPPool conflict counts", false)
 	if nil != err {
-		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %v", ipam_release_update_ippool_conflict_counts, err)
+		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %w", ipamReleaseUpdateIPPoolConflictCountsName, err)
 	}
 	IpamReleaseUpdateIPPoolConflictCounts = releaseUpdateIPPoolConflictCounts
 
 	// spiderpool agent ipam releasing internal error counts, metric type "int64 counter"
-	releasingErrInternalCounts, err := newMetricInt64Counter(ipam_release_err_internal_counts, "spiderpool agent ipam release internal error counts", false)
+	releasingErrInternalCounts, err := newMetricInt64Counter(ipamReleaseErrInternalCountsName, "spiderpool agent ipam release internal error counts", false)
 	if nil != err {
-		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %v", ipam_release_err_internal_counts, err)
+		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %w", ipamReleaseErrInternalCountsName, err)
 	}
 	IpamReleaseErrInternalCounts = releasingErrInternalCounts
 
 	// spiderpool agent ipam releasing retries exhausted error counts, metric type "int64 counter"
-	releasingErrRetriesExhaustedCounts, err := newMetricInt64Counter(ipam_release_err_retries_exhausted_counts, "spiderpool agent ipam release retries exhausted error counts", false)
+	releasingErrRetriesExhaustedCounts, err := newMetricInt64Counter(ipamReleaseErrRetriesExhaustedCountsName, "spiderpool agent ipam release retries exhausted error counts", false)
 	if nil != err {
-		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %v", ipam_release_err_retries_exhausted_counts, err)
+		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %w", ipamReleaseErrRetriesExhaustedCountsName, err)
 	}
 	IpamReleaseErrRetriesExhaustedCounts = releasingErrRetriesExhaustedCounts
 
 	// spiderpool agent ipam average release duration, metric type "float64 gauge"
-	err = ipamReleaseAverageDurationSeconds.initGauge(ipam_release_average_duration_seconds, "spiderpool agent ipam average release duration", false)
+	err = ipamReleaseAverageDurationSeconds.initGauge(ipamReleaseAverageDurationSecondsName, "spiderpool agent ipam average release duration", false)
 	if nil != err {
 		return err
 	}
 
 	// spiderpool agent ipam maximum release duration, metric type "float64 gauge"
-	err = ipamReleaseMaxDurationSeconds.initGauge(ipam_release_max_duration_seconds, "spiderpool agent ipam maximum release duration", false)
+	err = ipamReleaseMaxDurationSeconds.initGauge(ipamReleaseMaxDurationSecondsName, "spiderpool agent ipam maximum release duration", false)
 	if nil != err {
 		return err
 	}
 
 	// spiderpool agent ipam minimum allocation duration, metric type "float64 gauge"
-	err = ipamReleaseMinDurationSeconds.initGauge(ipam_release_min_duration_seconds, "spiderpool agent ipam minimum release duration", false)
+	err = ipamReleaseMinDurationSeconds.initGauge(ipamReleaseMinDurationSecondsName, "spiderpool agent ipam minimum release duration", false)
 	if nil != err {
 		return err
 	}
 
 	// spiderpool agent ipam latest release duration, metric type "float64 gauge"
-	err = ipamReleaseLatestDurationSeconds.initGauge(ipam_release_latest_duration_seconds, "spiderpool agent ipam latest release duration", false)
+	err = ipamReleaseLatestDurationSeconds.initGauge(ipamReleaseLatestDurationSecondsName, "spiderpool agent ipam latest release duration", false)
 	if nil != err {
 		return err
 	}
 
 	// spiderpool agent ipam allocation duration bucket, metric type "float64 histogram"
-	releaseHistogram, err := newMetricFloat64Histogram(ipam_release_duration_seconds, "histogram of spiderpool agent ipam release duration", false)
+	releaseHistogram, err := newMetricFloat64Histogram(ipamReleaseDurationSecondsName, "histogram of spiderpool agent ipam release duration", false)
 	if nil != err {
-		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %v", ipam_release_duration_seconds, err)
+		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %w", ipamReleaseDurationSecondsName, err)
 	}
 	ipamReleaseDurationSecondsHistogram = releaseHistogram
 
 	// spiderpool agent ipam average release limit duration, metric type "float64 gauge"
-	err = ipamReleaseAverageLimitDurationSeconds.initGauge(ipam_release_average_limit_duration_seconds, "spiderpool agent ipam average release limit duration", false)
+	err = ipamReleaseAverageLimitDurationSeconds.initGauge(ipamReleaseAverageLimitDurationSecondsName, "spiderpool agent ipam average release limit duration", false)
 	if nil != err {
 		return err
 	}
 
 	// spiderpool agent ipam maximum release limit duration, metric type "float64 gauge"
-	err = ipamReleaseMaxLimitDurationSeconds.initGauge(ipam_release_max_limit_duration_seconds, "spiderpool agent ipam maximum release limit duration", false)
+	err = ipamReleaseMaxLimitDurationSeconds.initGauge(ipamReleaseMaxLimitDurationSecondsName, "spiderpool agent ipam maximum release limit duration", false)
 	if nil != err {
 		return err
 	}
 
 	// spiderpool agent ipam minimum allocation limit duration, metric type "float64 gauge"
-	err = ipamReleaseMinLimitDurationSeconds.initGauge(ipam_release_min_limit_duration_seconds, "spiderpool agent ipam minimum release limit duration", false)
+	err = ipamReleaseMinLimitDurationSeconds.initGauge(ipamReleaseMinLimitDurationSecondsName, "spiderpool agent ipam minimum release limit duration", false)
 	if nil != err {
 		return err
 	}
 
 	// spiderpool agent ipam latest release limit duration, metric type "float64 gauge"
-	err = ipamReleaseLatestLimitDurationSeconds.initGauge(ipam_release_latest_limit_duration_seconds, "spiderpool agent ipam latest release limit duration", false)
+	err = ipamReleaseLatestLimitDurationSeconds.initGauge(ipamReleaseLatestLimitDurationSecondsName, "spiderpool agent ipam latest release limit duration", false)
 	if nil != err {
 		return err
 	}
 
 	// spiderpool agent ipam allocation limit duration bucket, metric type "float64 histogram"
-	releaseLimitHistogram, err := newMetricFloat64Histogram(ipam_release_limit_duration_seconds, "histogram of spiderpool agent ipam release limit duration", false)
+	releaseLimitHistogram, err := newMetricFloat64Histogram(ipamReleaseLimitDurationSecondsName, "histogram of spiderpool agent ipam release limit duration", false)
 	if nil != err {
-		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %v", ipam_release_limit_duration_seconds, err)
+		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %w", ipamReleaseLimitDurationSecondsName, err)
 	}
 	ipamReleaseLimitDurationSecondsHistogram = releaseLimitHistogram
 
@@ -488,23 +490,23 @@ func initSpiderpoolAgentReleaseMetrics(ctx context.Context) error {
 
 // initSpiderpoolControllerGCMetrics will init spiderpool-controller IP gc metrics
 func initSpiderpoolControllerGCMetrics(ctx context.Context) error {
-	ipGCTotalCounts, err := newMetricInt64Counter(ip_gc_counts, "spiderpool controller ip gc total counts", false)
+	ipGCTotalCounts, err := newMetricInt64Counter(ipGCCCountsName, "spiderpool controller ip gc total counts", false)
 	if nil != err {
-		return fmt.Errorf("failed to new spiderpool controller metric '%s', error: %v", ip_gc_counts, err)
+		return fmt.Errorf("failed to new spiderpool controller metric '%s', error: %w", ipGCCCountsName, err)
 	}
 	IPGCTotalCounts = ipGCTotalCounts
 	IPGCTotalCounts.Add(ctx, 0)
 
-	ipGCFailureCounts, err := newMetricInt64Counter(ip_gc_failure_counts, "spiderpool controller ip gc total counts", false)
+	ipGCFailureCounts, err := newMetricInt64Counter(ipGCFailureCountsName, "spiderpool controller ip gc total counts", false)
 	if nil != err {
-		return fmt.Errorf("failed to new spiderpool controller metric '%s', error: %v", ip_gc_failure_counts, err)
+		return fmt.Errorf("failed to new spiderpool controller metric '%s', error: %w", ipGCFailureCountsName, err)
 	}
 	IPGCFailureCounts = ipGCFailureCounts
 	ipGCFailureCounts.Add(ctx, 0)
 
-	releaseUpdateIPPoolConflictCounts, err := newMetricInt64Counter(ipam_release_update_ippool_conflict_counts, "spiderpool controller gc release update IPPool conflict counts", false)
+	releaseUpdateIPPoolConflictCounts, err := newMetricInt64Counter(ipamReleaseUpdateIPPoolConflictCountsName, "spiderpool controller gc release update IPPool conflict counts", false)
 	if nil != err {
-		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %v", ipam_release_update_ippool_conflict_counts, err)
+		return fmt.Errorf("failed to new spiderpool agent metric '%s', error: %w", ipamReleaseUpdateIPPoolConflictCountsName, err)
 	}
 	IpamReleaseUpdateIPPoolConflictCounts = releaseUpdateIPPoolConflictCounts
 
@@ -512,41 +514,41 @@ func initSpiderpoolControllerGCMetrics(ctx context.Context) error {
 }
 
 func initSpiderpoolControllerCRMetrics(ctx context.Context) error {
-	err := TotalSubnetCounts.initGauge(total_subnet_counts, "spiderpool total SpiderSubnet counts", false)
+	err := TotalSubnetCounts.initGauge(totalSubnetCountsName, "spiderpool total SpiderSubnet counts", false)
 	if nil != err {
 		return err
 	}
 
-	subnetTotalIPCounts, err := newMetricInt64Counter(subnet_total_ip_counts, "spiderpool single SpiderSubnet corresponding total IP counts", true)
+	subnetTotalIPCounts, err := newMetricInt64Counter(subnetTotalIPCountsName, "spiderpool single SpiderSubnet corresponding total IP counts", true)
 	if nil != err {
-		return fmt.Errorf("failed to new spiderpool controller metric '%s', error: %v", subnet_total_ip_counts, err)
+		return fmt.Errorf("failed to new spiderpool controller metric '%s', error: %w", subnetTotalIPCountsName, err)
 	}
 	SubnetTotalIPCounts = subnetTotalIPCounts
 
-	subnetAvailableIPCounts, err := newMetricInt64Counter(subnet_available_ip_counts, "spiderpool single SpiderSubnet corresponding available IP counts", true)
+	subnetAvailableIPCounts, err := newMetricInt64Counter(subnetAvailableIPCountsName, "spiderpool single SpiderSubnet corresponding available IP counts", true)
 	if nil != err {
-		return fmt.Errorf("failed to new spiderpool controller metric '%s', error: %v", subnet_available_ip_counts, err)
+		return fmt.Errorf("failed to new spiderpool controller metric '%s', error: %w", subnetAvailableIPCountsName, err)
 	}
 	SubnetAvailableIPCounts = subnetAvailableIPCounts
 
-	err = TotalIPPoolCounts.initGauge(total_ippool_counts, "spiderpool total SpiderIPPool counts", false)
+	err = TotalIPPoolCounts.initGauge(totalIPPoolCountsName, "spiderpool total SpiderIPPool counts", false)
 	if nil != err {
 		return err
 	}
 
-	poolTotalIPCounts, err := newMetricInt64Counter(ippool_total_ip_counts, "spiderpool single SpiderIPPool corresponding total IP counts", true)
+	poolTotalIPCounts, err := newMetricInt64Counter(ippoolTotalIPCountsName, "spiderpool single SpiderIPPool corresponding total IP counts", true)
 	if nil != err {
-		return fmt.Errorf("failed to new spiderpool controller metric '%s', error: %v", ippool_total_ip_counts, err)
+		return fmt.Errorf("failed to new spiderpool controller metric '%s', error: %w", ippoolTotalIPCountsName, err)
 	}
 	IPPoolTotalIPCounts = poolTotalIPCounts
 
-	poolAvailableIPCounts, err := newMetricInt64Counter(ippool_available_ip_counts, "spiderpool single SpiderIPPool corresponding available IP counts", true)
+	poolAvailableIPCounts, err := newMetricInt64Counter(ippoolAvailableIPCountsName, "spiderpool single SpiderIPPool corresponding available IP counts", true)
 	if nil != err {
-		return fmt.Errorf("failed to new spiderpool controller metric '%s', error: %v", ippool_available_ip_counts, err)
+		return fmt.Errorf("failed to new spiderpool controller metric '%s', error: %w", ippoolAvailableIPCountsName, err)
 	}
 	IPPoolAvailableIPCounts = poolAvailableIPCounts
 
-	err = SubnetPoolCounts.initGauge(subnet_ippool_counts, "spider subnet corresponding ippools counts", true)
+	err = SubnetPoolCounts.initGauge(subnetIPPoolCountsName, "spider subnet corresponding ippools counts", true)
 	if nil != err {
 		return err
 	}

--- a/pkg/multuscniconfig/multusconfig_validate.go
+++ b/pkg/multuscniconfig/multusconfig_validate.go
@@ -97,7 +97,7 @@ func validateCNIConfig(multusConfig *spiderpoolv2beta1.SpiderMultusConfig) *fiel
 		}
 
 		if multusConfig.Spec.MacvlanConfig.VlanID != nil {
-			if err := validateVlanId(*multusConfig.Spec.MacvlanConfig.VlanID); err != nil {
+			if err := validateVlanID(*multusConfig.Spec.MacvlanConfig.VlanID); err != nil {
 				return field.Invalid(macvlanConfigField, *multusConfig.Spec.MacvlanConfig.VlanID, err.Error())
 			}
 		}
@@ -136,7 +136,7 @@ func validateCNIConfig(multusConfig *spiderpoolv2beta1.SpiderMultusConfig) *fiel
 		}
 
 		if multusConfig.Spec.IPVlanConfig.VlanID != nil {
-			if err := validateVlanId(*multusConfig.Spec.IPVlanConfig.VlanID); err != nil {
+			if err := validateVlanID(*multusConfig.Spec.IPVlanConfig.VlanID); err != nil {
 				return field.Invalid(ipvlanConfigField, *multusConfig.Spec.IPVlanConfig.VlanID, err.Error())
 			}
 		}
@@ -175,7 +175,7 @@ func validateCNIConfig(multusConfig *spiderpoolv2beta1.SpiderMultusConfig) *fiel
 		}
 
 		if multusConfig.Spec.SriovConfig.VlanID != nil {
-			if err := validateVlanId(*multusConfig.Spec.SriovConfig.VlanID); err != nil {
+			if err := validateVlanID(*multusConfig.Spec.SriovConfig.VlanID); err != nil {
 				return field.Invalid(sriovConfigField, *multusConfig.Spec.SriovConfig.VlanID, err.Error())
 			}
 		}
@@ -269,7 +269,7 @@ func validateCNIConfig(multusConfig *spiderpoolv2beta1.SpiderMultusConfig) *fiel
 		}
 
 		if multusConfig.Spec.OvsConfig.VlanTag != nil {
-			if err := validateVlanId(*multusConfig.Spec.OvsConfig.VlanTag); err != nil {
+			if err := validateVlanID(*multusConfig.Spec.OvsConfig.VlanTag); err != nil {
 				return field.Invalid(ovsConfigField, *multusConfig.Spec.OvsConfig.VlanTag, err.Error())
 			}
 		}
@@ -349,9 +349,9 @@ func validateVlanCNIConfig(master []string, bond *spiderpoolv2beta1.BondConfig) 
 	return nil
 }
 
-func validateVlanId(vlanId int32) error {
-	if vlanId < 0 || vlanId > 4094 {
-		return fmt.Errorf("invalid vlanId %v, please make sure vlanId in range [0,4094]", vlanId)
+func validateVlanID(vlanID int32) error {
+	if vlanID < 0 || vlanID > 4094 {
+		return fmt.Errorf("invalid vlanId %v, please make sure vlanId in range [0,4094]", vlanID)
 	}
 	return nil
 }
@@ -366,7 +366,7 @@ func (mcw *MultusConfigWebhook) validateAnnotation(ctx context.Context, multusCo
 				return nil
 			}
 			return field.InternalError(annotationField,
-				fmt.Errorf("failed to retrieve net-attach-def %s/%s, unable to determine conflicts with existing resources. error: %v", namespace, name, err))
+				fmt.Errorf("failed to retrieve net-attach-def %s/%s, unable to determine conflicts with existing resources. error: %w", namespace, name, err))
 		}
 
 		for _, ownerRef := range netAttachDef.OwnerReferences {

--- a/pkg/multuscniconfig/utils.go
+++ b/pkg/multuscniconfig/utils.go
@@ -125,7 +125,7 @@ func ParsePodNetworkAnnotation(podNetworks, defaultNamespace string) ([]*netv1.N
 
 	if strings.HasPrefix(podNetworks, "[{\"") {
 		if err := json.Unmarshal([]byte(podNetworks), &networks); err != nil {
-			return nil, fmt.Errorf("parsePodNetworkAnnotation: failed to parse pod Network Attachment Selection Annotation JSON format: %v", err)
+			return nil, fmt.Errorf("parsePodNetworkAnnotation: failed to parse pod Network Attachment Selection Annotation JSON format: %w", err)
 		}
 	} else {
 		// Comma-delimited list of network attachment object names
@@ -136,7 +136,7 @@ func ParsePodNetworkAnnotation(podNetworks, defaultNamespace string) ([]*netv1.N
 			// Parse network name (i.e. <namespace>/<network name>@<ifname>)
 			netNsName, networkName, netIfName, err := ParsePodNetworkObjectName(item)
 			if err != nil {
-				return nil, fmt.Errorf("parsePodNetworkAnnotation: %v", err)
+				return nil, fmt.Errorf("parsePodNetworkAnnotation: %w", err)
 			}
 
 			networks = append(networks, &netv1.NetworkSelectionElement{
@@ -154,13 +154,13 @@ func ParsePodNetworkAnnotation(podNetworks, defaultNamespace string) ([]*netv1.N
 		if n.MacRequest != "" {
 			// validate MAC address
 			if _, err := net.ParseMAC(n.MacRequest); err != nil {
-				return nil, fmt.Errorf("parsePodNetworkAnnotation: failed to mac: %v", err)
+				return nil, fmt.Errorf("parsePodNetworkAnnotation: failed to mac: %w", err)
 			}
 		}
 		if n.InfinibandGUIDRequest != "" {
 			// validate GUID address
 			if _, err := net.ParseMAC(n.InfinibandGUIDRequest); err != nil {
-				return nil, fmt.Errorf("parsePodNetworkAnnotation: failed to validate infiniband GUID: %v", err)
+				return nil, fmt.Errorf("parsePodNetworkAnnotation: failed to validate infiniband GUID: %w", err)
 			}
 		}
 		if n.IPRequest != nil {
@@ -168,7 +168,7 @@ func ParsePodNetworkAnnotation(podNetworks, defaultNamespace string) ([]*netv1.N
 				// validate IP address
 				if strings.Contains(ip, "/") {
 					if _, _, err := net.ParseCIDR(ip); err != nil {
-						return nil, fmt.Errorf("failed to parse CIDR %q: %v", ip, err)
+						return nil, fmt.Errorf("failed to parse CIDR %q: %w", ip, err)
 					}
 				} else if net.ParseIP(ip) == nil {
 					return nil, fmt.Errorf("failed to parse IP address %q", ip)
@@ -230,7 +230,7 @@ func ParsePodNetworkObjectName(podnetwork string) (string, string, string, error
 	return netNsName, networkName, netIfName, nil
 }
 
-// resourceName returns the appropriate resource name based on the CNI type and configuration
+// ResourceName returns the appropriate resource name based on the CNI type and configuration
 // of the given SpiderMultusConfig.
 func ResourceName(smc *v2beta1.SpiderMultusConfig) string {
 	switch *smc.Spec.CniType {
@@ -261,11 +261,11 @@ func ValidateRdmaResouce(name, namespace, rdmaResourceName string, ippools *v2be
 	}
 
 	if ippools == nil {
-		return fmt.Errorf("No any ippools configured for spidermultusconfig %s/%s", namespace, name)
+		return fmt.Errorf("no any ippools configured for spidermultusconfig %s/%s", namespace, name)
 	}
 
 	if len(ippools.IPv4IPPool)+len(ippools.IPv6IPPool) == 0 {
-		return fmt.Errorf("No any ippools configured for spidermultusconfig %s/%s", namespace, name)
+		return fmt.Errorf("no any ippools configured for spidermultusconfig %s/%s", namespace, name)
 	}
 
 	return nil
@@ -277,11 +277,11 @@ func ValidateNetworkResouce(name, namespace, resourceName string, ippools *v2bet
 	}
 
 	if ippools == nil {
-		return fmt.Errorf("No any ippools configured for spidermultusconfig %s/%s", namespace, name)
+		return fmt.Errorf("no any ippools configured for spidermultusconfig %s/%s", namespace, name)
 	}
 
 	if len(ippools.IPv4IPPool)+len(ippools.IPv6IPPool) == 0 {
-		return fmt.Errorf("No any ippools configured for spidermultusconfig %s/%s", namespace, name)
+		return fmt.Errorf("no any ippools configured for spidermultusconfig %s/%s", namespace, name)
 	}
 
 	return nil

--- a/pkg/namespacemanager/namespace_manager_suite_test.go
+++ b/pkg/namespacemanager/namespace_manager_suite_test.go
@@ -19,11 +19,13 @@ import (
 	"github.com/spidernet-io/spiderpool/pkg/namespacemanager"
 )
 
-var scheme *runtime.Scheme
-var fakeClient client.Client
-var tracker k8stesting.ObjectTracker
-var fakeAPIReader client.Reader
-var nsManager namespacemanager.NamespaceManager
+var (
+	scheme        *runtime.Scheme
+	fakeClient    client.Client
+	tracker       k8stesting.ObjectTracker
+	fakeAPIReader client.Reader
+	nsManager     namespacemanager.NamespaceManager
+)
 
 func TestNamespaceManager(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/networking/networking/mac.go
+++ b/pkg/networking/networking/mac.go
@@ -49,7 +49,6 @@ func OverwriteHwAddress(logger *zap.Logger, netns ns.NetNS, macPrefix, iface str
 		}
 		return netlink.LinkSetHardwareAddr(link, parseMac(hwAddr))
 	})
-
 	if err != nil {
 		logger.Error("failed to OverrideHwAddress", zap.String("hardware address", hwAddr), zap.Error(err))
 		return "", err
@@ -136,7 +135,6 @@ func GetHostVethName(netns ns.NetNS, podVethPairName string) (string, error) {
 		}
 		return nil
 	})
-
 	if err != nil {
 		return "", err
 	}
@@ -160,7 +158,7 @@ func AddStaticNeighborTable(linkIndex int, dstIP net.IP, hwAddress net.HardwareA
 	}
 
 	if err := netlink.NeighAdd(neigh); err != nil && !os.IsExist(err) {
-		return fmt.Errorf("failed to add neigh table: %v ", err)
+		return fmt.Errorf("failed to add neigh table: %w", err)
 	}
 
 	return nil

--- a/pkg/networking/networking/route.go
+++ b/pkg/networking/networking/route.go
@@ -13,9 +13,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var (
-	defaultRulePriority = 1000
-)
+var defaultRulePriority = 1000
 
 // GetRoutesByName return all routes is belonged to specify interface
 // filter by family also
@@ -144,7 +142,7 @@ func AddRoute(logger *zap.Logger, ruleTable, ipFamily int, scope netlink.Scope, 
 
 	if err = netlink.RouteAdd(route); err != nil && !os.IsExist(err) {
 		logger.Error("failed to RouteAdd", zap.String("route", route.String()), zap.Error(err))
-		return fmt.Errorf("failed to add route table(%v): %v", route.String(), err)
+		return fmt.Errorf("failed to add route table(%v): %w", route.String(), err)
 	}
 	return nil
 }
@@ -240,7 +238,7 @@ func moveRouteTable(linkIndex, srcRuleTable, dstRuleTable int, onlyCopyOverlayDe
 			logger.Debug("try to add the route", zap.String("Route", defaultRoute.String()))
 			if err = netlink.RouteAdd(&defaultRoute); err != nil && !os.IsExist(err) {
 				logger.Error("failed to copy overlay default route to hostRuleTable", zap.String("route", defaultRoute.String()), zap.Error(err))
-				return fmt.Errorf("failed to RouteAdd (%+v) to new table: %+v", defaultRoute, err)
+				return fmt.Errorf("failed to RouteAdd (%+v) to new table: %+w", defaultRoute, err)
 			}
 
 			if onlyCopyOverlayDefaultRoute {
@@ -254,7 +252,7 @@ func moveRouteTable(linkIndex, srcRuleTable, dstRuleTable int, onlyCopyOverlayDe
 			logger.Debug("try to delete the route", zap.String("Route", defaultRoute.String()))
 			if err = netlink.RouteDel(&defaultRoute); err != nil {
 				logger.Error("failed to RouteDel in main", zap.String("route", defaultRoute.String()), zap.Error(err))
-				return fmt.Errorf("failed to RouteDel %s in main table: %+v", defaultRoute.String(), err)
+				return fmt.Errorf("failed to RouteDel %s in main table: %+w", defaultRoute.String(), err)
 			}
 			return nil
 		}
@@ -276,7 +274,7 @@ func moveRouteTable(linkIndex, srcRuleTable, dstRuleTable int, onlyCopyOverlayDe
 		}
 		if err = netlink.RouteAdd(&staticRoute); err != nil && !os.IsExist(err) {
 			logger.Error("failed to add the route table", zap.String("route", staticRoute.String()), zap.Error(err))
-			return fmt.Errorf("failed to add the route table (%+v): %+v", route, err)
+			return fmt.Errorf("failed to add the route table (%+v): %+w", route, err)
 		}
 		logger.Debug("MoveRoute to new table successfully", zap.String("Route", staticRoute.String()))
 		return nil
@@ -320,7 +318,7 @@ func moveRouteTable(linkIndex, srcRuleTable, dstRuleTable int, onlyCopyOverlayDe
 
 	if err = netlink.RouteAdd(generatedRoute); err != nil && !os.IsExist(err) {
 		logger.Error("failed to RouteAdd for IPv6 to new table", zap.String("route", route.String()), zap.Error(err))
-		return fmt.Errorf("failed to RouteAdd for IPv6 (%+v) to new table: %+v", route.String(), err)
+		return fmt.Errorf("failed to RouteAdd for IPv6 (%+v) to new table: %+w", route.String(), err)
 	}
 
 	if onlyCopyOverlayDefaultRoute {
@@ -330,7 +328,7 @@ func moveRouteTable(linkIndex, srcRuleTable, dstRuleTable int, onlyCopyOverlayDe
 	logger.Debug("Deleting IPv6 DefaultRoute", zap.String("deletedRoute", deletedRoute.String()))
 	if err := netlink.RouteDel(deletedRoute); err != nil {
 		logger.Error("failed to RouteDel for IPv6", zap.String("Route", route.String()), zap.Error(err))
-		return fmt.Errorf("failed to RouteDel %v for IPv6: %+v", route.String(), err)
+		return fmt.Errorf("failed to RouteDel %v for IPv6: %+w", route.String(), err)
 	}
 
 	return nil

--- a/pkg/networking/networking/sys.go
+++ b/pkg/networking/networking/sys.go
@@ -15,7 +15,7 @@ const (
 	SysBusPciDevicesPath  = "/sys/bus/pci/devices"
 )
 
-func GetPfNameFromVfDeviceId(vfDeviceID string) (string, error) {
+func GetPfNameFromVfDeviceID(vfDeviceID string) (string, error) {
 	pfDeviceID, err := GetPfDeviceIDFromVF(vfDeviceID)
 	if err != nil {
 		return "", err
@@ -26,20 +26,20 @@ func GetPfNameFromVfDeviceId(vfDeviceID string) (string, error) {
 
 func GetPfDeviceIDFromVF(vfDeviceID string) (string, error) {
 	// First try the traditional approach via sysfs (works in host namespace)
-	vf_physfn := path.Join(SysBusPciDevicesPath, vfDeviceID, "physfn")
-	physfnInfo, err := os.Lstat(vf_physfn)
+	vfPhysfn := path.Join(SysBusPciDevicesPath, vfDeviceID, "physfn")
+	physfnInfo, err := os.Lstat(vfPhysfn)
 	if err != nil {
-		return "", fmt.Errorf("failed to get physfn info for VF %s: %v", vfDeviceID, err)
+		return "", fmt.Errorf("failed to get physfn info for VF %s: %w", vfDeviceID, err)
 	}
 
 	if physfnInfo.Mode()&os.ModeSymlink == 0 {
-		return "", fmt.Errorf("physfn %s is not a symlink", vf_physfn)
+		return "", fmt.Errorf("physfn %s is not a symlink", vfPhysfn)
 	}
 
 	// Read the path that the symlink points to
-	physfnPath, err := os.Readlink(vf_physfn)
+	physfnPath, err := os.Readlink(vfPhysfn)
 	if err != nil {
-		return "", fmt.Errorf("failed to read physfn symlink for vf %s: %v", vfDeviceID, err)
+		return "", fmt.Errorf("failed to read physfn symlink for vf %s: %w", vfDeviceID, err)
 	}
 
 	return filepath.Base(physfnPath), nil
@@ -50,7 +50,7 @@ func GetPfNameFromPfDeviceID(pfDeviceID string) (string, error) {
 	pfNetDir := path.Join(SysBusPciDevicesPath, pfDeviceID, "net")
 	dirs, err := os.ReadDir(pfNetDir)
 	if err != nil {
-		return "", fmt.Errorf("failed to read net directory for pf %s: %v", pfDeviceID, err)
+		return "", fmt.Errorf("failed to read net directory for pf %s: %w", pfDeviceID, err)
 	}
 
 	if len(dirs) == 0 {

--- a/pkg/networking/sysctl/sysctl.go
+++ b/pkg/networking/sysctl/sysctl.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/utils/sysctl"
-	cnisysctl "github.com/containernetworking/plugins/pkg/utils/sysctl"
 )
 
 var (
@@ -49,11 +48,13 @@ var DefaultSysctlConfig = []struct {
 		Name:   "net.ipv4.conf.all.arp_notify",
 		Value:  "1",
 		IsIPv4: true,
-	}, {
+	},
+	{
 		Name:   "net.ipv4.conf.all.forwarding",
 		Value:  "1",
 		IsIPv4: true,
-	}, {
+	},
+	{
 		Name:   "net.ipv6.conf.all.forwarding",
 		Value:  "1",
 		IsIPv6: true,
@@ -66,7 +67,7 @@ var DefaultSysctlConfig = []struct {
 	},
 }
 
-// SysctlRPFilter set rp_filter value for host netns and specify netns
+// SetSysctlRPFilter sets rp_filter value for host netns and specify netns.
 func SetSysctlRPFilter(netns ns.NetNS, value int32) error {
 	// set pod rp_filter
 	return netns.Do(func(_ ns.NetNS) error {
@@ -102,7 +103,7 @@ func EnableIPv6ForInterfaces(ifaces []string) error {
 		ipv6SysctlValueName := fmt.Sprintf(disableIPv6SysctlTemplate, iface)
 
 		// Read current sysctl value
-		value, err := cnisysctl.Sysctl(ipv6SysctlValueName)
+		value, err := sysctl.Sysctl(ipv6SysctlValueName)
 		if err != nil {
 			continue
 		}
@@ -111,9 +112,9 @@ func EnableIPv6ForInterfaces(ifaces []string) error {
 		}
 
 		// Write sysctl to enable IPv6
-		_, err = cnisysctl.Sysctl(ipv6SysctlValueName, "0")
+		_, err = sysctl.Sysctl(ipv6SysctlValueName, "0")
 		if err != nil {
-			return fmt.Errorf("failed to enable IPv6 for interface %q (%s=%s): %v", iface, ipv6SysctlValueName, value, err)
+			return fmt.Errorf("failed to enable IPv6 for interface %q (%s=%s): %w", iface, ipv6SysctlValueName, value, err)
 		}
 	}
 	return nil

--- a/pkg/nodemanager/node_manager_suite_test.go
+++ b/pkg/nodemanager/node_manager_suite_test.go
@@ -19,11 +19,13 @@ import (
 	"github.com/spidernet-io/spiderpool/pkg/nodemanager"
 )
 
-var scheme *runtime.Scheme
-var fakeClient client.Client
-var tracker k8stesting.ObjectTracker
-var fakeAPIReader client.Reader
-var nodeManager nodemanager.NodeManager
+var (
+	scheme        *runtime.Scheme
+	fakeClient    client.Client
+	tracker       k8stesting.ObjectTracker
+	fakeAPIReader client.Reader
+	nodeManager   nodemanager.NodeManager
+)
 
 func TestNodeManager(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/openapi/webhook_checker.go
+++ b/pkg/openapi/webhook_checker.go
@@ -37,7 +37,7 @@ func WebhookHealthyCheck(httpClient *http.Client, webhookPort string, url *strin
 
 	req, err := http.NewRequest(http.MethodGet, webhookMutateURL, nil)
 	if nil != err {
-		return fmt.Errorf("failed to new webhook https request, error: %v", err)
+		return fmt.Errorf("failed to new webhook https request, error: %w", err)
 	}
 
 	resp, err := httpClient.Do(req)

--- a/pkg/podmanager/pod_manager.go
+++ b/pkg/podmanager/pod_manager.go
@@ -82,7 +82,7 @@ func (pm *podManager) ListPods(ctx context.Context, cached bool, opts ...client.
 func (pm *podManager) GetPodTopController(ctx context.Context, pod *corev1.Pod) (types.PodTopController, error) {
 	logger := logutils.FromContext(ctx)
 
-	var ownerErr = fmt.Errorf("failed to get pod '%s/%s' owner", pod.Namespace, pod.Name)
+	ownerErr := fmt.Errorf("failed to get pod '%s/%s' owner", pod.Namespace, pod.Name)
 
 	podOwner := metav1.GetControllerOf(pod)
 	if podOwner == nil {
@@ -122,7 +122,7 @@ func (pm *podManager) GetPodTopController(ctx context.Context, pod *corev1.Pod) 
 		var replicaset appsv1.ReplicaSet
 		err := pm.client.Get(ctx, namespacedName, &replicaset)
 		if nil != err {
-			return types.PodTopController{}, fmt.Errorf("%w: %v", ownerErr, err)
+			return types.PodTopController{}, fmt.Errorf("%w: %w", ownerErr, err)
 		}
 
 		replicasetOwner := metav1.GetControllerOf(&replicaset)
@@ -130,7 +130,7 @@ func (pm *podManager) GetPodTopController(ctx context.Context, pod *corev1.Pod) 
 			var deployment appsv1.Deployment
 			err = pm.client.Get(ctx, apitypes.NamespacedName{Namespace: replicaset.Namespace, Name: replicasetOwner.Name}, &deployment)
 			if nil != err {
-				return types.PodTopController{}, fmt.Errorf("%w: %v", ownerErr, err)
+				return types.PodTopController{}, fmt.Errorf("%w: %w", ownerErr, err)
 			}
 			return types.PodTopController{
 				AppNamespacedName: types.AppNamespacedName{
@@ -160,14 +160,14 @@ func (pm *podManager) GetPodTopController(ctx context.Context, pod *corev1.Pod) 
 		var job batchv1.Job
 		err := pm.client.Get(ctx, namespacedName, &job)
 		if nil != err {
-			return types.PodTopController{}, fmt.Errorf("%w: %v", ownerErr, err)
+			return types.PodTopController{}, fmt.Errorf("%w: %w", ownerErr, err)
 		}
 		jobOwner := metav1.GetControllerOf(&job)
 		if jobOwner != nil && jobOwner.APIVersion == batchv1.SchemeGroupVersion.String() && jobOwner.Kind == constant.KindCronJob {
 			var cronJob batchv1.CronJob
 			err = pm.client.Get(ctx, apitypes.NamespacedName{Namespace: job.Namespace, Name: jobOwner.Name}, &cronJob)
 			if nil != err {
-				return types.PodTopController{}, fmt.Errorf("%w: %v", ownerErr, err)
+				return types.PodTopController{}, fmt.Errorf("%w: %w", ownerErr, err)
 			}
 			return types.PodTopController{
 				AppNamespacedName: types.AppNamespacedName{
@@ -196,7 +196,7 @@ func (pm *podManager) GetPodTopController(ctx context.Context, pod *corev1.Pod) 
 		var daemonSet appsv1.DaemonSet
 		err := pm.client.Get(ctx, namespacedName, &daemonSet)
 		if nil != err {
-			return types.PodTopController{}, fmt.Errorf("%w: %v", ownerErr, err)
+			return types.PodTopController{}, fmt.Errorf("%w: %w", ownerErr, err)
 		}
 		return types.PodTopController{
 			AppNamespacedName: types.AppNamespacedName{
@@ -214,7 +214,7 @@ func (pm *podManager) GetPodTopController(ctx context.Context, pod *corev1.Pod) 
 		var statefulSet appsv1.StatefulSet
 		err := pm.client.Get(ctx, namespacedName, &statefulSet)
 		if nil != err {
-			return types.PodTopController{}, fmt.Errorf("%w: %v", ownerErr, err)
+			return types.PodTopController{}, fmt.Errorf("%w: %w", ownerErr, err)
 		}
 		return types.PodTopController{
 			AppNamespacedName: types.AppNamespacedName{

--- a/pkg/podmanager/pod_manager_suite_test.go
+++ b/pkg/podmanager/pod_manager_suite_test.go
@@ -18,11 +18,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-var scheme *runtime.Scheme
-var fakeClient client.Client
-var tracker k8stesting.ObjectTracker
-var fakeAPIReader client.Reader
-var podManager podmanager.PodManager
+var (
+	scheme        *runtime.Scheme
+	fakeClient    client.Client
+	tracker       k8stesting.ObjectTracker
+	fakeAPIReader client.Reader
+	podManager    podmanager.PodManager
+)
 
 func TestPodManager(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -57,5 +59,4 @@ var _ = BeforeSuite(func() {
 		fakeAPIReader,
 	)
 	Expect(err).NotTo(HaveOccurred())
-
 })

--- a/pkg/podmanager/utils.go
+++ b/pkg/podmanager/utils.go
@@ -89,7 +89,7 @@ func podNetworkMutatingWebhook(spiderClient crdclientset.Interface, pod *corev1.
 
 		selector, err := metav1.LabelSelectorAsSelector(&labelSelector)
 		if err != nil {
-			return fmt.Errorf("failed to create label selector: %v", err)
+			return fmt.Errorf("failed to create label selector: %w", err)
 		}
 
 		multusConfigs, err := spiderClient.SpiderpoolV2beta1().SpiderMultusConfigs("").List(context.TODO(), metav1.ListOptions{
@@ -100,7 +100,7 @@ func podNetworkMutatingWebhook(spiderClient crdclientset.Interface, pod *corev1.
 		}
 
 		if len(multusConfigs.Items) == 0 {
-			return fmt.Errorf("No spidermultusconfigs with annotation: %v:%v found", anno, multusLabelValue)
+			return fmt.Errorf("no spidermultusconfigs with annotation: %v:%v found", anno, multusLabelValue)
 		}
 
 		return InjectPodNetwork(pod, *multusConfigs)
@@ -109,7 +109,7 @@ func podNetworkMutatingWebhook(spiderClient crdclientset.Interface, pod *corev1.
 	return nil
 }
 
-// injectPodNetwork injects network configurations into the pod based on the provided SpiderMultusConfigs.
+// InjectPodNetwork injects network configurations into the pod based on the provided SpiderMultusConfigs.
 // It checks for CNI type consistency, updates the pod's network attachment annotations,
 // and prepares a map of resources to be injected.
 //
@@ -151,7 +151,7 @@ func InjectPodNetwork(pod *corev1.Pod, multusConfigs v2beta1.SpiderMultusConfigL
 	return nil
 }
 
-// injectRdmaResourceToPod injects RDMA resources into the pod's containers.
+// InjectRdmaResourceToPod injects RDMA resources into the pod's containers.
 // It checks each container for existing resource requests/limits and updates
 // the resourceMap accordingly. If a resource is not found in any container,
 // it is injected into the first container's resource requests.

--- a/pkg/podmanager/utils_test.go
+++ b/pkg/podmanager/utils_test.go
@@ -181,7 +181,7 @@ var _ = Describe("PodManager utils", Label("pod_manager_utils_test"), func() {
 			}
 			err := podmanager.InjectPodNetwork(pod, multusConfigs)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("No any ippools configured"))
+			Expect(err.Error()).To(ContainSubstring("no any ippools configured"))
 		})
 
 		It("should preserve existing resources in the Pod", func() {
@@ -239,9 +239,7 @@ var _ = Describe("PodManager utils", Label("pod_manager_utils_test"), func() {
 	})
 
 	Describe("DoValidateRdmaResouce", func() {
-		var (
-			mc v2beta1.SpiderMultusConfig
-		)
+		var mc v2beta1.SpiderMultusConfig
 
 		Context("when CNI type is Macvlan", func() {
 			It("should not return an error for valid RDMA configuration", func() {

--- a/pkg/podownercache/pod_owner_cache_test.go
+++ b/pkg/podownercache/pod_owner_cache_test.go
@@ -12,7 +12,6 @@ import (
 	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -33,10 +32,10 @@ func TestPodOwnerCache(t *testing.T) {
 	informer := factory.Core().V1().Pods().Informer()
 
 	pod := &corev1.Pod{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-pod",
 			Namespace: "test-ns",
-			OwnerReferences: []v1.OwnerReference{
+			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: "apps/v1",
 					Kind:       "ReplicaSet",
@@ -60,7 +59,7 @@ func TestPodOwnerCache(t *testing.T) {
 	}
 
 	noOwnerPod := &corev1.Pod{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-pod-2",
 			Namespace: "test-ns",
 			Annotations: map[string]string{
@@ -103,11 +102,11 @@ func TestPodOwnerCache(t *testing.T) {
 	}
 
 	// case add
-	_, err = fakeCli.CoreV1().Pods("test-ns").Create(context.Background(), pod, v1.CreateOptions{})
+	_, err = fakeCli.CoreV1().Pods("test-ns").Create(context.Background(), pod, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = fakeCli.CoreV1().Pods("test-ns").Create(context.Background(), noOwnerPod, v1.CreateOptions{})
+	_, err = fakeCli.CoreV1().Pods("test-ns").Create(context.Background(), noOwnerPod, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,7 +127,7 @@ func TestPodOwnerCache(t *testing.T) {
 	}
 
 	// case update
-	_, err = fakeCli.CoreV1().Pods("test-ns").Update(context.Background(), pod, v1.UpdateOptions{})
+	_, err = fakeCli.CoreV1().Pods("test-ns").Update(context.Background(), pod, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,7 +141,7 @@ func TestPodOwnerCache(t *testing.T) {
 	}
 
 	// case delete
-	err = fakeCli.CoreV1().Pods("test-ns").Delete(context.Background(), "test-pod", v1.DeleteOptions{})
+	err = fakeCli.CoreV1().Pods("test-ns").Delete(context.Background(), "test-pod", metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatal("res is nil")
 	}
@@ -162,14 +161,14 @@ func TestPodOwnerCache(t *testing.T) {
 func getMockObjs() []client.Object {
 	return []client.Object{
 		&appv1.ReplicaSet{
-			TypeMeta: v1.TypeMeta{
+			TypeMeta: metav1.TypeMeta{
 				Kind:       "ReplicaSet",
 				APIVersion: "apps/v1",
 			},
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-rs",
 				Namespace: "test-ns",
-				OwnerReferences: []v1.OwnerReference{
+				OwnerReferences: []metav1.OwnerReference{
 					{
 						APIVersion: "apps/v1",
 						Kind:       "Deployment",
@@ -181,11 +180,11 @@ func getMockObjs() []client.Object {
 		},
 
 		&appv1.Deployment{
-			TypeMeta: v1.TypeMeta{
+			TypeMeta: metav1.TypeMeta{
 				Kind:       "Deployment",
 				APIVersion: "apps/v1",
 			},
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-deployment",
 				Namespace: "test-ns",
 			},

--- a/pkg/rdmametrics/ethtool/ethtool.go
+++ b/pkg/rdmametrics/ethtool/ethtool.go
@@ -1,6 +1,5 @@
 // Copyright 2024 Authors of spidernet-io
 // SPDX-License-Identifier: Apache-2.0
-
 package ethtool
 
 import (

--- a/pkg/rdmametrics/metrics.go
+++ b/pkg/rdmametrics/metrics.go
@@ -82,7 +82,8 @@ var (
 		"tx_discards":                     "The number of packets discarded by the device.",
 		"rx_pause":                        "The number of packets dropped by the device.",
 		"tx_pause":                        "The number of packets dropped by the device.",
-		"device_tos":                      "RDMA device traffic class (TOS) value."}
+		"device_tos":                      "RDMA device traffic class (TOS) value.",
+	}
 )
 
 type GetObservable func(string) (metric.Int64ObservableCounter, bool)
@@ -99,8 +100,8 @@ type NetlinkImpl struct {
 
 type RDMADevice struct {
 	NetDevName   string
-	NodeGuid     string
-	SysImageGuid string
+	NodeGUID     string
+	SysImageGUID string
 	IsRoot       bool
 }
 
@@ -300,8 +301,8 @@ func (e *exporter) updateUnregisteredMetrics(unRegistrationMetric []string) {
 
 func (e *exporter) processNetNS(netns NetnsItem,
 	vfToPfNameMap map[string]string,
-	observer metric.Observer, getObservable GetObservable) error {
-
+	observer metric.Observer, getObservable GetObservable,
+) error {
 	list := make([]oteltype.Metrics, 0)
 
 	err := e.netns(netns, func() error {
@@ -334,8 +335,8 @@ func (e *exporter) processNetNS(netns NetnsItem,
 				e.nodeName,
 				attribute.String("ifname", ifName),
 				attribute.String("net_dev_name", deviceInfo.NetDevName),
-				attribute.String("node_guid", deviceInfo.NodeGuid),
-				attribute.String("sys_image_guid", deviceInfo.SysImageGuid),
+				attribute.String("node_guid", deviceInfo.NodeGUID),
+				attribute.String("sys_image_guid", deviceInfo.SysImageGUID),
 				attribute.Bool("is_root", deviceInfo.IsRoot),
 			}
 			busInfo, err := e.ethtool.BusInfo(deviceInfo.NetDevName)
@@ -457,8 +458,8 @@ func getIPToPodMap(ctx context.Context, cli client.Client) (map[string]types.Nam
 	return res, err
 }
 
-// getNodeGuidNetDeviceNameMap get map of node guid to rdma name
-func getNodeGuidNetDeviceNameMap(nl NetlinkImpl) (map[string]string, error) {
+// getNodeGUIDNetDeviceNameMap get map of node guid to rdma name
+func getNodeGUIDNetDeviceNameMap(nl NetlinkImpl) (map[string]string, error) {
 	list, err := getIfnameNetDevMap(nl)
 	if err != nil {
 		return nil, err
@@ -466,7 +467,7 @@ func getNodeGuidNetDeviceNameMap(nl NetlinkImpl) (map[string]string, error) {
 	res := make(map[string]string)
 	for _, item := range list {
 		if item.IsRoot {
-			res[item.NodeGuid] = item.NetDevName
+			res[item.NodeGUID] = item.NetDevName
 		}
 	}
 	return res, nil
@@ -552,8 +553,8 @@ func getIfnameNetDevMap(nl NetlinkImpl) (map[string]RDMADevice, error) {
 		if devName, ok := netDevHardwareAddrMap[guid]; ok {
 			res[v.Attrs.Name] = RDMADevice{
 				NetDevName:   devName,
-				NodeGuid:     v.Attrs.NodeGuid,
-				SysImageGuid: v.Attrs.SysImageGuid,
+				NodeGUID:     v.Attrs.NodeGuid,
+				SysImageGUID: v.Attrs.SysImageGuid,
 				IsRoot:       v.Attrs.NodeGuid == v.Attrs.SysImageGuid,
 			}
 			continue
@@ -565,8 +566,8 @@ func getIfnameNetDevMap(nl NetlinkImpl) (map[string]RDMADevice, error) {
 			if devName, ok := netDevHardwareAddrMap[roceHardwareAddr]; ok {
 				res[v.Attrs.Name] = RDMADevice{
 					NetDevName:   devName,
-					NodeGuid:     v.Attrs.NodeGuid,
-					SysImageGuid: v.Attrs.SysImageGuid,
+					NodeGUID:     v.Attrs.NodeGuid,
+					SysImageGUID: v.Attrs.SysImageGuid,
 					IsRoot:       v.Attrs.NodeGuid == v.Attrs.SysImageGuid,
 				}
 			}

--- a/pkg/rdmametrics/metrics_test.go
+++ b/pkg/rdmametrics/metrics_test.go
@@ -1029,7 +1029,7 @@ func TestGetNodeGuidNetDeviceNameMap(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := getNodeGuidNetDeviceNameMap(tt.nl)
+			got, err := getNodeGUIDNetDeviceNameMap(tt.nl)
 			if (err != nil) != tt.expErr {
 				t.Errorf("expected error: %v, but got: %v", tt.expErr, err)
 			}
@@ -1115,7 +1115,7 @@ func TestGetVfToPfNameMapAt(t *testing.T) {
 			name: "empty directory",
 			setup: func(tmpDir string) string {
 				devicesRoot := filepath.Join(tmpDir, "devices")
-				_ = os.MkdirAll(devicesRoot, 0755)
+				_ = os.MkdirAll(devicesRoot, 0o755)
 				return devicesRoot
 			},
 			expected: map[string]string{},
@@ -1129,9 +1129,9 @@ func TestGetVfToPfNameMapAt(t *testing.T) {
 				pfPath := filepath.Join(pciRoot, "0000:00:02.0")
 				pfNetDir := filepath.Join(pfPath, "net")
 
-				_ = os.MkdirAll(vfPath, 0755)
-				_ = os.MkdirAll(pfNetDir, 0755)
-				_ = os.MkdirAll(filepath.Join(pfNetDir, "eth0"), 0755)
+				_ = os.MkdirAll(vfPath, 0o755)
+				_ = os.MkdirAll(pfNetDir, 0o755)
+				_ = os.MkdirAll(filepath.Join(pfNetDir, "eth0"), 0o755)
 				_ = os.Symlink(pfPath, filepath.Join(vfPath, "physfn"))
 
 				return devicesRoot
@@ -1147,13 +1147,13 @@ func TestGetVfToPfNameMapAt(t *testing.T) {
 				pci1Root := filepath.Join(devicesRoot, "pci0000:00")
 				pf1Path := filepath.Join(pci1Root, "0000:00:02.0")
 				pf1NetDir := filepath.Join(pf1Path, "net")
-				_ = os.MkdirAll(pf1NetDir, 0755)
-				_ = os.MkdirAll(filepath.Join(pf1NetDir, "eth0"), 0755)
+				_ = os.MkdirAll(pf1NetDir, 0o755)
+				_ = os.MkdirAll(filepath.Join(pf1NetDir, "eth0"), 0o755)
 
 				vf1Path := filepath.Join(pci1Root, "0000:00:02.1")
 				vf2Path := filepath.Join(pci1Root, "0000:00:02.2")
-				_ = os.MkdirAll(vf1Path, 0755)
-				_ = os.MkdirAll(vf2Path, 0755)
+				_ = os.MkdirAll(vf1Path, 0o755)
+				_ = os.MkdirAll(vf2Path, 0o755)
 				_ = os.Symlink(pf1Path, filepath.Join(vf1Path, "physfn"))
 				_ = os.Symlink(pf1Path, filepath.Join(vf2Path, "physfn"))
 
@@ -1161,11 +1161,11 @@ func TestGetVfToPfNameMapAt(t *testing.T) {
 				pci2Root := filepath.Join(devicesRoot, "pci0001:00")
 				pf2Path := filepath.Join(pci2Root, "0001:00:03.0")
 				pf2NetDir := filepath.Join(pf2Path, "net")
-				_ = os.MkdirAll(pf2NetDir, 0755)
-				_ = os.MkdirAll(filepath.Join(pf2NetDir, "eth1"), 0755)
+				_ = os.MkdirAll(pf2NetDir, 0o755)
+				_ = os.MkdirAll(filepath.Join(pf2NetDir, "eth1"), 0o755)
 
 				vf3Path := filepath.Join(pci2Root, "0001:00:03.1")
-				_ = os.MkdirAll(vf3Path, 0755)
+				_ = os.MkdirAll(vf3Path, 0o755)
 				_ = os.Symlink(pf2Path, filepath.Join(vf3Path, "physfn"))
 
 				return devicesRoot
@@ -1182,7 +1182,7 @@ func TestGetVfToPfNameMapAt(t *testing.T) {
 				devicesRoot := filepath.Join(tmpDir, "devices")
 				pciRoot := filepath.Join(devicesRoot, "pci0000:00")
 				devicePath := filepath.Join(pciRoot, "0000:00:02.0")
-				_ = os.MkdirAll(devicePath, 0755)
+				_ = os.MkdirAll(devicePath, 0o755)
 				return devicesRoot
 			},
 			expected: map[string]string{},
@@ -1193,7 +1193,7 @@ func TestGetVfToPfNameMapAt(t *testing.T) {
 				devicesRoot := filepath.Join(tmpDir, "devices")
 				pciRoot := filepath.Join(devicesRoot, "pci0000:00")
 				vfPath := filepath.Join(pciRoot, "0000:00:02.1")
-				_ = os.MkdirAll(vfPath, 0755)
+				_ = os.MkdirAll(vfPath, 0o755)
 				_ = os.Symlink(filepath.Join(tmpDir, "nonexistent"), filepath.Join(vfPath, "physfn"))
 				return devicesRoot
 			},
@@ -1206,8 +1206,8 @@ func TestGetVfToPfNameMapAt(t *testing.T) {
 				pciRoot := filepath.Join(devicesRoot, "pci0000:00")
 				vfPath := filepath.Join(pciRoot, "0000:00:02.1")
 				pfPath := filepath.Join(pciRoot, "0000:00:02.0")
-				_ = os.MkdirAll(vfPath, 0755)
-				_ = os.MkdirAll(pfPath, 0755)
+				_ = os.MkdirAll(vfPath, 0o755)
+				_ = os.MkdirAll(pfPath, 0o755)
 				_ = os.Symlink(pfPath, filepath.Join(vfPath, "physfn"))
 				return devicesRoot
 			},
@@ -1223,14 +1223,14 @@ func TestGetVfToPfNameMapAt(t *testing.T) {
 				validVfPath := filepath.Join(pciRoot, "0000:00:02.1")
 				validPfPath := filepath.Join(pciRoot, "0000:00:02.0")
 				validPfNetDir := filepath.Join(validPfPath, "net")
-				_ = os.MkdirAll(validVfPath, 0755)
-				_ = os.MkdirAll(validPfNetDir, 0755)
-				_ = os.MkdirAll(filepath.Join(validPfNetDir, "eth0"), 0755)
+				_ = os.MkdirAll(validVfPath, 0o755)
+				_ = os.MkdirAll(validPfNetDir, 0o755)
+				_ = os.MkdirAll(filepath.Join(validPfNetDir, "eth0"), 0o755)
 				_ = os.Symlink(validPfPath, filepath.Join(validVfPath, "physfn"))
 
 				// 无效的VF（损坏的符号链接）
 				invalidVfPath := filepath.Join(pciRoot, "0000:00:03.1")
-				_ = os.MkdirAll(invalidVfPath, 0755)
+				_ = os.MkdirAll(invalidVfPath, 0o755)
 				_ = os.Symlink(filepath.Join(tmpDir, "nonexistent"), filepath.Join(invalidVfPath, "physfn"))
 
 				return devicesRoot
@@ -1246,9 +1246,9 @@ func TestGetVfToPfNameMapAt(t *testing.T) {
 				pfPath := filepath.Join(pciRoot, "0000:01:00.0")
 				pfNetDir := filepath.Join(pfPath, "net")
 
-				_ = os.MkdirAll(nestedVfPath, 0755)
-				_ = os.MkdirAll(pfNetDir, 0755)
-				_ = os.MkdirAll(filepath.Join(pfNetDir, "eth0"), 0755)
+				_ = os.MkdirAll(nestedVfPath, 0o755)
+				_ = os.MkdirAll(pfNetDir, 0o755)
+				_ = os.MkdirAll(filepath.Join(pfNetDir, "eth0"), 0o755)
 				_ = os.Symlink(pfPath, filepath.Join(nestedVfPath, "physfn"))
 
 				return devicesRoot

--- a/pkg/rdmametrics/tos.go
+++ b/pkg/rdmametrics/tos.go
@@ -18,8 +18,10 @@ type DeviceTrafficClass struct {
 
 const prefix = "Global tclass="
 
-var statFunc = os.Stat
-var readFileFunc = os.ReadFile
+var (
+	statFunc     = os.Stat
+	readFileFunc = os.ReadFile
+)
 
 func GetDeviceTrafficClass(impl NetlinkImpl) ([]DeviceTrafficClass, error) {
 	m, err := getIfnameNetDevMap(impl)

--- a/pkg/rdmametrics/tos_test.go
+++ b/pkg/rdmametrics/tos_test.go
@@ -4,11 +4,12 @@
 package rdmametrics
 
 import (
-	"github.com/vishvananda/netlink"
 	"net"
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/vishvananda/netlink"
 )
 
 // Label(K00002)

--- a/pkg/reservedipmanager/reservedip_manager_suite_test.go
+++ b/pkg/reservedipmanager/reservedip_manager_suite_test.go
@@ -21,12 +21,14 @@ import (
 	"github.com/spidernet-io/spiderpool/pkg/reservedipmanager"
 )
 
-var scheme *runtime.Scheme
-var fakeClient client.Client
-var tracker k8stesting.ObjectTracker
-var fakeAPIReader client.Reader
-var rIPManager reservedipmanager.ReservedIPManager
-var rIPWebhook *reservedipmanager.ReservedIPWebhook
+var (
+	scheme        *runtime.Scheme
+	fakeClient    client.Client
+	tracker       k8stesting.ObjectTracker
+	fakeAPIReader client.Reader
+	rIPManager    reservedipmanager.ReservedIPManager
+	rIPWebhook    *reservedipmanager.ReservedIPWebhook
+)
 
 func TestReservedIPManager(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/reservedipmanager/reservedip_mutate.go
+++ b/pkg/reservedipmanager/reservedip_mutate.go
@@ -46,7 +46,7 @@ func (rw *ReservedIPWebhook) mutateReservedIP(ctx context.Context, rIP *spiderpo
 	if len(rIP.Spec.IPs) > 1 {
 		mergedIPs, err := spiderpoolip.MergeIPRanges(*rIP.Spec.IPVersion, rIP.Spec.IPs)
 		if err != nil {
-			return fmt.Errorf("failed to merge 'spec.ips': %v", err)
+			return fmt.Errorf("failed to merge 'spec.ips': %w", err)
 		}
 
 		ips := rIP.Spec.IPs

--- a/pkg/reservedipmanager/reservedip_webhook.go
+++ b/pkg/reservedipmanager/reservedip_webhook.go
@@ -52,7 +52,7 @@ func (rw *ReservedIPWebhook) Default(ctx context.Context, obj runtime.Object) er
 	logger.Sugar().Debugf("Request ReservedIP: %+v", *rIP)
 
 	if err := rw.mutateReservedIP(logutils.IntoContext(ctx, logger), rIP); err != nil {
-		logger.Sugar().Errorf("Failed to mutate ReservedIP: %v", err)
+		logger.Sugar().Errorf("Failed to mutate ReservedIP: %w", err)
 	}
 
 	return nil
@@ -72,7 +72,7 @@ func (rw *ReservedIPWebhook) ValidateCreate(ctx context.Context, obj runtime.Obj
 	logger.Sugar().Debugf("Request ReservedIP: %+v", *rIP)
 
 	if errs := rw.validateCreateReservedIP(logutils.IntoContext(ctx, logger), rIP); len(errs) != 0 {
-		logger.Sugar().Errorf("Failed to create ReservedIP: %v", errs.ToAggregate().Error())
+		logger.Sugar().Errorf("Failed to create ReservedIP: %w", errs.ToAggregate().Error())
 		return nil, apierrors.NewInvalid(
 			schema.GroupKind{Group: constant.SpiderpoolAPIGroup, Kind: constant.KindSpiderReservedIP},
 			rIP.Name,
@@ -109,7 +109,7 @@ func (rw *ReservedIPWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj 
 	}
 
 	if errs := rw.validateUpdateReservedIP(logutils.IntoContext(ctx, logger), oldRIP, newRIP); len(errs) != 0 {
-		logger.Sugar().Errorf("Failed to update ReservedIP: %v", errs.ToAggregate().Error())
+		logger.Sugar().Errorf("Failed to update ReservedIP: %w", errs.ToAggregate().Error())
 		return nil, apierrors.NewInvalid(
 			schema.GroupKind{Group: constant.SpiderpoolAPIGroup, Kind: constant.KindSpiderReservedIP},
 			newRIP.Name,

--- a/pkg/statefulsetmanager/sts_manager_suite_test.go
+++ b/pkg/statefulsetmanager/sts_manager_suite_test.go
@@ -19,11 +19,13 @@ import (
 	"github.com/spidernet-io/spiderpool/pkg/statefulsetmanager"
 )
 
-var scheme *runtime.Scheme
-var fakeClient client.Client
-var tracker k8stesting.ObjectTracker
-var fakeAPIReader client.Reader
-var stsManager statefulsetmanager.StatefulSetManager
+var (
+	scheme        *runtime.Scheme
+	fakeClient    client.Client
+	tracker       k8stesting.ObjectTracker
+	fakeAPIReader client.Reader
+	stsManager    statefulsetmanager.StatefulSetManager
+)
 
 func TestStatefulSetManager(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/subnetmanager/subnet_informer_test.go
+++ b/pkg/subnetmanager/subnet_informer_test.go
@@ -369,6 +369,5 @@ var _ = Describe("SubnetController", Label("subnet_controller_test"), func() {
 				g.Expect(subnetR.Status.ControlledIPPools).To(BeNil())
 			}).Should(Succeed())
 		})
-
 	})
 })

--- a/pkg/subnetmanager/subnet_manager_suite_test.go
+++ b/pkg/subnetmanager/subnet_manager_suite_test.go
@@ -28,17 +28,21 @@ import (
 	"github.com/spidernet-io/spiderpool/pkg/subnetmanager"
 )
 
-var mockCtrl *gomock.Controller
-var mockLeaderElector *electionmock.MockSpiderLeaseElector
-var mockRIPManager *reservedipmanagermock.MockReservedIPManager
+var (
+	mockCtrl          *gomock.Controller
+	mockLeaderElector *electionmock.MockSpiderLeaseElector
+	mockRIPManager    *reservedipmanagermock.MockReservedIPManager
+)
 
-var scheme *runtime.Scheme
-var fakeClient client.Client
-var tracker k8stesting.ObjectTracker
-var fakeAPIReader client.Reader
-var fakeDynamicClient dynamic.Interface
-var subnetManager subnetmanager.SubnetManager
-var subnetWebhook *subnetmanager.SubnetWebhook
+var (
+	scheme            *runtime.Scheme
+	fakeClient        client.Client
+	tracker           k8stesting.ObjectTracker
+	fakeAPIReader     client.Reader
+	fakeDynamicClient dynamic.Interface
+	subnetManager     subnetmanager.SubnetManager
+	subnetWebhook     *subnetmanager.SubnetWebhook
+)
 
 func TestSubnetManager(t *testing.T) {
 	mockCtrl = gomock.NewController(t)

--- a/pkg/subnetmanager/subnet_mutate.go
+++ b/pkg/subnetmanager/subnet_mutate.go
@@ -47,7 +47,7 @@ func (sw *SubnetWebhook) mutateSubnet(ctx context.Context, subnet *spiderpoolv2b
 
 	cidr, err := spiderpoolip.CIDRToLabelValue(*subnet.Spec.IPVersion, subnet.Spec.Subnet)
 	if err != nil {
-		return fmt.Errorf("failed to parse 'spec.subnet' %s as a valid label value: %v", subnet.Spec.Subnet, err)
+		return fmt.Errorf("failed to parse 'spec.subnet' %s as a valid label value: %w", subnet.Spec.Subnet, err)
 	}
 
 	if v, ok := subnet.Labels[constant.LabelSubnetCIDR]; !ok || v != cidr {
@@ -61,7 +61,7 @@ func (sw *SubnetWebhook) mutateSubnet(ctx context.Context, subnet *spiderpoolv2b
 	if len(subnet.Spec.IPs) > 1 {
 		mergedIPs, err := spiderpoolip.MergeIPRanges(*subnet.Spec.IPVersion, subnet.Spec.IPs)
 		if err != nil {
-			return fmt.Errorf("failed to merge 'spec.ips': %v", err)
+			return fmt.Errorf("failed to merge 'spec.ips': %w", err)
 		}
 
 		ips := subnet.Spec.IPs
@@ -72,7 +72,7 @@ func (sw *SubnetWebhook) mutateSubnet(ctx context.Context, subnet *spiderpoolv2b
 	if len(subnet.Spec.ExcludeIPs) > 1 {
 		mergedExcludeIPs, err := spiderpoolip.MergeIPRanges(*subnet.Spec.IPVersion, subnet.Spec.ExcludeIPs)
 		if err != nil {
-			return fmt.Errorf("failed to merge 'spec.excludeIPs': %v", err)
+			return fmt.Errorf("failed to merge 'spec.excludeIPs': %w", err)
 		}
 
 		excludeIPs := subnet.Spec.ExcludeIPs

--- a/pkg/subnetmanager/subnet_webhook.go
+++ b/pkg/subnetmanager/subnet_webhook.go
@@ -61,7 +61,7 @@ func (sw *SubnetWebhook) Default(ctx context.Context, obj runtime.Object) error 
 	logger.Sugar().Debugf("Request Subnet: %+v", *subnet)
 
 	if err := sw.mutateSubnet(logutils.IntoContext(ctx, logger), subnet); err != nil {
-		logger.Sugar().Errorf("Failed to mutate Subnet: %v", err)
+		logger.Sugar().Errorf("Failed to mutate Subnet: %w", err)
 	}
 
 	return nil
@@ -124,7 +124,7 @@ func (sw *SubnetWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runt
 	}
 
 	if errs := sw.validateUpdateSubnet(logutils.IntoContext(ctx, logger), oldSubnet, newSubnet); len(errs) != 0 {
-		logger.Sugar().Errorf("Failed to update Subnet: %v", errs.ToAggregate().Error())
+		logger.Sugar().Errorf("Failed to update Subnet: %w", errs.ToAggregate().Error())
 		return nil, apierrors.NewInvalid(
 			schema.GroupKind{Group: constant.SpiderpoolAPIGroup, Kind: constant.KindSpiderSubnet},
 			newSubnet.Name,

--- a/pkg/types/k8s.go
+++ b/pkg/types/k8s.go
@@ -66,12 +66,13 @@ func (in *PodSubnetAnnoConfig) String() string {
 		return "nil"
 	}
 
-	s := strings.Join([]string{`&PodSubnetAnnoConfig{`,
-		`MultipleSubnets` + fmt.Sprintf("%v", in.MultipleSubnets),
+	s := strings.Join([]string{
+		`&PodSubnetAnnoConfig{`,
+		`MultipleSubnets` + fmt.Sprintf("%v", in.MultipleSubnets) + `,`,
 		`SingleSubnet:` + strings.Replace(strings.Replace(in.SingleSubnet.String(), "AnnoSubnetItem", "", 1), `&`, ``, 1) + `,`,
 		`FlexibleIPNum:` + stringutil.ValueToStringGenerated(in.FlexibleIPNum) + `,`,
 		`AssignIPNumber:` + fmt.Sprintf("%v", in.AssignIPNum) + `,`,
-		`ReclaimIPPool:` + fmt.Sprintf("%v", in.ReclaimIPPool),
+		`ReclaimIPPool:` + fmt.Sprintf("%v", in.ReclaimIPPool) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -89,13 +90,12 @@ func (in *AnnoSubnetItem) String() string {
 		return "nil"
 	}
 
-	s := strings.Join([]string{`&AnnoSubnetItem{`,
-		`Interface:` + fmt.Sprintf("%v", in.Interface) + `,`,
-		`IPv4:` + fmt.Sprintf("%v", in.IPv4) + `,`,
-		`IPv6:` + fmt.Sprintf("%v", in.IPv6),
-		`}`,
-	}, "")
-	return s
+	return fmt.Sprintf(
+		"&AnnoSubnetItem{Interface:%v,IPv4:%v,IPv6:%v}",
+		in.Interface,
+		in.IPv4,
+		in.IPv6,
+	)
 }
 
 // AutoPoolProperty describes Auto-created IPPool's properties

--- a/pkg/utils/cmdgenmd/cmd_generate_markdown.go
+++ b/pkg/utils/cmdgenmd/cmd_generate_markdown.go
@@ -15,7 +15,7 @@ var markdownPath string
 // The first param is the root cmd component name, the second one is the root cmd,
 // the third one should be the root cmd logger.
 func GenMarkDownCmd(component string, rootCmd *cobra.Command, logger *zap.Logger) *cobra.Command {
-	var genMarkDownCmd = &cobra.Command{
+	genMarkDownCmd := &cobra.Command{
 		Use:   "generate-markdown",
 		Short: "generate markdown for " + component,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/utils/convert/convert.go
+++ b/pkg/utils/convert/convert.go
@@ -31,7 +31,7 @@ func ConvertIPDetailsToIPConfigsAndAllRoutes(details []spiderpoolv2beta1.IPAlloc
 			if d.IPv4Gateway != nil {
 				ipv4Gateway = *d.IPv4Gateway
 				// don't set default route if we have cleangateway
-				if !(d.CleanGateway != nil && *d.CleanGateway) {
+				if d.CleanGateway == nil || !*d.CleanGateway {
 					routes = append(routes, genDefaultRoute(nic, ipv4Gateway))
 				}
 			}
@@ -53,7 +53,7 @@ func ConvertIPDetailsToIPConfigsAndAllRoutes(details []spiderpoolv2beta1.IPAlloc
 			if d.IPv6Gateway != nil {
 				ipv6Gateway = *d.IPv6Gateway
 				// don't set default route if we have cleangateway
-				if !(d.CleanGateway != nil && *d.CleanGateway) {
+				if d.CleanGateway == nil || !*d.CleanGateway {
 					routes = append(routes, genDefaultRoute(nic, ipv6Gateway))
 				}
 			}

--- a/pkg/utils/string/string.go
+++ b/pkg/utils/string/string.go
@@ -17,6 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package string provides string utility functions.
 package string
 
 import (

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -37,7 +37,7 @@ func GetDefaultCniName(cniDir string) (string, error) {
 func findDefaultCNIConf(cniDir string) (string, error) {
 	cnifiles, err := libcni.ConfFiles(cniDir, []string{".conf", ".conflist"})
 	if err != nil {
-		return "", fmt.Errorf("failed to load cni files in %s: %v", cniDir, err)
+		return "", fmt.Errorf("failed to load cni files in %s: %w", cniDir, err)
 	}
 
 	var cniPluginConfigs []string
@@ -60,14 +60,14 @@ func fetchCniNameFromPath(cniPath string) (string, error) {
 	if strings.HasSuffix(cniPath, ".conflist") {
 		confList, err := libcni.ConfListFromFile(cniPath)
 		if err != nil {
-			return "", fmt.Errorf("error loading CNI conflist file %s: %v", cniPath, err)
+			return "", fmt.Errorf("error loading CNI conflist file %s: %w", cniPath, err)
 		}
 		return confList.Name, nil
 	}
 
 	conf, err := libcni.ConfFromFile(cniPath)
 	if err != nil {
-		return "", fmt.Errorf("error loading CNI config file %s: %v", cniPath, err)
+		return "", fmt.Errorf("error loading CNI config file %s: %w", cniPath, err)
 	}
 	return conf.Network.Name, nil
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var _ = Describe("Utils", Label("utils"), Serial, func() {
-	var clusterConfigurationJson = `{
+	clusterConfigurationJson := `{
 	"apiVersion": "v1",
 	"data": {
 		"ClusterConfiguration": "networking:\n  dnsDomain: cluster.local\n  podSubnet: 192.168.165.0/24\n  serviceSubnet: 245.100.128.0/18"
@@ -25,7 +25,7 @@ var _ = Describe("Utils", Label("utils"), Serial, func() {
 	}
 }`
 
-	var noClusterConfigurationJson = `{
+	noClusterConfigurationJson := `{
 	"apiVersion": "v1",
 	"data": {
 		"ClusterStatus": "apiEndpoints:\n  anolios79:\n    advertiseAddress: 192.168.165.128\n    bindPort: 6443\napiVersion: kubeadm.k8s.io/v1beta2\nkind: ClusterStatus\n"
@@ -36,7 +36,7 @@ var _ = Describe("Utils", Label("utils"), Serial, func() {
 		"namespace": "kube-system"
 	}
 }`
-	var noCIDRJson = `{
+	noCIDRJson := `{
 	"apiVersion": "v1",
 	"data": {
 		"ClusterConfiguration": "clusterName: spider\ncontrolPlaneEndpoint: spider-control-plane:6443\ncontrollerManager:\n"
@@ -58,7 +58,7 @@ var _ = Describe("Utils", Label("utils"), Serial, func() {
 			if expectError {
 				Expect(err).To(HaveOccurred(), "Expected an error but got none")
 			} else {
-				Expect(err).NotTo(HaveOccurred(), "Did not expect an error but got one: %v", err)
+				Expect(err).NotTo(HaveOccurred(), "Did not expect an error but got one: %w", err)
 			}
 
 			Expect(podCIDR).To(Equal(expectedPodCIDR), "Pod CIDR does not match")
@@ -110,7 +110,7 @@ var _ = Describe("Utils", Label("utils"), Serial, func() {
 						}
 					}
 				]
-			}`), 0644)
+			}`), 0o644)
 			Expect(err).NotTo(HaveOccurred())
 			cniName, err := GetDefaultCniName("/tmp")
 			Expect(err).NotTo(HaveOccurred())
@@ -121,9 +121,7 @@ var _ = Describe("Utils", Label("utils"), Serial, func() {
 	})
 
 	Describe("ExtractK8sCIDRFromKCMPod", func() {
-		var (
-			pod *corev1.Pod
-		)
+		var pod *corev1.Pod
 
 		BeforeEach(func() {
 			pod = &corev1.Pod{
@@ -200,5 +198,4 @@ var _ = Describe("Utils", Label("utils"), Serial, func() {
 			})
 		})
 	})
-
 })

--- a/pkg/workloadendpointmanager/workloadendpoint_manager_suite_test.go
+++ b/pkg/workloadendpointmanager/workloadendpoint_manager_suite_test.go
@@ -20,11 +20,13 @@ import (
 	"github.com/spidernet-io/spiderpool/pkg/workloadendpointmanager"
 )
 
-var scheme *runtime.Scheme
-var fakeClient client.Client
-var tracker k8stesting.ObjectTracker
-var fakeAPIReader client.Reader
-var endpointManager workloadendpointmanager.WorkloadEndpointManager
+var (
+	scheme          *runtime.Scheme
+	fakeClient      client.Client
+	tracker         k8stesting.ObjectTracker
+	fakeAPIReader   client.Reader
+	endpointManager workloadendpointmanager.WorkloadEndpointManager
+)
 
 func TestWorkloadEndpointManager(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/workloadendpointmanager/workloadendpoint_manager_test.go
+++ b/pkg/workloadendpointmanager/workloadendpoint_manager_test.go
@@ -452,7 +452,6 @@ var _ = Describe("WorkloadEndpointManager", Label("workloadendpoint_manager_test
 				err := endpointManager.PatchIPAllocationResults(ctx, []*spiderpooltypes.AllocationResult{}, endpointT, podT, spiderpooltypes.PodTopController{}, false)
 				Expect(err).To(MatchError(constant.ErrUnknown))
 			})
-
 		})
 
 		Describe("ReallocateCurrentIPAllocation", func() {
@@ -642,7 +641,6 @@ var _ = Describe("WorkloadEndpointManager", Label("workloadendpoint_manager_test
 		})
 
 		Describe("ReleaseEndpointAndFinalizer", func() {
-
 			It("failed to release EndpointAndFinalizer due to getting non-existent Endpoint", func() {
 				err := endpointManager.ReleaseEndpointAndFinalizer(ctx, namespace, endpointName, constant.IgnoreCache)
 				Expect(err).To(BeNil())

--- a/test/e2e/affinity/affinity_suite_test.go
+++ b/test/e2e/affinity/affinity_suite_test.go
@@ -25,5 +25,4 @@ var _ = BeforeSuite(func() {
 	var e error
 	frame, e = e2e.NewFramework(GinkgoT(), []func(*runtime.Scheme) error{spiderpool.AddToScheme})
 	Expect(e).NotTo(HaveOccurred())
-
 })

--- a/test/e2e/affinity/affinity_test.go
+++ b/test/e2e/affinity/affinity_test.go
@@ -353,7 +353,7 @@ var _ = Describe("test Affinity", Label("affinity"), func() {
 			// check pod ip in different node-ippool
 			GinkgoWriter.Println("check pod ip if in different node-ippool")
 			for _, pod := range podList.Items {
-				ok, _, _, err := common.CheckPodIpRecordInIppool(frame, nodeV4PoolMap[pod.Spec.NodeName], nodeV6PoolMap[pod.Spec.NodeName], &corev1.PodList{Items: []corev1.Pod{pod}})
+				ok, _, _, err := common.CheckPodIPRecordInIPPool(frame, nodeV4PoolMap[pod.Spec.NodeName], nodeV6PoolMap[pod.Spec.NodeName], &corev1.PodList{Items: []corev1.Pod{pod}})
 				Expect(err).NotTo(HaveOccurred(), "error: %v\n", err)
 				Expect(ok).To(BeTrue())
 			}
@@ -368,7 +368,7 @@ var _ = Describe("test Affinity", Label("affinity"), func() {
 			// check pod ip if reclaimed in different node-ippool
 			GinkgoWriter.Println("check pod ip if reclaimed in different node-ippool")
 			for _, pod := range podList.Items {
-				_, ok, _, err := common.CheckPodIpRecordInIppool(frame, nodeV4PoolMap[pod.Spec.NodeName], nodeV6PoolMap[pod.Spec.NodeName], &corev1.PodList{Items: []corev1.Pod{pod}})
+				_, ok, _, err := common.CheckPodIPRecordInIPPool(frame, nodeV4PoolMap[pod.Spec.NodeName], nodeV6PoolMap[pod.Spec.NodeName], &corev1.PodList{Items: []corev1.Pod{pod}})
 				Expect(err).NotTo(HaveOccurred(), "error: %v\n", err)
 				Expect(ok).To(BeTrue())
 			}
@@ -465,17 +465,17 @@ var _ = Describe("test Affinity", Label("affinity"), func() {
 			Expect(stsObject).NotTo(BeNil())
 			Expect(err).NotTo(HaveOccurred())
 			podlist, err := frame.GetPodListByLabel(stsObject.Spec.Template.Labels)
-			Expect(err).NotTo(HaveOccurred(), "failed to get pod list, reason= %v", err)
+			Expect(err).NotTo(HaveOccurred(), "failed to get pod list, reason= %w", err)
 			Expect(int32(len(podlist.Items))).Should(Equal(stsObject.Status.ReadyReplicas))
 
 			// check pod ip record in ippool
-			ok, _, _, err := common.CheckPodIpRecordInIppool(frame, defaultV4PoolNameList, defaultV6PoolNameList, podlist)
+			ok, _, _, err := common.CheckPodIPRecordInIPPool(frame, defaultV4PoolNameList, defaultV6PoolNameList, podlist)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ok).To(BeTrue())
 
 			// Record the Pod IP、containerID、workloadendpoint UID information of the statefulset
 			ipMap := make(map[string]string)
-			containerIdMap := make(map[string]string)
+			containerIDMap := make(map[string]string)
 			uidMap := make(map[string]string)
 			for _, pod := range podlist.Items {
 				if frame.Info.IpV4Enabled {
@@ -491,7 +491,7 @@ var _ = Describe("test Affinity", Label("affinity"), func() {
 					ipMap[podIPv6] = pod.Name
 				}
 				for _, c := range pod.Status.ContainerStatuses {
-					containerIdMap[c.ContainerID] = pod.Name
+					containerIDMap[c.ContainerID] = pod.Name
 				}
 				object, err := common.GetWorkloadByName(frame, pod.Namespace, pod.Name)
 				Expect(err).NotTo(HaveOccurred())
@@ -533,7 +533,7 @@ var _ = Describe("test Affinity", Label("affinity"), func() {
 							continue LOOP
 						}
 						for _, c := range pod.Status.ContainerStatuses {
-							if _, ok := containerIdMap[c.ContainerID]; ok {
+							if _, ok := containerIDMap[c.ContainerID]; ok {
 								time.Sleep(common.ForcedWaitingTime)
 								continue LOOP
 							}

--- a/test/e2e/annotation/annotation_test.go
+++ b/test/e2e/annotation/annotation_test.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/kubectl/pkg/util/podutils"
 	"k8s.io/utils/ptr"
 
-	"github.com/spidernet-io/spiderpool/pkg/constant"
 	pkgconstant "github.com/spidernet-io/spiderpool/pkg/constant"
 	spiderpool "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1"
 	"github.com/spidernet-io/spiderpool/pkg/types"
@@ -217,7 +216,7 @@ var _ = Describe("test annotation", Label("annotation"), func() {
 			v4PoolName, v6PoolName   string
 			iPv4PoolObj, iPv6PoolObj *spiderpool.SpiderIPPool
 			err                      error
-			ipNum                    int = 2
+			ipNum                    = 2
 		)
 
 		// The case relies on a Dual-stack
@@ -290,7 +289,7 @@ var _ = Describe("test annotation", Label("annotation"), func() {
 		var v4PoolNameList, v6PoolNameList []string
 		var cleanGateway bool
 		var err error
-		var ipNum int = 10
+		ipNum := 10
 
 		BeforeEach(func() {
 			cleanGateway = false
@@ -375,10 +374,10 @@ var _ = Describe("test annotation", Label("annotation"), func() {
 
 		It(`A00008: Successfully run an annotated multi-container pod, E00007: Succeed to run a pod with long yaml for ipv4, ipv6 and dual-stack case`,
 			Label("A00008", "E00007"), func() {
-				var containerName = "cn" + tools.RandomName()
-				var annotationKeyName = "test-long-yaml-" + tools.RandomName()
-				var annotationLength int = 200
-				var containerNum int = 2
+				containerName := "cn" + tools.RandomName()
+				annotationKeyName := "test-long-yaml-" + tools.RandomName()
+				annotationLength := 200
+				containerNum := 2
 
 				// Generate IPPool annotation string
 				podIppoolAnnoStr = common.GeneratePodIPPoolAnnotations(frame, common.NIC1, v4PoolNameList, v6PoolNameList)
@@ -388,8 +387,10 @@ var _ = Describe("test annotation", Label("annotation"), func() {
 				containerObject := podYaml.Spec.Containers[0]
 				containerObject.Name = containerName
 				podYaml.Spec.Containers = append(podYaml.Spec.Containers, containerObject)
-				podYaml.Annotations = map[string]string{pkgconstant.AnnoPodIPPool: podIppoolAnnoStr,
-					annotationKeyName: common.GenerateString(annotationLength, false)}
+				podYaml.Annotations = map[string]string{
+					pkgconstant.AnnoPodIPPool: podIppoolAnnoStr,
+					annotationKeyName:         common.GenerateString(annotationLength, false),
+				}
 				Expect(podYaml).NotTo(BeNil())
 
 				pod, podIPv4, podIPv6 := common.CreatePodUntilReady(frame, podYaml, podName, nsName, common.PodStartTimeout)
@@ -405,7 +406,7 @@ var _ = Describe("test annotation", Label("annotation"), func() {
 				Expect(len(pod.Annotations[annotationKeyName])).To(Equal(annotationLength))
 
 				// Check Pod IP record in IPPool
-				ok, _, _, e := common.CheckPodIpRecordInIppool(frame, v4PoolNameList, v6PoolNameList, &corev1.PodList{Items: []corev1.Pod{*pod}})
+				ok, _, _, e := common.CheckPodIPRecordInIPPool(frame, v4PoolNameList, v6PoolNameList, &corev1.PodList{Items: []corev1.Pod{*pod}})
 				Expect(e).NotTo(HaveOccurred())
 				Expect(ok).To(BeTrue())
 
@@ -753,7 +754,7 @@ var _ = Describe("test annotation", Label("annotation"), func() {
 			Expect(pod).NotTo(BeNil())
 
 			GinkgoWriter.Println("Check if multiple NICs are valid.")
-			ok, _, _, err := common.CheckPodIpRecordInIppool(frame, globalDefaultV4IpoolList, globalDefaultV6IpoolList, &corev1.PodList{Items: []corev1.Pod{*pod}})
+			ok, _, _, err := common.CheckPodIPRecordInIPPool(frame, globalDefaultV4IpoolList, globalDefaultV6IpoolList, &corev1.PodList{Items: []corev1.Pod{*pod}})
 			Expect(ok).NotTo(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
 
@@ -812,7 +813,7 @@ var _ = Describe("test annotation", Label("annotation"), func() {
 			Expect(pod).NotTo(BeNil())
 
 			GinkgoWriter.Println("Check if multiple NICs are valid.")
-			ok, _, _, err := common.CheckPodIpRecordInIppool(frame, globalDefaultV4IpoolList, globalDefaultV6IpoolList, &corev1.PodList{Items: []corev1.Pod{*pod}})
+			ok, _, _, err := common.CheckPodIPRecordInIPPool(frame, globalDefaultV4IpoolList, globalDefaultV6IpoolList, &corev1.PodList{Items: []corev1.Pod{*pod}})
 			Expect(ok).NotTo(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
 
@@ -981,7 +982,7 @@ var _ = Describe("test annotation", Label("annotation"), func() {
 					Namespace: nsName,
 				},
 				Spec: spiderpool.MultusCNIConfigSpec{
-					CniType: ptr.To(constant.MacvlanCNI),
+					CniType: ptr.To(pkgconstant.MacvlanCNI),
 					MacvlanConfig: &spiderpool.SpiderMacvlanCniConfig{
 						Master:                []string{common.NIC1},
 						SpiderpoolConfigPools: &spiderpool.SpiderpoolPools{},
@@ -1071,7 +1072,7 @@ var _ = Describe("test annotation", Label("annotation"), func() {
 				if frame.Info.IpV6Enabled {
 					tmpV6PoolNameList = []string{v6PoolName1}
 				}
-				ok, _, _, e := common.CheckPodIpRecordInIppool(frame, tmpV4PoolNameList, tmpV6PoolNameList, newPodList)
+				ok, _, _, e := common.CheckPodIPRecordInIPPool(frame, tmpV4PoolNameList, tmpV6PoolNameList, newPodList)
 				if e != nil {
 					GinkgoWriter.Printf("failed to check pod ip record in ippool %v\n", e)
 					return false
@@ -1191,7 +1192,7 @@ var _ = Describe("test annotation", Label("annotation"), func() {
 				if frame.Info.IpV6Enabled {
 					tmpV6PoolNameList = []string{v6PoolName1}
 				}
-				ok, _, _, e := common.CheckPodIpRecordInIppool(frame, tmpV4PoolNameList, tmpV6PoolNameList, newPodList)
+				ok, _, _, e := common.CheckPodIPRecordInIPPool(frame, tmpV4PoolNameList, tmpV6PoolNameList, newPodList)
 				if e != nil {
 					GinkgoWriter.Printf("failed to check pod ip record in ippool %v\n", e)
 					return false
@@ -1335,7 +1336,6 @@ var _ = Describe("test annotation", Label("annotation"), func() {
 })
 
 func checkAnnotationPriority(podYaml *corev1.Pod, podName, nsName string, v4PoolNameList, v6PoolNameList []string) {
-
 	pod, podIPv4, podIPv6 := common.CreatePodUntilReady(frame, podYaml, podName, nsName, common.PodStartTimeout)
 	GinkgoWriter.Printf("pod %v/%v: podIPv4: %v, podIPv6: %v \n", nsName, podName, podIPv4, podIPv6)
 
@@ -1343,7 +1343,7 @@ func checkAnnotationPriority(podYaml *corev1.Pod, podName, nsName string, v4Pool
 	podlist := &corev1.PodList{
 		Items: []corev1.Pod{*pod},
 	}
-	ok, _, _, e := common.CheckPodIpRecordInIppool(frame, v4PoolNameList, v6PoolNameList, podlist)
+	ok, _, _, e := common.CheckPodIPRecordInIPPool(frame, v4PoolNameList, v6PoolNameList, podlist)
 	Expect(e).NotTo(HaveOccurred())
 	Expect(ok).To(BeTrue())
 

--- a/test/e2e/assignip/assiginip_suite_test.go
+++ b/test/e2e/assignip/assiginip_suite_test.go
@@ -25,5 +25,4 @@ var _ = BeforeSuite(func() {
 	var e error
 	frame, e = e2e.NewFramework(GinkgoT(), []func(*runtime.Scheme) error{spiderpool.AddToScheme})
 	Expect(e).NotTo(HaveOccurred())
-
 })

--- a/test/e2e/assignip/assignip_test.go
+++ b/test/e2e/assignip/assignip_test.go
@@ -28,16 +28,16 @@ var _ = Describe("test pod", Label("assignip"), func() {
 		var v4SubnetObject, v6SubnetObject *spiderpoolv2beta1.SpiderSubnet
 
 		var (
-			deployOriginialNum int = 1
-			deployScaleupNum   int = 2
-			ippoolIpNum        int = 2
+			deployOriginialNum = 1
+			deployScaleupNum   = 2
+			ippoolIPNum        = 2
 		)
 
 		BeforeEach(func() {
 			if frame.Info.SpiderSubnetEnabled {
 				Eventually(func() error {
 					if frame.Info.IpV4Enabled {
-						v4SubnetName, v4SubnetObject = common.GenerateExampleV4SubnetObject(frame, ippoolIpNum)
+						v4SubnetName, v4SubnetObject = common.GenerateExampleV4SubnetObject(frame, ippoolIPNum)
 						err := common.CreateSubnet(frame, v4SubnetObject)
 						if nil != err {
 							GinkgoWriter.Printf("Failed to create v4 Subnet: %v \n", err)
@@ -46,7 +46,7 @@ var _ = Describe("test pod", Label("assignip"), func() {
 						GinkgoWriter.Printf("Succeeded to create SpiderSubnet %s\n", v4SubnetName)
 					}
 					if frame.Info.IpV6Enabled {
-						v6SubnetName, v6SubnetObject = common.GenerateExampleV6SubnetObject(frame, ippoolIpNum)
+						v6SubnetName, v6SubnetObject = common.GenerateExampleV6SubnetObject(frame, ippoolIPNum)
 						err := common.CreateSubnet(frame, v6SubnetObject)
 						if nil != err {
 							GinkgoWriter.Printf("Failed to create v6 Subnet: %v \n", err)
@@ -68,7 +68,7 @@ var _ = Describe("test pod", Label("assignip"), func() {
 			// Create IPv4Pool and IPV6Pool
 			Eventually(func() error {
 				if frame.Info.IpV4Enabled {
-					v4PoolName, v4PoolObj = common.GenerateExampleIpv4poolObject(ippoolIpNum)
+					v4PoolName, v4PoolObj = common.GenerateExampleIpv4poolObject(ippoolIPNum)
 					// Add an IP from the IPPool.Spec.IPs to the Spec.excludeIPs.
 					if frame.Info.SpiderSubnetEnabled {
 						v4PoolObj.Spec.Subnet = v4SubnetObject.Spec.Subnet
@@ -84,7 +84,7 @@ var _ = Describe("test pod", Label("assignip"), func() {
 					v4PoolNameList = append(v4PoolNameList, v4PoolName)
 				}
 				if frame.Info.IpV6Enabled {
-					v6PoolName, v6PoolObj = common.GenerateExampleIpv6poolObject(ippoolIpNum)
+					v6PoolName, v6PoolObj = common.GenerateExampleIpv6poolObject(ippoolIPNum)
 					// Add an IP from the IPPool.Spec.IPs to the Spec.excludeIPs.
 					if frame.Info.SpiderSubnetEnabled {
 						v6PoolObj.Spec.Subnet = v6SubnetObject.Spec.Subnet
@@ -135,7 +135,7 @@ var _ = Describe("test pod", Label("assignip"), func() {
 			Label("E00008", "S00002"), func() {
 				// Create Deployment with types.AnnoPodIPPoolValue and The Pods IP is recorded in the IPPool.
 				deploy := common.CreateDeployWithPodAnnoation(frame, deployName, namespace, deployOriginialNum, common.NIC1, v4PoolNameList, v6PoolNameList)
-				common.CheckPodIpReadyByLabel(frame, deploy.Spec.Selector.MatchLabels, v4PoolNameList, v6PoolNameList)
+				common.CheckPodIPReadyByLabel(frame, deploy.Spec.Selector.MatchLabels, v4PoolNameList, v6PoolNameList)
 
 				// Scale Deployment to exhaust IP resource
 				GinkgoWriter.Println("scale Deployment to exhaust IP resource")
@@ -179,7 +179,7 @@ var _ = Describe("test pod", Label("assignip"), func() {
 				newPodList, err := frame.DeletePodListUntilReady(podList, common.PodReStartTimeout)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(newPodList.Items)).Should(Equal(deployScaleupNum))
-				ok2, _, _, err := common.CheckPodIpRecordInIppool(frame, v4PoolNameList, v6PoolNameList, newPodList)
+				ok2, _, _, err := common.CheckPodIPRecordInIPPool(frame, v4PoolNameList, v6PoolNameList, newPodList)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(ok2).To(BeTrue())
 
@@ -189,7 +189,7 @@ var _ = Describe("test pod", Label("assignip"), func() {
 			})
 
 		It("The cluster is dual stack, but the spiderpool can allocates ipv4 or ipv6 only with IPPools annotation", Label("E00009"), func() {
-			if !(frame.Info.IpV4Enabled && frame.Info.IpV6Enabled) {
+			if !frame.Info.IpV4Enabled || !frame.Info.IpV6Enabled {
 				Skip("Single stack just skip this e2e case")
 			}
 
@@ -222,7 +222,7 @@ var _ = Describe("test pod", Label("assignip"), func() {
 			if !frame.Info.SpiderSubnetEnabled {
 				Skip("The SpiderSubnet feature is disabled, skip this e2e case")
 			}
-			if !(frame.Info.IpV4Enabled && frame.Info.IpV6Enabled) {
+			if !frame.Info.IpV4Enabled || !frame.Info.IpV6Enabled {
 				Skip("Single stack just skip this e2e case")
 			}
 

--- a/test/e2e/common/constant.go
+++ b/test/e2e/common/constant.go
@@ -1,5 +1,7 @@
 // Copyright 2022 Authors of spidernet-io
 // SPDX-License-Identifier: Apache-2.0
+
+// Package common provides utility functions and constants for E2E tests.
 package common
 
 import (

--- a/test/e2e/common/daemonset.go
+++ b/test/e2e/common/daemonset.go
@@ -1,8 +1,11 @@
 // Copyright 2022 Authors of spidernet-io
 // SPDX-License-Identifier: Apache-2.0
+
+// Package common provides test utilities for E2E tests.
 package common
 
 import (
+	//nolint:all // Standard for Ginkgo/Gomega BDD testing framework
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/test/e2e/common/deployment.go
+++ b/test/e2e/common/deployment.go
@@ -1,5 +1,7 @@
 // Copyright 2022 Authors of spidernet-io
 // SPDX-License-Identifier: Apache-2.0
+
+// Package common provides test utilities for E2E tests.
 package common
 
 import (
@@ -9,7 +11,9 @@ import (
 	"sync"
 	"time"
 
+	//nolint:all // Standard for Ginkgo/Gomega BDD testing framework
 	. "github.com/onsi/ginkgo/v2"
+	//nolint:all // Standard for Ginkgo/Gomega BDD testing framework
 	. "github.com/onsi/gomega"
 	e2e "github.com/spidernet-io/e2eframework/framework"
 	"github.com/spidernet-io/e2eframework/tools"
@@ -124,7 +128,6 @@ func GenerateDraDeploymentYaml(dpmName, claim, namespace string, replica int32) 
 }
 
 func ScaleDeployUntilExpectedReplicas(ctx context.Context, frame *e2e.Framework, deploy *appsv1.Deployment, expectedReplicas int, scalePodRun bool) (addedPod, removedPod []corev1.Pod, err error) {
-
 	if frame == nil || deploy == nil || expectedReplicas <= 0 || int32(expectedReplicas) == *deploy.Spec.Replicas {
 		return nil, nil, e2e.ErrWrongInput
 	}
@@ -168,7 +171,6 @@ func ScaleDeployUntilExpectedReplicas(ctx context.Context, frame *e2e.Framework,
 }
 
 func CreateDeployUntilExpectedReplicas(frame *e2e.Framework, deploy *appsv1.Deployment, ctx context.Context) (pods *corev1.PodList, err error) {
-
 	if frame == nil || deploy == nil {
 		return nil, e2e.ErrWrongInput
 	}
@@ -221,7 +223,7 @@ func CreateDeployUnitlReadyCheckInIppool(frame *e2e.Framework, depName, namespac
 	Expect(err).NotTo(HaveOccurred())
 
 	// check pod ip record still in this ippool
-	ok, _, _, err := CheckPodIpRecordInIppool(frame, v4PoolNameList, v6PoolNameList, podlist)
+	ok, _, _, err := CheckPodIPRecordInIPPool(frame, v4PoolNameList, v6PoolNameList, podlist)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(ok).To(BeTrue())
 }

--- a/test/e2e/common/ips.go
+++ b/test/e2e/common/ips.go
@@ -1,5 +1,7 @@
 // Copyright 2022 Authors of spidernet-io
 // SPDX-License-Identifier: Apache-2.0
+
+// Package common provides test utilities for E2E tests.
 package common
 
 import (

--- a/test/e2e/common/job.go
+++ b/test/e2e/common/job.go
@@ -20,7 +20,6 @@ const (
 )
 
 func GenerateExampleJobYaml(behavior JobBehave, jdName, namespace string, parallelism *int32) *batchv1.Job {
-
 	Expect(jdName).NotTo(BeEmpty())
 	Expect(namespace).NotTo(BeEmpty())
 

--- a/test/e2e/common/kruise.go
+++ b/test/e2e/common/kruise.go
@@ -49,7 +49,6 @@ func GenerateExampleKruiseCloneSetYaml(name, namespace string, replica int32) *k
 }
 
 func GenerateExampleKruiseStatefulSetYaml(name, namespace string, replica int32) *kruisev1.StatefulSet {
-
 	return &kruisev1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
@@ -90,14 +89,14 @@ func CreateKruiseCloneSet(f *frame.Framework, kruiseCloneSet *kruisev1.CloneSet,
 
 	fake := &kruisev1.CloneSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: kruiseCloneSet.ObjectMeta.Name,
+			Name: kruiseCloneSet.Name,
 		},
 	}
 	key := client.ObjectKeyFromObject(fake)
 	existing := &kruisev1.CloneSet{}
 	e := f.GetResource(key, existing)
-	if e == nil && existing.ObjectMeta.DeletionTimestamp == nil {
-		return fmt.Errorf("failed to create, a same kruise cloneset %v/%v exists", kruiseCloneSet.ObjectMeta.Namespace, kruiseCloneSet.ObjectMeta.Name)
+	if e == nil && existing.DeletionTimestamp == nil {
+		return fmt.Errorf("failed to create, a same kruise cloneset %v/%v exists", kruiseCloneSet.Namespace, kruiseCloneSet.Name)
 	}
 	return f.CreateResource(kruiseCloneSet, opts...)
 }
@@ -162,6 +161,7 @@ func GetKruiseStatefulSet(f *frame.Framework, namespace, name string) (*kruisev1
 	}
 	return existing, e
 }
+
 func ScaleKruiseStatefulSet(f *frame.Framework, kruiseStatefulSet *kruisev1.StatefulSet, replicas int32) (*kruisev1.StatefulSet, error) {
 	if kruiseStatefulSet == nil {
 		return nil, errors.New("wrong input")

--- a/test/e2e/common/pod.go
+++ b/test/e2e/common/pod.go
@@ -54,7 +54,7 @@ func CreatePodUntilReady(frame *e2e.Framework, podYaml *corev1.Pod, podName, nam
 	err := retry.RetryOnConflictWithContext(context.Background(), retry.DefaultBackoff, func(ctx context.Context) error {
 		err := frame.CreatePod(podYaml)
 		if err != nil {
-			GinkgoLogr.Error(fmt.Errorf("failed to create pod %v/%v, error: %v", namespace, podName, err), "Failed")
+			GinkgoLogr.Error(fmt.Errorf("failed to create pod %v/%v, error: %w", namespace, podName, err), "Failed")
 			return err
 		}
 		return nil
@@ -114,8 +114,7 @@ func CreatePodWithAnnoPodIPPool(frame *e2e.Framework, podName, namespace string,
 	GinkgoWriter.Printf("pod %v/%v anno: %+v\n", namespace, podName, pod.Annotations)
 }
 
-func CheckPodIpReadyByLabel(frame *e2e.Framework, label map[string]string, v4PoolNameList, v6PoolNameList []string) *corev1.PodList {
-
+func CheckPodIPReadyByLabel(frame *e2e.Framework, label map[string]string, v4PoolNameList, v6PoolNameList []string) *corev1.PodList {
 	Expect(label).NotTo(BeNil(), "label is nil \n")
 	Expect(frame).NotTo(BeNil(), "frame is nil \n")
 
@@ -128,7 +127,7 @@ func CheckPodIpReadyByLabel(frame *e2e.Framework, label map[string]string, v4Poo
 	Expect(frame.CheckPodListIpReady(podList)).NotTo(HaveOccurred(), "failed to check ipv4 or ipv6 ,reason=%v \n", err)
 
 	// check pod ip recorded in ippool
-	ok, _, _, e := CheckPodIpRecordInIppool(frame, v4PoolNameList, v6PoolNameList, podList)
+	ok, _, _, e := CheckPodIPRecordInIPPool(frame, v4PoolNameList, v6PoolNameList, podList)
 	Expect(e).NotTo(HaveOccurred(), "Failed to check Pod IP Record In IPPool, error is %v \n", err)
 	Expect(ok).To(BeTrue())
 	GinkgoWriter.Printf("Pod IP recorded in IPPool %v , %v \n", v4PoolNameList, v6PoolNameList)

--- a/test/e2e/common/reservedip.go
+++ b/test/e2e/common/reservedip.go
@@ -102,42 +102,42 @@ func DeleteResverdIPUntilFinish(ctx context.Context, f *frame.Framework, reserve
 	}
 }
 
-func GenerateExampleV4ReservedIpObject(ips []string) (string, *spiderpool.SpiderReservedIP) {
-	var v4Ipversion = new(types.IPVersion)
-	var iPv4ReservedIpObj *spiderpool.SpiderReservedIP
-	var v4ReservedIpName string
+func GenerateExampleV4ReservedIPObject(ips []string) (string, *spiderpool.SpiderReservedIP) {
+	v4Ipversion := new(types.IPVersion)
+	var ipv4ReservedIPObj *spiderpool.SpiderReservedIP
+	var v4ReservedIPName string
 
 	*v4Ipversion = constant.IPv4
-	v4ReservedIpName = "v4-sr-" + tools.RandomName()
+	v4ReservedIPName = "v4-sr-" + tools.RandomName()
 
-	iPv4ReservedIpObj = &spiderpool.SpiderReservedIP{
+	ipv4ReservedIPObj = &spiderpool.SpiderReservedIP{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: v4ReservedIpName,
+			Name: v4ReservedIPName,
 		},
 		Spec: spiderpool.ReservedIPSpec{
 			IPVersion: v4Ipversion,
 			IPs:       ips,
 		},
 	}
-	return v4ReservedIpName, iPv4ReservedIpObj
+	return v4ReservedIPName, ipv4ReservedIPObj
 }
 
-func GenerateExampleV6ReservedIpObject(ips []string) (string, *spiderpool.SpiderReservedIP) {
-	var v6Ipversion = new(types.IPVersion)
-	var iPv6ReservedIpObj *spiderpool.SpiderReservedIP
-	var v6ReservedIpName string
+func GenerateExampleV6ReservedIPObject(ips []string) (string, *spiderpool.SpiderReservedIP) {
+	v6Ipversion := new(types.IPVersion)
+	var ipv6ReservedIPObj *spiderpool.SpiderReservedIP
+	var v6ReservedIPName string
 
 	*v6Ipversion = constant.IPv6
-	v6ReservedIpName = "v6-sr-" + tools.RandomName()
+	v6ReservedIPName = "v6-sr-" + tools.RandomName()
 
-	iPv6ReservedIpObj = &spiderpool.SpiderReservedIP{
+	ipv6ReservedIPObj = &spiderpool.SpiderReservedIP{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: v6ReservedIpName,
+			Name: v6ReservedIPName,
 		},
 		Spec: spiderpool.ReservedIPSpec{
 			IPVersion: v6Ipversion,
 			IPs:       ips,
 		},
 	}
-	return v6ReservedIpName, iPv6ReservedIpObj
+	return v6ReservedIPName, ipv6ReservedIPObj
 }

--- a/test/e2e/common/spidersubnet.go
+++ b/test/e2e/common/spidersubnet.go
@@ -213,7 +213,7 @@ func DeleteSubnetUntilFinish(ctx context.Context, f *frame.Framework, subnetName
 		default:
 			_, err := GetSubnetByName(f, subnetName)
 			if err != nil {
-				GinkgoWriter.Printf("Subnet '%s' has been removed，error: %v", subnetName, err)
+				GinkgoWriter.Printf("Subnet '%s' has been removed，error: %w", subnetName, err)
 				return nil
 			}
 			time.Sleep(time.Second)
@@ -259,7 +259,7 @@ func PatchSpiderSubnet(f *frame.Framework, desiredSubnet, originalSubnet *spider
 	d, err := mergePatch.Data(desiredSubnet)
 	GinkgoWriter.Printf("the patch is: %v. \n", string(d))
 	if err != nil {
-		return fmt.Errorf("failed to generate patch, err is %v", err)
+		return fmt.Errorf("failed to generate patch, err is %w", err)
 	}
 
 	return f.PatchResource(desiredSubnet, mergePatch, opts...)
@@ -296,7 +296,7 @@ func GetAvailableIpsInSubnet(f *frame.Framework, subnetName string) ([]net.IP, e
 
 	subnetObj, err := GetSubnetByName(f, subnetName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get subnet '%s', error:'%v' ", subnetName, err)
+		return nil, fmt.Errorf("failed to get subnet '%s', error:'%w' ", subnetName, err)
 	}
 
 	ips1, err := ip.ParseIPRanges(*subnetObj.Spec.IPVersion, subnetObj.Spec.IPs)
@@ -328,7 +328,7 @@ func GetAvailableIpsInSubnet(f *frame.Framework, subnetName string) ([]net.IP, e
 	return ips, nil
 }
 
-func WaitValidateSubnetAndPoolIpConsistency(ctx context.Context, f *frame.Framework, subnetName string) error {
+func WaitValidateSubnetAndPoolIPConsistency(ctx context.Context, f *frame.Framework, subnetName string) error {
 	if f == nil || subnetName == "" {
 		return frame.ErrWrongInput
 	}
@@ -341,7 +341,7 @@ LOOP:
 		default:
 			subnetObject, err := GetSubnetByName(f, subnetName)
 			if err != nil {
-				return fmt.Errorf("failed to get subnet '%s', error:'%v' ", subnetName, err)
+				return fmt.Errorf("failed to get subnet '%s', error:'%w' ", subnetName, err)
 			}
 
 			poolList, err := GetIppoolsInSubnet(f, subnetName)
@@ -363,7 +363,7 @@ LOOP:
 					if pool.Name == poolInSubnet {
 						ips1, err := ip.AssembleTotalIPs(*pool.Spec.IPVersion, pool.Spec.IPs, pool.Spec.ExcludeIPs)
 						if err != nil {
-							return fmt.Errorf("failed to calculate SpiderIPPool '%s' total IP count, error: %v", pool.Name, err)
+							return fmt.Errorf("failed to calculate SpiderIPPool '%s' total IP count, error: %w", pool.Name, err)
 						}
 
 						for _, v := range ips1 {
@@ -394,8 +394,8 @@ LOOP:
 	}
 }
 
-func BatchCreateSubnet(f *frame.Framework, version types.IPVersion, subnetNums, subnetIpNums int) ([]string, error) {
-	if f == nil || subnetNums <= 0 || subnetIpNums <= 0 {
+func BatchCreateSubnet(f *frame.Framework, version types.IPVersion, subnetNums, subnetIPNums int) ([]string, error) {
+	if f == nil || subnetNums <= 0 || subnetIPNums <= 0 {
 		return nil, frame.ErrWrongInput
 	}
 
@@ -408,9 +408,9 @@ func BatchCreateSubnet(f *frame.Framework, version types.IPVersion, subnetNums, 
 OUTER_FOR:
 	for i := 1; i <= subnetNums; i++ {
 		if version == constant.IPv4 {
-			subnetName, subnetObject = GenerateExampleV4SubnetObject(f, subnetIpNums)
+			subnetName, subnetObject = GenerateExampleV4SubnetObject(f, subnetIPNums)
 		} else {
-			subnetName, subnetObject = GenerateExampleV6SubnetObject(f, subnetIpNums)
+			subnetName, subnetObject = GenerateExampleV6SubnetObject(f, subnetIPNums)
 		}
 
 		if d, ok := CirdMap[subnetObject.Spec.Subnet]; ok {

--- a/test/e2e/common/statefulset.go
+++ b/test/e2e/common/statefulset.go
@@ -105,14 +105,13 @@ func PatchStatefulSet(frame *e2e.Framework, desiredStatefulSet, originalStateful
 	d, err := mergePatch.Data(desiredStatefulSet)
 	GinkgoWriter.Printf("the patch is: %v. \n", string(d))
 	if err != nil {
-		return fmt.Errorf("failed to generate patch, err is %v", err)
+		return fmt.Errorf("failed to generate patch, err is %w", err)
 	}
 
 	return frame.PatchResource(desiredStatefulSet, mergePatch, opts...)
 }
 
 func RestartAndValidateStatefulSetPodIP(frame *e2e.Framework, label map[string]string) error {
-
 	stsPodList, err := frame.GetPodListByLabel(label)
 	if err != nil {
 		return err

--- a/test/e2e/common/tools.go
+++ b/test/e2e/common/tools.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"math/rand"
 	"net"
 	"os/exec"
@@ -33,7 +34,10 @@ func GenerateString(lenNum int, isHex bool) string {
 	str := strings.Builder{}
 	length := len(chars)
 	for i := 0; i < lenNum; i++ {
-		str.WriteString(chars[r.Intn(length)])
+		_, err := str.WriteString(chars[r.Intn(length)])
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 	return str.String()
 }
@@ -100,16 +104,16 @@ func ContrastIpv6ToIntValues(ip1, ip2 string) error {
 		return errors.New("invalid value")
 	}
 
-	netIp1 := net.ParseIP(ip1)
-	netIp2 := net.ParseIP(ip2)
+	netIP1 := net.ParseIP(ip1)
+	netIP2 := net.ParseIP(ip2)
 
-	if res := ip.Cmp(netIp1, netIp2); res != 0 {
+	if res := ip.Cmp(netIP1, netIP2); res != 0 {
 		return errors.New("both Mismatch")
 	}
 	return nil
 }
 
-func SelectIpFromIps(version types.IPVersion, ips []net.IP, ipNum int) ([]string, error) {
+func SelectIPFromIps(version types.IPVersion, ips []net.IP, ipNum int) ([]string, error) {
 	var ipArray []net.IP
 	ipMap := make(map[string]bool)
 

--- a/test/e2e/coordinator/macvlan-overlay-one/macvlan_overlay_one_suite_test.go
+++ b/test/e2e/coordinator/macvlan-overlay-one/macvlan_overlay_one_suite_test.go
@@ -26,10 +26,13 @@ func TestMacvlanOverlayOne(t *testing.T) {
 var frame *e2e.Framework
 
 // var name string
-var successRate = float64(1)
-var name string
-var err error
-var delayMs = int64(15000)
+var (
+	successRate = float64(1)
+	name        string
+	err         error
+	delayMs     = int64(15000)
+)
+
 var (
 	task           *kdoctorV1beta1.NetReach
 	netreach       *kdoctorV1beta1.AgentSpec

--- a/test/e2e/coordinator/macvlan-overlay-one/macvlan_overlay_one_test.go
+++ b/test/e2e/coordinator/macvlan-overlay-one/macvlan_overlay_one_test.go
@@ -24,7 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/spidernet-io/spiderpool/pkg/constant"
-	pkgconstant "github.com/spidernet-io/spiderpool/pkg/constant"
 	"github.com/spidernet-io/spiderpool/pkg/ip"
 	spiderpoolv2beta1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1"
 	"github.com/spidernet-io/spiderpool/pkg/types"
@@ -36,12 +35,10 @@ import (
 var r = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator"), func() {
-
 	Context("In overlay mode with macvlan connectivity should be normal", func() {
-
 		BeforeEach(func() {
 			defer GinkgoRecover()
-			var annotations = make(map[string]string)
+			annotations := make(map[string]string)
 
 			task = new(kdoctorV1beta1.NetReach)
 			targetAgent = new(kdoctorV1beta1.NetReachTarget)
@@ -60,7 +57,6 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 		})
 
 		It("kdoctor connectivity should be succeed with no annotations", Serial, Label("C00002", "C00013"), func() {
-
 			enable := true
 			disable := false
 			// create task kdoctor crd
@@ -155,7 +151,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 					Expect(errors.New("wait nethttp test timeout")).NotTo(HaveOccurred(), " running kdoctor task timeout")
 				default:
 					err = frame.GetResource(apitypes.NamespacedName{Name: name}, taskCopy)
-					Expect(err).NotTo(HaveOccurred(), "kdoctor nethttp crd get failed, err is %v", err)
+					Expect(err).NotTo(HaveOccurred(), "kdoctor nethttp crd get failed, err is %w", err)
 
 					if taskCopy.Status.Finish == true {
 						command := fmt.Sprintf("get netreaches.kdoctor.io %s -oyaml", taskCopy.Name)
@@ -198,7 +194,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 	Context("In overlay mode with macvlan connectivity should be normal with annotations: ipam.spidernet.io/default-route-nic: net1", func() {
 		BeforeEach(func() {
 			defer GinkgoRecover()
-			var annotations = make(map[string]string)
+			annotations := make(map[string]string)
 
 			task = new(kdoctorV1beta1.NetReach)
 			targetAgent = new(kdoctorV1beta1.NetReachTarget)
@@ -218,7 +214,6 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 		})
 
 		It("kdoctor connectivity should be succeed with annotations: ipam.spidernet.io/default-route-nic: net1", Serial, Label("C00020"), func() {
-
 			enable := true
 			disable := false
 			// create task kdoctor crd
@@ -313,7 +308,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 					Expect(errors.New("wait nethttp test timeout")).NotTo(HaveOccurred(), " running kdoctor task timeout")
 				default:
 					err = frame.GetResource(apitypes.NamespacedName{Name: name}, taskCopy)
-					Expect(err).NotTo(HaveOccurred(), "kdoctor nethttp crd get failed, err is %v", err)
+					Expect(err).NotTo(HaveOccurred(), "kdoctor nethttp crd get failed, err is %w", err)
 
 					if taskCopy.Status.Finish == true {
 						command := fmt.Sprintf("get netreaches.kdoctor.io %s -oyaml", taskCopy.Name)
@@ -454,7 +449,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 			}
 			podAnnoMarshal, err := json.Marshal(podIppoolsAnno)
 			Expect(err).NotTo(HaveOccurred())
-			var annotations = make(map[string]string)
+			annotations := make(map[string]string)
 			annotations[common.MultusNetworks] = fmt.Sprintf("%s/%s", namespace, multusNadName)
 			annotations[constant.AnnoPodIPPools] = string(podAnnoMarshal)
 			deployObject := common.GenerateExampleDeploymentYaml(depName, namespace, int32(1))
@@ -610,7 +605,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 			Expect(err).NotTo(HaveOccurred())
 
 			// multus cni configure detectGatewayMultusName detectGateway is true
-			var annotations = make(map[string]string)
+			annotations := make(map[string]string)
 			annotations[common.MultusNetworks] = fmt.Sprintf("%s/%s", namespace, detectGatewayMultusName)
 			annotations[constant.AnnoPodIPPool] = string(podAnnoMarshal)
 			deployObject := common.GenerateExampleDeploymentYaml(depName, namespace, int32(1))
@@ -642,18 +637,18 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 					if err != nil {
 						ctx, cancel = context.WithTimeout(context.Background(), common.EventOccurTimeout)
 						defer cancel()
-						GinkgoWriter.Printf("Failed to get v4 gateway unreachable event, trying to get v6 gateway, err is %v", err)
+						GinkgoWriter.Printf("Failed to get v4 gateway unreachable event, trying to get v6 gateway, err is %w", err)
 						err = frame.WaitExceptEventOccurred(ctx, common.OwnerPod, pod.Name, pod.Namespace, networkV6ErrString)
 					}
-					Expect(err).To(Succeed(), "Failed to get the event that the gateway is unreachable, error is: %v", err)
+					Expect(err).To(Succeed(), "Failed to get the event that the gateway is unreachable, error is: %w", err)
 				}
 				if frame.Info.IpV4Enabled && !frame.Info.IpV6Enabled {
 					err = frame.WaitExceptEventOccurred(ctx, common.OwnerPod, pod.Name, pod.Namespace, networkV4ErrString)
-					Expect(err).To(Succeed(), "Failed to get the event that the gateway is unreachable, error is: %v", err)
+					Expect(err).To(Succeed(), "Failed to get the event that the gateway is unreachable, error is: %w", err)
 				}
 				if !frame.Info.IpV4Enabled && frame.Info.IpV6Enabled {
 					err = frame.WaitExceptEventOccurred(ctx, common.OwnerPod, pod.Name, pod.Namespace, networkV6ErrString)
-					Expect(err).To(Succeed(), "Failed to get the event that the gateway is unreachable, error is: %v", err)
+					Expect(err).To(Succeed(), "Failed to get the event that the gateway is unreachable, error is: %w", err)
 				}
 			}
 
@@ -666,7 +661,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 		var v4IpConflict, v6IpConflict string
 		var depName, namespace, v4PoolName, v6PoolName, mode, podCidrType string
 		var v4PoolObj, v6PoolObj *spiderpoolv2beta1.SpiderIPPool
-		var multusNadName = "test-multus-" + common.GenerateString(10, true)
+		multusNadName := "test-multus-" + common.GenerateString(10, true)
 
 		BeforeEach(func() {
 			depName = "dep-name-" + common.GenerateString(10, true)
@@ -740,7 +735,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 
 			if frame.Info.IpV4Enabled {
 				spiderPoolIPv4SubnetVlan200, err := common.GetIppoolByName(frame, common.SpiderPoolIPv4SubnetVlan200)
-				Expect(err).NotTo(HaveOccurred(), "failed to get v4 ippool, error is %v", err)
+				Expect(err).NotTo(HaveOccurred(), "failed to get v4 ippool, error is %w", err)
 
 				v4PoolName, v4PoolObj = common.GenerateExampleIpv4poolObject(1)
 				v4PoolObj.Spec.Subnet = spiderPoolIPv4SubnetVlan200.Spec.Subnet
@@ -757,7 +752,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 				v4PoolObj.Spec.IPs = []string{strings.Split(spiderPoolIPv4SubnetVlan200.Spec.Subnet, "0/")[0] + strconv.Itoa(v4RandNum)}
 				v4IpConflict = v4PoolObj.Spec.IPs[0]
 				err = common.CreateIppool(frame, v4PoolObj)
-				Expect(err).NotTo(HaveOccurred(), "failed to create v4 ippool, error is %v", err)
+				Expect(err).NotTo(HaveOccurred(), "failed to create v4 ippool, error is %w", err)
 
 				// Add a conflicting v4 IP to the cluster
 				ctx, cancel := context.WithTimeout(context.Background(), common.ExecCommandTimeout)
@@ -771,7 +766,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 
 			if frame.Info.IpV6Enabled {
 				spiderPoolIPv6SubnetVlan200, err := common.GetIppoolByName(frame, common.SpiderPoolIPv6SubnetVlan200)
-				Expect(err).NotTo(HaveOccurred(), "failed to get v6 ippool, error is %v", err)
+				Expect(err).NotTo(HaveOccurred(), "failed to get v6 ippool, error is %w", err)
 
 				v6PoolName, v6PoolObj = common.GenerateExampleIpv6poolObject(1)
 				v6PoolObj.Spec.Subnet = spiderPoolIPv6SubnetVlan200.Spec.Subnet
@@ -787,7 +782,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 				v6PoolObj.Spec.IPs = []string{strings.Split(spiderPoolIPv6SubnetVlan200.Spec.Subnet, "/")[0] + strconv.Itoa(v6RandNum)}
 				v6IpConflict = v6PoolObj.Spec.IPs[0]
 				err = common.CreateIppool(frame, v6PoolObj)
-				Expect(err).NotTo(HaveOccurred(), "failed to create v6 ippool, error is %v", err)
+				Expect(err).NotTo(HaveOccurred(), "failed to create v6 ippool, error is %w", err)
 
 				// Add a conflicting v6 IP to the cluster
 				ctx, cancel := context.WithTimeout(context.Background(), common.ExecCommandTimeout)
@@ -795,7 +790,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 				addV6IpCmdString := fmt.Sprintf("ip a add %s/%v dev %s", v6IpConflict, strings.Split(v6PoolObj.Spec.Subnet, "/")[1], common.NIC4)
 				GinkgoWriter.Println("add v6 ip conflict command: ", addV6IpCmdString)
 				output, err := frame.DockerExecCommand(ctx, common.VlanGatewayContainer, addV6IpCmdString)
-				Expect(err).NotTo(HaveOccurred(), "Failed to add v6 conflicting ip of docker container, error is: %v, log: %v.", err, string(output))
+				Expect(err).NotTo(HaveOccurred(), "Failed to add v6 conflicting ip of docker container, error is: %w, log: %v.", err, string(output))
 				podAnno.IPv6Pools = []string{v6PoolName}
 				// Avoid code creating pods too fast, which will be detected by ipv6 addresses dad failed.
 				time.Sleep(time.Second * 10)
@@ -804,7 +799,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 			Expect(err).NotTo(HaveOccurred())
 
 			// multus cni configure MacvlanUnderlayVlan200 ip_conflict is true
-			var annotations = make(map[string]string)
+			annotations := make(map[string]string)
 			annotations[common.MultusNetworks] = fmt.Sprintf("%s/%s", namespace, multusNadName)
 			annotations[constant.AnnoPodIPPool] = string(podAnnoMarshal)
 			deployObject := common.GenerateExampleDeploymentYaml(depName, namespace, int32(1))
@@ -827,7 +822,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 						defer cancel()
 						err = frame.WaitExceptEventOccurred(ctx, common.OwnerPod, pod.Name, pod.Namespace, v6NetworkErrString)
 					}
-					Expect(err).To(Succeed(), "Failed to get IP conflict event, error is: %v", err)
+					Expect(err).To(Succeed(), "Failed to get IP conflict event, error is: %w", err)
 				}
 
 				ctx, cancel := context.WithTimeout(context.Background(), common.ExecCommandTimeout)
@@ -842,7 +837,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 					defer cancel()
 					for _, pod := range podList.Items {
 						err = frame.WaitExceptEventOccurred(ctx, common.OwnerPod, pod.Name, pod.Namespace, v6NetworkErrString)
-						Expect(err).To(Succeed(), "Failed to get IP conflict event, error is: %v", err)
+						Expect(err).To(Succeed(), "Failed to get IP conflict event, error is: %w", err)
 					}
 
 					ctx, cancel = context.WithTimeout(context.Background(), common.ExecCommandTimeout)
@@ -859,7 +854,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 				defer cancel()
 				for _, pod := range podList.Items {
 					err = frame.WaitExceptEventOccurred(ctx, common.OwnerPod, pod.Name, pod.Namespace, v6NetworkErrString)
-					Expect(err).To(Succeed(), "Failed to get IP conflict event, error is: %v", err)
+					Expect(err).To(Succeed(), "Failed to get IP conflict event, error is: %w", err)
 				}
 
 				ctx, cancel = context.WithTimeout(context.Background(), common.ExecCommandTimeout)
@@ -953,7 +948,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 				// set an IP address for NIC to mock IP conflict
 				commandV4Str := fmt.Sprintf("ip addr add %s dev eth0", firstConflictV4IP)
 				output, err := frame.DockerExecCommand(ctx, common.VlanGatewayContainer, commandV4Str)
-				Expect(err).NotTo(HaveOccurred(), "Failed to exec %s for Node %s, error is: %v, log: %v", commandV4Str, common.VlanGatewayContainer, err, string(output))
+				Expect(err).NotTo(HaveOccurred(), "Failed to exec %s for Node %s, error is: %w, log: %v", commandV4Str, common.VlanGatewayContainer, err, string(output))
 
 				podAnno.IPv4Pools = []string{conflictV4PoolName}
 			}
@@ -1005,7 +1000,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 				// set an IP address for NIC to mock IP conflict
 				commandV6Str := fmt.Sprintf("ip addr add %s dev eth0", firstConflictV6IP)
 				output, err := frame.DockerExecCommand(ctx, common.VlanGatewayContainer, commandV6Str)
-				Expect(err).NotTo(HaveOccurred(), "Failed to exec %s for Node %s, error is: %v, log: %v", commandV6Str, common.VlanGatewayContainer, err, string(output))
+				Expect(err).NotTo(HaveOccurred(), "Failed to exec %s for Node %s, error is: %w, log: %v", commandV6Str, common.VlanGatewayContainer, err, string(output))
 
 				podAnno.IPv6Pools = []string{conflictV6PoolName}
 			}
@@ -1086,7 +1081,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 
 				commandV4Str := fmt.Sprintf("ip addr del %s dev eth0", firstConflictV4IP)
 				output, err := frame.DockerExecCommand(ctx, common.VlanGatewayContainer, commandV4Str)
-				Expect(err).NotTo(HaveOccurred(), "Failed to exec %s for Node %s, error is: %v, log: %v", commandV4Str, common.VlanGatewayContainer, err, string(output))
+				Expect(err).NotTo(HaveOccurred(), "Failed to exec %s for Node %s, error is: %w, log: %v", commandV4Str, common.VlanGatewayContainer, err, string(output))
 			}
 			if frame.Info.IpV6Enabled {
 				err := frame.KClient.Delete(ctx, &conflictV6Pool)
@@ -1094,7 +1089,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 
 				commandV6Str := fmt.Sprintf("ip addr del %s dev eth0", firstConflictV6IP)
 				output, err := frame.DockerExecCommand(ctx, common.VlanGatewayContainer, commandV6Str)
-				Expect(err).NotTo(HaveOccurred(), "Failed to exec %s for Node %s, error is: %v, log: %v", commandV6Str, common.VlanGatewayContainer, err, string(output))
+				Expect(err).NotTo(HaveOccurred(), "Failed to exec %s for Node %s, error is: %w, log: %v", commandV6Str, common.VlanGatewayContainer, err, string(output))
 			}
 		})
 	})
@@ -1191,7 +1186,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 			}
 			podAnnoMarshal, err := json.Marshal(podIppoolsAnno)
 			Expect(err).NotTo(HaveOccurred())
-			var annotations = make(map[string]string)
+			annotations := make(map[string]string)
 			annotations[common.MultusNetworks] = fmt.Sprintf("%s/%s", namespace, multusNadName)
 			annotations[constant.AnnoPodIPPools] = string(podAnnoMarshal)
 
@@ -1304,10 +1299,9 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 	})
 
 	Context("In overlay mode with two macvlan CNI networks", func() {
-
 		BeforeEach(func() {
 			defer GinkgoRecover()
-			var annotations = make(map[string]string)
+			annotations := make(map[string]string)
 
 			task = new(kdoctorV1beta1.NetReach)
 			targetAgent = new(kdoctorV1beta1.NetReachTarget)
@@ -1338,7 +1332,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 				}
 				subnetsAnnoMarshal, err := json.Marshal(subnetsAnno)
 				Expect(err).NotTo(HaveOccurred())
-				annotations[pkgconstant.AnnoSpiderSubnets] = string(subnetsAnnoMarshal)
+				annotations[constant.AnnoSpiderSubnets] = string(subnetsAnnoMarshal)
 			}
 			netreach.Annotation = annotations
 			netreach.HostNetwork = false
@@ -1346,7 +1340,6 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 		})
 
 		It("kdoctor connectivity should be succeed", Serial, Label("C00004"), func() {
-
 			enable := true
 			disable := false
 			// create task kdoctor crd
@@ -1404,7 +1397,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 					Expect(errors.New("wait nethttp test timeout")).NotTo(HaveOccurred(), " running kdoctor task timeout")
 				default:
 					err = frame.GetResource(apitypes.NamespacedName{Name: name}, taskCopy)
-					Expect(err).NotTo(HaveOccurred(), "kdoctor nethttp crd get failed, err is %v", err)
+					Expect(err).NotTo(HaveOccurred(), "kdoctor nethttp crd get failed, err is %w", err)
 
 					if taskCopy.Status.Finish == true {
 						command := fmt.Sprintf("get netreaches.kdoctor.io %s -oyaml", taskCopy.Name)
@@ -1447,7 +1440,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 	Context("In overlay mode with three macvlan interfaces, connectivity should be normal", func() {
 		BeforeEach(func() {
 			defer GinkgoRecover()
-			var annotations = make(map[string]string)
+			annotations := make(map[string]string)
 
 			task = new(kdoctorV1beta1.NetReach)
 			targetAgent = new(kdoctorV1beta1.NetReachTarget)
@@ -1466,7 +1459,6 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 		})
 
 		It("kdoctor connectivity should be succeed with three macavlan interfaces", Serial, Label("C00021"), func() {
-
 			enable := true
 			disable := false
 			// create task kdoctor crd
@@ -1561,7 +1553,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 					Expect(errors.New("wait nethttp test timeout")).NotTo(HaveOccurred(), " running kdoctor task timeout")
 				default:
 					err = frame.GetResource(apitypes.NamespacedName{Name: name}, taskCopy)
-					Expect(err).NotTo(HaveOccurred(), "kdoctor nethttp crd get failed, err is %v", err)
+					Expect(err).NotTo(HaveOccurred(), "kdoctor nethttp crd get failed, err is %w", err)
 
 					if taskCopy.Status.Finish == true {
 						command := fmt.Sprintf("get netreaches.kdoctor.io %s -oyaml", taskCopy.Name)
@@ -1659,7 +1651,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 			}
 			podAnnoMarshal, err := json.Marshal(podIppoolsAnno)
 			Expect(err).NotTo(HaveOccurred())
-			var annotations = make(map[string]string)
+			annotations := make(map[string]string)
 			annotations[common.MultusNetworks] = fmt.Sprintf("%s/%s", namespace, multusNadName)
 			annotations[constant.AnnoPodIPPools] = string(podAnnoMarshal)
 			deployObject := common.GenerateExampleDeploymentYaml(depName, namespace, int32(1))
@@ -1699,7 +1691,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 			}
 			podAnnoMarshal, err := json.Marshal(podIppoolsAnno)
 			Expect(err).NotTo(HaveOccurred())
-			var annotations = make(map[string]string)
+			annotations := make(map[string]string)
 
 			// 2.Customize the Pod NIC name through muluts
 			annotations[common.MultusNetworks] = fmt.Sprintf("%s/%s@%s", namespace, multusNadName, randomNICName)
@@ -1751,7 +1743,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 			}
 			podAnnoMarshal, err := json.Marshal(podIppoolsAnno)
 			Expect(err).NotTo(HaveOccurred())
-			var annotations = make(map[string]string)
+			annotations := make(map[string]string)
 			annotations[common.MultusNetworks] = fmt.Sprintf("%s/%s", namespace, multusNadName)
 			annotations[constant.AnnoPodIPPools] = string(podAnnoMarshal)
 			deployObject := common.GenerateExampleDeploymentYaml(depName, namespace, int32(1))
@@ -1781,7 +1773,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 					}
 				}
 				if err != nil {
-					GinkgoWriter.Printf("table 100 does not exist: %v", err)
+					GinkgoWriter.Printf("table 100 does not exist: %w", err)
 				}
 				return nil
 			}).WithTimeout(time.Minute * 2).WithPolling(time.Second).Should(BeNil())
@@ -1829,7 +1821,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 			}
 
 			// 2. Create the NIC and set the IP address from step 1 as dirty data for the neighbor table in each node.
-			var nicName = "nic" + common.GenerateString(3, true)
+			nicName := "nic" + common.GenerateString(3, true)
 			var nicMac string
 			for _, node := range frame.Info.KindNodeList {
 				var err error
@@ -1875,7 +1867,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 			}
 			podAnnoMarshal, err := json.Marshal(podIppoolsAnno)
 			Expect(err).NotTo(HaveOccurred())
-			var annotations = make(map[string]string)
+			annotations := make(map[string]string)
 
 			annotations[common.MultusNetworks] = fmt.Sprintf("%s/%s", namespace, multusNadName)
 			annotations[constant.AnnoPodIPPools] = string(podAnnoMarshal)
@@ -1916,7 +1908,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 						podNicMacInNode := fmt.Sprintf("ip -4 n | grep %s | grep %s", dirtyV4IPUsed, strings.TrimRight(string(podNicMac), "\n"))
 						_, err = frame.DockerExecCommand(ctx, pod.Spec.NodeName, podNicMacInNode)
 						if err != nil {
-							return fmt.Errorf("pod IP Mac %v should exist, try checking again..., errors %v ", podNicMac, err)
+							return fmt.Errorf("pod IP Mac %v should exist, try checking again..., errors %w ", podNicMac, err)
 						}
 					}
 
@@ -1932,7 +1924,7 @@ var _ = Describe("MacvlanOverlayOne", Label("overlay", "one-nic", "coordinator")
 						podNicMacInNode := fmt.Sprintf("ip -6 n | grep %s | grep %s", dirtyV6IPUsed, strings.TrimRight(string(podNicMac), "\n"))
 						_, err = frame.DockerExecCommand(ctx, pod.Spec.NodeName, podNicMacInNode)
 						if err != nil {
-							return fmt.Errorf("pod IP Mac %v should exist, try checking again..., errors %v ", podNicMac, err)
+							return fmt.Errorf("pod IP Mac %v should exist, try checking again..., errors %w ", podNicMac, err)
 						}
 					}
 				}

--- a/test/e2e/coordinator/macvlan-underlay-one/macvlan_underlay_one_suite_test.go
+++ b/test/e2e/coordinator/macvlan-underlay-one/macvlan_underlay_one_suite_test.go
@@ -20,12 +20,15 @@ func TestMacvlanStandaloneOne(t *testing.T) {
 	RunSpecs(t, "MacvlanStandaloneOne Suite")
 }
 
-var frame *e2e.Framework
-var name string
-var err error
-var annotations = make(map[string]string)
-var successRate = float64(1)
-var delayMs = int64(15000)
+var (
+	frame       *e2e.Framework
+	name        string
+	err         error
+	annotations = make(map[string]string)
+	successRate = float64(1)
+	delayMs     = int64(15000)
+)
+
 var (
 	task        *kdoctorV1beta1.NetReach
 	netreach    *kdoctorV1beta1.AgentSpec

--- a/test/e2e/coordinator/macvlan-underlay-one/macvlan_underlay_one_test.go
+++ b/test/e2e/coordinator/macvlan-underlay-one/macvlan_underlay_one_test.go
@@ -29,9 +29,7 @@ import (
 )
 
 var _ = Describe("MacvlanUnderlayOne", Serial, Label("underlay", "one-interface", "coordinator"), func() {
-
 	Context("In underlay mode, verify single CNI network", func() {
-
 		BeforeEach(func() {
 			defer GinkgoRecover()
 			task = new(kdoctorV1beta1.NetReach)
@@ -58,7 +56,6 @@ var _ = Describe("MacvlanUnderlayOne", Serial, Label("underlay", "one-interface"
 		})
 
 		It("kdoctor connectivity should be succeed", Label("C00001", "C00013"), Label("ebpf"), func() {
-
 			enable := true
 			disable := false
 			// create task kdoctor crd
@@ -289,7 +286,7 @@ var _ = Describe("MacvlanUnderlayOne", Serial, Label("underlay", "one-interface"
 			}
 			podAnnoMarshal, err := json.Marshal(podIppoolsAnno)
 			Expect(err).NotTo(HaveOccurred())
-			var annotations = make(map[string]string)
+			annotations := make(map[string]string)
 			annotations[common.MultusNetworks] = fmt.Sprintf("%s/%s", namespace, multusNadName)
 			annotations[pkgconstant.AnnoPodIPPools] = string(podAnnoMarshal)
 			deployObject := common.GenerateExampleDeploymentYaml(depName, namespace, int32(1))
@@ -399,7 +396,6 @@ var _ = Describe("MacvlanUnderlayOne", Serial, Label("underlay", "one-interface"
 	})
 
 	Context("In Underlay mode, verify two CNI networks", func() {
-
 		BeforeEach(func() {
 			defer GinkgoRecover()
 			task = new(kdoctorV1beta1.NetReach)
@@ -450,7 +446,6 @@ var _ = Describe("MacvlanUnderlayOne", Serial, Label("underlay", "one-interface"
 		})
 
 		PIt("kdoctor connectivity should be succeed", Label("C00003"), Label("ebpf"), func() {
-
 			enable := true
 			disable := false
 			// create task kdoctor crd
@@ -497,7 +492,7 @@ var _ = Describe("MacvlanUnderlayOne", Serial, Label("underlay", "one-interface"
 
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*60*5)
 			defer cancel()
-			var err1 = errors.New("error has occurred")
+			err1 := errors.New("error has occurred")
 			for run {
 				select {
 				case <-ctx.Done():

--- a/test/e2e/ifacer/ifacer_test.go
+++ b/test/e2e/ifacer/ifacer_test.go
@@ -215,7 +215,6 @@ var _ = Describe("test ifacer", Label("ifacer"), func() {
 	// N00004: Different VLAN interfaces have the same VLAN id, an error is returned
 	// N00005: The master interface is down, setting it up and creating VLAN interface
 	It("Creating a VLAN interface sets the primary interface from down to up while disallowing subinterfaces with the same vlan ID.", Serial, Label("N00004", "N00005"), func() {
-
 		mainInterface = common.NIC5
 		ctx, cancel := context.WithTimeout(context.Background(), common.ExecCommandTimeout)
 		defer cancel()
@@ -237,7 +236,7 @@ var _ = Describe("test ifacer", Label("ifacer"), func() {
 		Eventually(func() bool {
 			for _, node := range frame.Info.KindNodeList {
 				out, err := frame.DockerExecCommand(ctx, node, setDownString)
-				Expect(err).NotTo(HaveOccurred(), "Executing the set sub-interface to down command on the node %s fails, error: %v, log: %v", node, err, string(out))
+				Expect(err).NotTo(HaveOccurred(), "Executing the set sub-interface to down command on the node %s fails, error: %w, log: %v", node, err, string(out))
 			}
 			return true
 		}, common.ResourceDeleteTimeout, common.ForcedWaitingTime).Should(BeTrue())
@@ -321,17 +320,17 @@ var _ = Describe("test ifacer", Label("ifacer"), func() {
 		Eventually(func() bool {
 			podList, err = frame.GetPodListByLabel(dsObject.Spec.Template.Labels)
 			if err != nil {
-				GinkgoWriter.Printf("failed to get pod list by label, error is %v", err)
+				GinkgoWriter.Printf("failed to get pod list by label, error is %w", err)
 				return false
 			}
 			return len(podList.Items) == len(frame.Info.KindNodeList)
 		}, common.PodStartTimeout, common.ForcedWaitingTime).Should(BeTrue())
 
-		sameVlanIdErrorString := fmt.Sprintf("cannot have multiple different vlan interfaces with the same vlanId %v on node at the same time", vlanInterface)
+		sameVlanIDErrorString := fmt.Sprintf("cannot have multiple different vlan interfaces with the same vlanId %v on node at the same time", vlanInterface)
 		for _, pod := range podList.Items {
 			ctx, cancel = context.WithTimeout(context.Background(), common.EventOccurTimeout)
 			defer cancel()
-			err = frame.WaitExceptEventOccurred(ctx, common.OwnerPod, pod.Name, namespace, sameVlanIdErrorString)
+			err = frame.WaitExceptEventOccurred(ctx, common.OwnerPod, pod.Name, namespace, sameVlanIDErrorString)
 			Expect(err).NotTo(HaveOccurred())
 		}
 	})

--- a/test/e2e/performance/performance_test.go
+++ b/test/e2e/performance/performance_test.go
@@ -28,7 +28,6 @@ var _ = Describe("performance test case", Serial, Label("performance"), func() {
 		v4PoolNameList, v6PoolNameList                            []string
 	)
 	BeforeEach(func() {
-
 		// Init test ENV
 		perName = "per" + tools.RandomName()
 		nsName = "ns" + tools.RandomName()
@@ -62,7 +61,6 @@ var _ = Describe("performance test case", Serial, Label("performance"), func() {
 
 	DescribeTable("time cost for creating, rebuilding, deleting deployment pod in batches",
 		func(controllerType string, replicas int32, overtimeCheck time.Duration) {
-
 			// Generate Pod.IPPool annotations string and create IPv4Pool and IPV6Pool
 			ctx := context.TODO()
 			if frame.Info.IpV4Enabled {
@@ -88,8 +86,8 @@ var _ = Describe("performance test case", Serial, Label("performance"), func() {
 			podIppoolAnnoStr = common.GeneratePodIPPoolAnnotations(frame, common.NIC1, v4PoolNameList, v6PoolNameList)
 
 			// Generate Deployment yaml with Pod.IPPool annotation
-			switch {
-			case controllerType == common.OwnerDeployment:
+			switch controllerType {
+			case common.OwnerDeployment:
 				dpm = common.GenerateExampleDeploymentYaml(perName, nsName, replicas)
 				dpm.Spec.Template.Annotations = map[string]string{constant.AnnoPodIPPool: podIppoolAnnoStr}
 			default:
@@ -104,15 +102,15 @@ var _ = Describe("performance test case", Serial, Label("performance"), func() {
 			Expect(dpm).NotTo(BeNil())
 
 			// The Pods IP is recorded in the IPPool.
-			podlist = common.CheckPodIpReadyByLabel(frame, dpm.Spec.Template.Labels, v4PoolNameList, v6PoolNameList)
+			podlist = common.CheckPodIPReadyByLabel(frame, dpm.Spec.Template.Labels, v4PoolNameList, v6PoolNameList)
 			GinkgoWriter.Printf("Pod %v/%v IP recorded in IPPool %v %v \n", nsName, perName, v4PoolNameList, v6PoolNameList)
 
 			// check uuid in ippool
 			if frame.Info.IpV4Enabled {
-				Expect(common.CheckUniqueUuidInSpiderPool(frame, v4PoolName)).NotTo(HaveOccurred())
+				Expect(common.CheckUniqueUUIDInSpiderPool(frame, v4PoolName)).NotTo(HaveOccurred())
 			}
 			if frame.Info.IpV6Enabled {
-				Expect(common.CheckUniqueUuidInSpiderPool(frame, v6PoolName)).NotTo(HaveOccurred())
+				Expect(common.CheckUniqueUUIDInSpiderPool(frame, v6PoolName)).NotTo(HaveOccurred())
 			}
 			endT1 := time.Since(startT1)
 
@@ -123,15 +121,15 @@ var _ = Describe("performance test case", Serial, Label("performance"), func() {
 			GinkgoWriter.Printf("Succeeded to rebuild controller %v : %v/%v, rebuild replicas is %v \n", controllerType, nsName, perName, replicas)
 
 			// All Pod IPs are still recorded in the IPPool after the deployment rebuild.
-			podlist = common.CheckPodIpReadyByLabel(frame, dpm.Spec.Template.Labels, v4PoolNameList, v6PoolNameList)
+			podlist = common.CheckPodIPReadyByLabel(frame, dpm.Spec.Template.Labels, v4PoolNameList, v6PoolNameList)
 			GinkgoWriter.Printf("Pod %v/%v IP recorded in IPPool %v %v \n", nsName, perName, v4PoolNameList, v6PoolNameList)
 
 			// check uuid in ippool
 			if frame.Info.IpV4Enabled {
-				Expect(common.CheckUniqueUuidInSpiderPool(frame, v4PoolName)).NotTo(HaveOccurred())
+				Expect(common.CheckUniqueUUIDInSpiderPool(frame, v4PoolName)).NotTo(HaveOccurred())
 			}
 			if frame.Info.IpV6Enabled {
-				Expect(common.CheckUniqueUuidInSpiderPool(frame, v6PoolName)).NotTo(HaveOccurred())
+				Expect(common.CheckUniqueUUIDInSpiderPool(frame, v6PoolName)).NotTo(HaveOccurred())
 			}
 			endT2 := time.Since(startT2)
 

--- a/test/e2e/podwebhook/podwebhook_test.go
+++ b/test/e2e/podwebhook/podwebhook_test.go
@@ -99,7 +99,7 @@ var _ = Describe("Podwebhook", func() {
 
 			By("Check pod network annotations and resources")
 			p, err := frame.GetPod(pod.Name, pod.Namespace)
-			Expect(err).NotTo(HaveOccurred(), "failed to get pod: %v", err)
+			Expect(err).NotTo(HaveOccurred(), "failed to get pod: %w", err)
 
 			GinkgoWriter.Printf("Pod annotations: %v\n", p.Annotations)
 			GinkgoWriter.Printf("Pod resources: %v\n", p.Spec.Containers[0].Resources.Limits)

--- a/test/e2e/reclaim/chaos_test.go
+++ b/test/e2e/reclaim/chaos_test.go
@@ -25,11 +25,10 @@ import (
 )
 
 var _ = Describe("Chaos Testing of GC", Label("reclaim"), func() {
-
 	Context("GC correctly handles ip addresses", func() {
 		var (
-			gcNamespace                    string = "sts-ns" + tools.RandomName()
-			replicasNum                    int32  = 5
+			gcNamespace                          = "sts-ns" + tools.RandomName()
+			replicasNum                    int32 = 5
 			v4PoolName, v6PoolName         string
 			v4PoolObj, v6PoolObj           *spiderpool.SpiderIPPool
 			v4PoolNameList, v6PoolNameList []string
@@ -37,7 +36,6 @@ var _ = Describe("Chaos Testing of GC", Label("reclaim"), func() {
 		)
 
 		BeforeEach(func() {
-
 			err = frame.CreateNamespaceUntilDefaultServiceAccountReady(gcNamespace, common.ServiceAccountReadyTimeout)
 			Expect(err).NotTo(HaveOccurred(), "failed to create namespace %v", gcNamespace)
 
@@ -82,12 +80,12 @@ var _ = Describe("Chaos Testing of GC", Label("reclaim"), func() {
 
 		It("The IPPool is used by 2 statefulSets and scaling up/down the replicas, gc works normally and there is no IP conflict in statefulset.", Label("G00011"), func() {
 			var (
-				stsNameOne string = "sts-1-" + tools.RandomName()
-				stsNameTwo string = "sts-2-" + tools.RandomName()
+				stsNameOne = "sts-1-" + tools.RandomName()
+				stsNameTwo = "sts-2-" + tools.RandomName()
 			)
 
 			// 1. Using the default pool, create a statefulset application with 5 replicas and check if spiderpool has assigned it an IP address.
-			var annotations = make(map[string]string)
+			annotations := make(map[string]string)
 			podIppoolAnnoStr := common.GeneratePodIPPoolAnnotations(frame, common.NIC1, v4PoolNameList, v6PoolNameList)
 			annotations[constant.AnnoPodIPPool] = podIppoolAnnoStr
 			annotations[common.MultusDefaultNetwork] = fmt.Sprintf("%s/%s", common.MultusNs, common.MacvlanUnderlayVlan0)
@@ -104,7 +102,7 @@ var _ = Describe("Chaos Testing of GC", Label("reclaim"), func() {
 				}
 				return frame.CheckPodListRunning(podList)
 			}, common.PodStartTimeout, common.ForcedWaitingTime).Should(BeTrue())
-			ok, _, _, err := common.CheckPodIpRecordInIppool(frame, v4PoolNameList, v6PoolNameList, podList)
+			ok, _, _, err := common.CheckPodIPRecordInIPPool(frame, v4PoolNameList, v6PoolNameList, podList)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ok).To(BeTrue())
 
@@ -152,7 +150,7 @@ var _ = Describe("Chaos Testing of GC", Label("reclaim"), func() {
 				// It is expected that GC All and tracePod_worker processes will be triggered multiple times within 1 minutes to check whether the IP address is incorrectly collected by GC,
 				// resulting in an IP address conflict.
 				if time.Since(startTime) >= timeout {
-					fmt.Println("3 minutes have passed, IP conflict check passed, exiting.")
+					GinkgoWriter.Println("3 minutes have passed, IP conflict check passed, exiting.")
 					break
 				}
 				GinkgoWriter.Printf("Start checking for IP conflicts, time: %v \n", time.Since(startTime))
@@ -186,7 +184,7 @@ var _ = Describe("Chaos Testing of GC", Label("reclaim"), func() {
 
 			// Check that all Pods are assigned IPs in the expected IPPool.
 			GinkgoWriter.Printf("Start checking that the Pod IPs are recorded in the desired v4 pool %v and v6 pool %v \n", v4PoolNameList, v6PoolNameList)
-			ok, _, _, err = common.CheckPodIpRecordInIppool(frame, v4PoolNameList, v6PoolNameList, &runningPodList)
+			ok, _, _, err = common.CheckPodIPRecordInIPPool(frame, v4PoolNameList, v6PoolNameList, &runningPodList)
 			Expect(ok).To(BeTrue())
 			Expect(err).NotTo(HaveOccurred(), "error: %v \n", err)
 		})
@@ -194,10 +192,10 @@ var _ = Describe("Chaos Testing of GC", Label("reclaim"), func() {
 
 	Context("Chaos Testing of GC", func() {
 		var (
-			chaosNamespace                 string = "gc-chaos-ns-" + tools.RandomName()
-			replicasNum                    int32  = 3
-			testUser                       int    = 6
-			ipNumInIPPool                  int    = testUser * int(replicasNum)
+			chaosNamespace                       = "gc-chaos-ns-" + tools.RandomName()
+			replicasNum                    int32 = 3
+			testUser                             = 6
+			ipNumInIPPool                        = testUser * int(replicasNum)
 			v4PoolName, v6PoolName         string
 			v4PoolObj, v6PoolObj           *spiderpool.SpiderIPPool
 			v4PoolNameList, v6PoolNameList []string
@@ -268,16 +266,16 @@ var _ = Describe("Chaos Testing of GC", Label("reclaim"), func() {
 
 		It("Multiple resource types compete for a single IPPool. In scenarios of creation, scaling up/down, and deletion, GC all can correctly handle IP addresses.", Serial, Label("G00012"), func() {
 			var (
-				stsNameOne       string = "gc-chaos-sts-1-" + tools.RandomName()
-				stsNameTwo       string = "gc-chaos-sts-2-" + tools.RandomName()
-				deployNameOne    string = "gc-chaos-deploy-1-" + tools.RandomName()
-				deployNameTwo    string = "gc-chaos-deploy-2-" + tools.RandomName()
-				kruiseStsNameOne string = "gc-chaos-kruise-sts-1-" + tools.RandomName()
-				kruiseStsNameTwo string = "gc-chaos-kruise-sts-2-" + tools.RandomName()
+				stsNameOne       = "gc-chaos-sts-1-" + tools.RandomName()
+				stsNameTwo       = "gc-chaos-sts-2-" + tools.RandomName()
+				deployNameOne    = "gc-chaos-deploy-1-" + tools.RandomName()
+				deployNameTwo    = "gc-chaos-deploy-2-" + tools.RandomName()
+				kruiseStsNameOne = "gc-chaos-kruise-sts-1-" + tools.RandomName()
+				kruiseStsNameTwo = "gc-chaos-kruise-sts-2-" + tools.RandomName()
 			)
 
 			// 1. Use the spiderpool annotation to specify the same IPPool for all users, allowing them to compete for IP resources.
-			var annotations = map[string]string{
+			annotations := map[string]string{
 				constant.AnnoPodIPPool:      common.GeneratePodIPPoolAnnotations(frame, common.NIC1, v4PoolNameList, v6PoolNameList),
 				common.MultusDefaultNetwork: fmt.Sprintf("%s/%s", common.MultusNs, common.MacvlanUnderlayVlan0),
 			}
@@ -292,7 +290,7 @@ var _ = Describe("Chaos Testing of GC", Label("reclaim"), func() {
 				startTime := time.Now()
 				err := createFunc()
 				if err != nil {
-					return fmt.Errorf("failed to create %s/%s, at time %v, error %v", chaosNamespace, createName, startTime, err)
+					return fmt.Errorf("failed to create %s/%s, at time %v, error %w", chaosNamespace, createName, startTime, err)
 				}
 
 				GinkgoWriter.Printf("Succeeded in creating %s/%s at time %v \n", chaosNamespace, createName, startTime)
@@ -380,17 +378,17 @@ var _ = Describe("Chaos Testing of GC", Label("reclaim"), func() {
 				ctx, cancel := context.WithTimeout(context.Background(), common.PodStartTimeout)
 				defer cancel()
 				Expect(frame.WaitPodListRunning(map[string]string{"namespace": chaosNamespace}, ipNumInIPPool, ctx)).NotTo(HaveOccurred(),
-					"failed to check pod status in namespace %s, error %v", chaosNamespace, err)
+					"failed to check pod status in namespace %s, error %w", chaosNamespace, err)
 				GinkgoWriter.Printf("all Pods in the namespace %s are running normally. \n", chaosNamespace)
 				podList, err := frame.GetPodListByLabel(map[string]string{"namespace": chaosNamespace})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(common.ValidatePodIPConflict(podList)).NotTo(HaveOccurred())
 				if frame.Info.IpV4Enabled {
-					Expect(common.CheckIppoolSanity(frame, v4PoolName)).NotTo(HaveOccurred(), "error %v", err)
+					Expect(common.CheckIppoolSanity(frame, v4PoolName)).NotTo(HaveOccurred(), "error %w", err)
 					GinkgoWriter.Printf("successfully checked sanity of spiderpool %v \n", v4PoolName)
 				}
 				if frame.Info.IpV6Enabled {
-					Expect(common.CheckIppoolSanity(frame, v6PoolName)).NotTo(HaveOccurred(), "error %v", err)
+					Expect(common.CheckIppoolSanity(frame, v6PoolName)).NotTo(HaveOccurred(), "error %w", err)
 					GinkgoWriter.Printf("successfully checked sanity of spiderpool %v \n", v6PoolName)
 				}
 			}
@@ -411,7 +409,7 @@ var _ = Describe("Chaos Testing of GC", Label("reclaim"), func() {
 				startTime := time.Now()
 				err := scaleFunc(scale)
 				if err != nil {
-					return fmt.Errorf("failed to scale %s/%s replicas to %d at time %v, error %v", chaosNamespace, scaleName, scale, startTime, err)
+					return fmt.Errorf("failed to scale %s/%s replicas to %d at time %v, error %w", chaosNamespace, scaleName, scale, startTime, err)
 				}
 
 				GinkgoWriter.Printf("Succeeded in scaling %s/%s to %d replicas at time %v\n", chaosNamespace, scaleName, scale, startTime)
@@ -425,7 +423,7 @@ var _ = Describe("Chaos Testing of GC", Label("reclaim"), func() {
 				}
 				_, err = frame.ScaleStatefulSet(stsObj, scale)
 				if err != nil {
-					return fmt.Errorf("failed to scale %s/%s replicas to %d, error: %v", chaosNamespace, scaleName, scale, err)
+					return fmt.Errorf("failed to scale %s/%s replicas to %d, error: %w", chaosNamespace, scaleName, scale, err)
 				}
 				return nil
 			}
@@ -437,7 +435,7 @@ var _ = Describe("Chaos Testing of GC", Label("reclaim"), func() {
 				}
 				_, err = frame.ScaleDeployment(deployObj, scale)
 				if err != nil {
-					return fmt.Errorf("failed to scale %s/%s replicas to %d, error: %v", chaosNamespace, scaleName, scale, err)
+					return fmt.Errorf("failed to scale %s/%s replicas to %d, error: %w", chaosNamespace, scaleName, scale, err)
 				}
 				return nil
 			}
@@ -449,7 +447,7 @@ var _ = Describe("Chaos Testing of GC", Label("reclaim"), func() {
 				}
 				_, err = common.ScaleKruiseStatefulSet(frame, kruiseStsObj, scale)
 				if err != nil {
-					return fmt.Errorf("failed to scale %s/%s replicas to %d, error: %v", chaosNamespace, scaleName, scale, err)
+					return fmt.Errorf("failed to scale %s/%s replicas to %d, error: %w", chaosNamespace, scaleName, scale, err)
 				}
 				return nil
 			}
@@ -515,7 +513,7 @@ var _ = Describe("Chaos Testing of GC", Label("reclaim"), func() {
 				strartTime := time.Now()
 				err := restartFunc()
 				if err != nil {
-					return fmt.Errorf("failed to restart %s/%s at time %v, error %v", chaosNamespace, restartName, strartTime, err)
+					return fmt.Errorf("failed to restart %s/%s at time %v, error %w", chaosNamespace, restartName, strartTime, err)
 				}
 
 				GinkgoWriter.Printf("Succeeded in restarting %s/%s at time %v \n", chaosNamespace, restartName, strartTime)
@@ -564,7 +562,7 @@ var _ = Describe("Chaos Testing of GC", Label("reclaim"), func() {
 
 			// Get all Pods in advance to check if ippool and endpoint are deleted
 			podList, err := frame.GetPodList(client.InNamespace(chaosNamespace))
-			Expect(err).NotTo(HaveOccurred(), "before deleting, failed to get Pod list %v", err)
+			Expect(err).NotTo(HaveOccurred(), "before deleting, failed to get Pod list %w", err)
 
 			// 8. Randomly delete Pods to verify that IPPool and endpoints can be recycled
 			deletePodSet := func(deleteFun func() error, deleteName string, duration time.Duration) error {
@@ -623,7 +621,7 @@ var _ = Describe("Chaos Testing of GC", Label("reclaim"), func() {
 						if api_errors.IsNotFound(err) {
 							return fmt.Errorf("v4 ippool %s dose not exist", v4PoolName)
 						}
-						return fmt.Errorf("failed to get v4 ippool %s, error %v", v4PoolName, err)
+						return fmt.Errorf("failed to get v4 ippool %s, error %w", v4PoolName, err)
 					}
 					if ippool.Status.AllocatedIPs != nil || *ippool.Status.AllocatedIPCount != int64(0) {
 						return fmt.Errorf("The IP address %v in the v4 ippool %v is not completely released", *ippool.Status.AllocatedIPs, v4PoolName)
@@ -635,7 +633,7 @@ var _ = Describe("Chaos Testing of GC", Label("reclaim"), func() {
 						if api_errors.IsNotFound(err) {
 							return fmt.Errorf("ippool %s dose not exist", v4PoolName)
 						}
-						return fmt.Errorf("failed to get ippool %s, error %v", v6PoolName, err)
+						return fmt.Errorf("failed to get ippool %s, error %w", v6PoolName, err)
 					}
 					if ippool.Status.AllocatedIPs != nil || *ippool.Status.AllocatedIPCount != int64(0) {
 						return fmt.Errorf("The IP address %v in the v6 ippool %v is not completely released", *ippool.Status.AllocatedIPs, v6PoolName)
@@ -648,7 +646,7 @@ var _ = Describe("Chaos Testing of GC", Label("reclaim"), func() {
 						if api_errors.IsNotFound(err) {
 							return nil
 						}
-						return fmt.Errorf("failed to get endpoint %s/%s, error %v", pod.Namespace, pod.Name, err)
+						return fmt.Errorf("failed to get endpoint %s/%s, error %w", pod.Namespace, pod.Name, err)
 					}
 				}
 				return nil

--- a/test/e2e/reclaim/reclaim_test.go
+++ b/test/e2e/reclaim/reclaim_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/spidernet-io/spiderpool/pkg/utils/convert"
 	"github.com/spidernet-io/spiderpool/pkg/utils/retry"
 	"github.com/spidernet-io/spiderpool/test/e2e/common"
-	api_errors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 var _ = Describe("test ip with reclaim ip case", Label("reclaim"), func() {
@@ -69,8 +68,8 @@ var _ = Describe("test ip with reclaim ip case", Label("reclaim"), func() {
 
 	DescribeTable("check ip release after job finished", func(behavior common.JobBehave) {
 		var wg sync.WaitGroup
-		var jdName string = "jd" + tools.RandomName()
-		var jobHoldDuration = "sleep 5;"
+		jdName := "jd" + tools.RandomName()
+		jobHoldDuration := "sleep 5;"
 
 		// Generate job yaml with different behaviour and create it
 		GinkgoWriter.Printf("try to create Job %v/%v with job behavior is %v \n", namespace, jdName, behavior)
@@ -103,7 +102,7 @@ var _ = Describe("test ip with reclaim ip case", Label("reclaim"), func() {
 						continue OUTER
 					}
 					GinkgoWriter.Printf("Confirm that the job has been assigned to the IP address \n")
-					ok, _, _, err := common.CheckPodIpRecordInIppool(frame, globalDefaultV4IPPoolList, globalDefaultV6IPPoolList, podList)
+					ok, _, _, err := common.CheckPodIPRecordInIPPool(frame, globalDefaultV4IPPoolList, globalDefaultV6IPPoolList, podList)
 					if !ok || err != nil {
 						continue OUTER
 					}
@@ -151,7 +150,7 @@ var _ = Describe("test ip with reclaim ip case", Label("reclaim"), func() {
 	It(`G00002:the IP of a running pod should not be reclaimed after a same-name pod within a different namespace is deleted;
 		G00001:related IP resource recorded in ippool will be reclaimed after the namespace is deleted`, Label("G00002", "G00001", "smoke"), func() {
 		var podList *corev1.PodList
-		var namespace1 string = "ns1-" + tools.RandomName()
+		namespace1 := "ns1-" + tools.RandomName()
 
 		// Create a namespace again and name it namespace1
 		GinkgoWriter.Printf("create namespace1 %v \n", namespace1)
@@ -185,7 +184,7 @@ var _ = Describe("test ip with reclaim ip case", Label("reclaim"), func() {
 
 		// Another Pod in namespace1 with the same name has a normal status and IP
 		Expect(frame.CheckPodListIpReady(podList)).NotTo(HaveOccurred())
-		ok, _, _, err := common.CheckPodIpRecordInIppool(frame, globalDefaultV4IPPoolList, globalDefaultV6IPPoolList, podList)
+		ok, _, _, err := common.CheckPodIPRecordInIPPool(frame, globalDefaultV4IPPoolList, globalDefaultV6IPPoolList, podList)
 		Expect(err).NotTo(HaveOccurred(), "error: %v\n", err)
 		Expect(ok).To(BeTrue())
 
@@ -209,15 +208,15 @@ var _ = Describe("test ip with reclaim ip case", Label("reclaim"), func() {
 		Label("G00003", "G00004", "E00001", "E00002", "E00003", "E00004", "E00005", "E00006", "smoke"), Serial, func() {
 			var podList *corev1.PodList
 			var (
-				deployName     string = "deploy-" + tools.RandomName()
-				depReplicasNum int32  = 1
-				stsName        string = "sts-" + tools.RandomName()
-				stsReplicasNum int32  = 1
-				dsName         string = "ds-" + tools.RandomName()
-				rsName         string = "rs-" + tools.RandomName()
-				rsReplicasNum  int32  = 1
-				jobName        string = "job-" + tools.RandomName()
-				jobNum         int32  = *ptr.To(int32(1))
+				deployName           = "deploy-" + tools.RandomName()
+				depReplicasNum int32 = 1
+				stsName              = "sts-" + tools.RandomName()
+				stsReplicasNum int32 = 1
+				dsName               = "ds-" + tools.RandomName()
+				rsName               = "rs-" + tools.RandomName()
+				rsReplicasNum  int32 = 1
+				jobName              = "job-" + tools.RandomName()
+				jobNum               = *ptr.To(int32(1))
 			)
 
 			// Create different controller resources
@@ -295,7 +294,7 @@ var _ = Describe("test ip with reclaim ip case", Label("reclaim"), func() {
 			// E00001、E00002、E00003、E00004、E00005、E00006
 			// Check the resource ip information in ippool is correct
 			GinkgoWriter.Printf("check the ip information of resources in the nippool is correct \n", namespace)
-			ok, _, _, err := common.CheckPodIpRecordInIppool(frame, globalDefaultV4IPPoolList, globalDefaultV6IPPoolList, podList)
+			ok, _, _, err := common.CheckPodIPRecordInIPPool(frame, globalDefaultV4IPPoolList, globalDefaultV6IPPoolList, podList)
 			Expect(err).NotTo(HaveOccurred(), "failed to check ip recorded in ippool, err: %v\n", err)
 			Expect(ok).To(BeTrue())
 
@@ -397,7 +396,8 @@ var _ = Describe("test ip with reclaim ip case", Label("reclaim"), func() {
 			dirtyIPv4 = common.GenerateRandomIPV4()
 			GinkgoWriter.Printf("generate dirty IPv4 :%v \n", dirtyIPv4)
 
-			dirtyIPv6 = common.GenerateRandomIPV6()
+			dirtyIPv6, err := common.GenerateRandomIPV6()
+			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Printf("generate dirty IPv6:%v\n", dirtyIPv6)
 
 			dirtyPodName = "dirtyPod-" + tools.RandomName()
@@ -479,7 +479,7 @@ var _ = Describe("test ip with reclaim ip case", Label("reclaim"), func() {
 			// check pod ip in ippool
 			GinkgoWriter.Printf("check pod %v/%v ip in ippool\n", namespace, podName)
 			podList := &corev1.PodList{Items: []corev1.Pod{*pod}}
-			allRecorded, _, _, err := common.CheckPodIpRecordInIppool(frame, v4poolNameList, v6poolNameList, podList)
+			allRecorded, _, _, err := common.CheckPodIPRecordInIPPool(frame, v4poolNameList, v6poolNameList, podList)
 			Expect(allRecorded).To(BeTrue())
 			Expect(err).NotTo(HaveOccurred())
 
@@ -527,7 +527,7 @@ var _ = Describe("test ip with reclaim ip case", Label("reclaim"), func() {
 						GinkgoWriter.Printf("update v4 IPPool %v for adding dirty record: %+v \n", v4poolName, *dirtyIPv4Record)
 						if err := frame.UpdateResourceStatus(v4poolObj); err != nil {
 							if errors.IsConflict(err) {
-								GinkgoWriter.Printf("A conflict occurred when updating the status of Spiderpool v4 IPPool %s: %s, errors: %v", v4poolObj.Name, err)
+								GinkgoWriter.Printf("A conflict occurred when updating the status of Spiderpool v4 IPPool %s: %s, errors: %w", v4poolObj.Name, err)
 							}
 							return err
 						}
@@ -560,7 +560,7 @@ var _ = Describe("test ip with reclaim ip case", Label("reclaim"), func() {
 						GinkgoWriter.Printf("update v6 IPPool %v for adding dirty record: %+v \n", v6poolName, *dirtyIPv6Record)
 						if err := frame.UpdateResourceStatus(v6poolObj); err != nil {
 							if errors.IsConflict(err) {
-								GinkgoWriter.Printf("A conflict occurred when updating the status of Spiderpool v6 IPPool %s: %s, errors: %v", v6poolObj.Name, err)
+								GinkgoWriter.Printf("A conflict occurred when updating the status of Spiderpool v6 IPPool %s: %s, errors: %w", v6poolObj.Name, err)
 							}
 							return err
 						}
@@ -592,7 +592,7 @@ var _ = Describe("test ip with reclaim ip case", Label("reclaim"), func() {
 				}
 			}
 			// Check Pod IP in IPPool
-			allRecorded, _, _, err = common.CheckPodIpRecordInIppool(frame, v4poolNameList, v6poolNameList, podList)
+			allRecorded, _, _, err = common.CheckPodIPRecordInIPPool(frame, v4poolNameList, v6poolNameList, podList)
 			Expect(allRecorded).To(BeTrue())
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Printf("succeed to check pod %v/%v ip in ippool\n", namespace, podName)
@@ -667,7 +667,7 @@ var _ = Describe("test ip with reclaim ip case", Label("reclaim"), func() {
 			// Get the original spiderpool-controller Pod list，
 			// to check if the Pods have been restarted
 			originalPodList, err = frame.GetPodListByLabel(map[string]string{"app.kubernetes.io/component": constant.SpiderpoolController})
-			Expect(err).NotTo(HaveOccurred(), "failed to get spiderpoolController Pod list, error is: %v", err)
+			Expect(err).NotTo(HaveOccurred(), "failed to get spiderpoolController Pod list, error is: %w", err)
 
 			// When maxSurge is 0, spiderpool-controller Pods will be restarted one by one
 			err = frame.KClient.Patch(ctx, deployment, client.MergeFrom(oldDeploy))
@@ -695,7 +695,7 @@ var _ = Describe("test ip with reclaim ip case", Label("reclaim"), func() {
 					checkCommandStr := "systemctl is-active kubelet"
 					output, err := frame.DockerExecCommand(ctx, workerNodeName, checkCommandStr)
 					if err != nil {
-						return fmt.Errorf("Failed to check kubelet status: %v, log: %v", err, string(output))
+						return fmt.Errorf("Failed to check kubelet status: %w, log: %v", err, string(output))
 					}
 					if strings.TrimSpace(string(output)) != "active" {
 						return fmt.Errorf("kubelet is not running, status: %v", strings.TrimSpace(string(output)))
@@ -843,7 +843,7 @@ var _ = Describe("test ip with reclaim ip case", Label("reclaim"), func() {
 				if frame.Info.IpV4Enabled {
 					defaultV4pool, err := common.GetIppoolByName(frame, common.SpiderPoolIPv4PoolDefault)
 					if nil != err {
-						return fmt.Errorf("failed to get IPPool %s, error: %v", common.SpiderPoolIPv4PoolDefault, err)
+						return fmt.Errorf("failed to get IPPool %s, error: %w", common.SpiderPoolIPv4PoolDefault, err)
 					}
 
 					v4Allocations, err := convert.UnmarshalIPPoolAllocatedIPs(defaultV4pool.Status.AllocatedIPs)
@@ -857,7 +857,7 @@ var _ = Describe("test ip with reclaim ip case", Label("reclaim"), func() {
 				if frame.Info.IpV6Enabled {
 					defaultV6pool, err := common.GetIppoolByName(frame, common.SpiderPoolIPv6PoolDefault)
 					if nil != err {
-						return fmt.Errorf("failed to get IPPool %s, error: %v", common.SpiderPoolIPv6PoolDefault, err)
+						return fmt.Errorf("failed to get IPPool %s, error: %w", common.SpiderPoolIPv6PoolDefault, err)
 					}
 
 					v6Allocations, err := convert.UnmarshalIPPoolAllocatedIPs(defaultV6pool.Status.AllocatedIPs)
@@ -879,12 +879,12 @@ var _ = Describe("test ip with reclaim ip case", Label("reclaim"), func() {
 		}
 
 		var (
-			stsName        string = "sts-" + tools.RandomName()
-			stsReplicasNum int32  = 2
+			stsName              = "sts-" + tools.RandomName()
+			stsReplicasNum int32 = 2
 		)
 
 		// 1. Using the default pool, create a set of statefulset applications and check that spiderpool assigns it an IP address.
-		var annotations = make(map[string]string)
+		annotations := make(map[string]string)
 		podIppoolAnnoStr := common.GeneratePodIPPoolAnnotations(frame, common.NIC1, globalDefaultV4IPPoolList, globalDefaultV6IPPoolList)
 		annotations[constant.AnnoPodIPPool] = podIppoolAnnoStr
 		annotations[common.MultusDefaultNetwork] = fmt.Sprintf("%s/%s", common.MultusNs, common.MacvlanUnderlayVlan0)
@@ -902,7 +902,7 @@ var _ = Describe("test ip with reclaim ip case", Label("reclaim"), func() {
 			return frame.CheckPodListRunning(podList)
 		}, common.PodStartTimeout, common.ForcedWaitingTime).Should(BeTrue())
 		GinkgoWriter.Printf("Check that the Pod IP record is in the expected v4 pool %v , v6 pool %v \n", globalDefaultV4IPPoolList, globalDefaultV6IPPoolList)
-		ok, _, _, err := common.CheckPodIpRecordInIppool(frame, globalDefaultV4IPPoolList, globalDefaultV6IPPoolList, podList)
+		ok, _, _, err := common.CheckPodIPRecordInIPPool(frame, globalDefaultV4IPPoolList, globalDefaultV6IPPoolList, podList)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ok).To(BeTrue())
 
@@ -932,7 +932,7 @@ var _ = Describe("test ip with reclaim ip case", Label("reclaim"), func() {
 			for _, pod := range podList.Items {
 				stsEndpoint, err := common.GetWorkloadByName(frame, namespace, pod.Name)
 				if err != nil {
-					if api_errors.IsNotFound(err) {
+					if errors.IsNotFound(err) {
 						GinkgoWriter.Printf("The statefulSet endpoint %v/%v has been recycled yet \n", namespace, pod.Name)
 						continue
 					} else {
@@ -945,7 +945,7 @@ var _ = Describe("test ip with reclaim ip case", Label("reclaim"), func() {
 				}
 			}
 			// The expected IP address does not exist in the pool
-			ok, _, _, _ := common.CheckPodIpRecordInIppool(frame, globalDefaultV4IPPoolList, globalDefaultV6IPPoolList, podList)
+			ok, _, _, _ := common.CheckPodIPRecordInIPPool(frame, globalDefaultV4IPPoolList, globalDefaultV6IPPoolList, podList)
 			if ok {
 				GinkgoWriter.Printf("The historical IP of statefulSet %v/%v in ippool has not been recycled yet, waiting... \n", namespace, stsName)
 				return false

--- a/test/e2e/reliability/reliability_suite_test.go
+++ b/test/e2e/reliability/reliability_suite_test.go
@@ -26,5 +26,4 @@ var _ = BeforeSuite(func() {
 	var e error
 	frame, e = e2e.NewFramework(GinkgoT(), []func(*runtime.Scheme) error{spiderpool.AddToScheme, coordinationv1.AddToScheme})
 	Expect(e).NotTo(HaveOccurred())
-
 })

--- a/test/e2e/reliability/reliability_test.go
+++ b/test/e2e/reliability/reliability_test.go
@@ -121,7 +121,7 @@ var _ = Describe("test reliability", Label("reliability"), Serial, func() {
 					}
 
 					// Check the Pod's IP recorded IPPool
-					ok, _, _, err := common.CheckPodIpRecordInIppool(frame, globalDefaultV4IppoolList, globalDefaultV6IppoolList, podList)
+					ok, _, _, err := common.CheckPodIPRecordInIPPool(frame, globalDefaultV4IppoolList, globalDefaultV6IppoolList, podList)
 					if err != nil && !ok {
 						return err
 					}
@@ -173,7 +173,7 @@ var _ = Describe("test reliability", Label("reliability"), Serial, func() {
 			Expect(err1).ShouldNot(HaveOccurred())
 
 			// Check if the IP exists in the IPPool before restarting the node
-			isRecord1, _, _, err2 := common.CheckPodIpRecordInIppool(frame, globalDefaultV4IppoolList, globalDefaultV6IppoolList, podList)
+			isRecord1, _, _, err2 := common.CheckPodIPRecordInIPPool(frame, globalDefaultV4IppoolList, globalDefaultV6IppoolList, podList)
 			Expect(isRecord1).Should(BeTrue())
 			Expect(err2).ShouldNot(HaveOccurred())
 			GinkgoWriter.Printf("Pod IP recorded in IPPool %v,%v \n", globalDefaultV4IppoolList, globalDefaultV6IppoolList)
@@ -196,7 +196,7 @@ var _ = Describe("test reliability", Label("reliability"), Serial, func() {
 			Expect(err5).ShouldNot(HaveOccurred())
 
 			// After restarting the node, check that the IP is still recorded in the ippool.
-			isRecord2, _, _, err6 := common.CheckPodIpRecordInIppool(frame, globalDefaultV4IppoolList, globalDefaultV6IppoolList, restartPodList)
+			isRecord2, _, _, err6 := common.CheckPodIPRecordInIPPool(frame, globalDefaultV4IppoolList, globalDefaultV6IppoolList, restartPodList)
 			Expect(isRecord2).Should(BeTrue())
 			Expect(err6).ShouldNot(HaveOccurred())
 			GinkgoWriter.Printf("After restarting the node, the IP recorded in the ippool: %v ,%v", globalDefaultV4IppoolList, globalDefaultV6IppoolList)
@@ -209,7 +209,6 @@ var _ = Describe("test reliability", Label("reliability"), Serial, func() {
 	)
 
 	It("Spiderpool Controller active/standby switching is normal", Label("R00007"), func() {
-
 		podList, err := frame.GetPodListByLabel(map[string]string{"app.kubernetes.io/component": constant.SpiderpoolController})
 		Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/reservedip/reservedip_test.go
+++ b/test/e2e/reservedip/reservedip_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 var _ = Describe("test reservedIP", Label("reservedIP"), func() {
-	var nsName, manualDeployName, autoDeployName, v4PoolName, v6PoolName, v4ReservedIpName, v6ReservedIpName string
+	var nsName, manualDeployName, autoDeployName, v4PoolName, v6PoolName, v4ReservedIPName, v6ReservedIPName string
 	var v4PoolNameList, v6PoolNameList []string
 	var iPv4PoolObj, iPv6PoolObj *spiderpoolv2beta1.SpiderIPPool
-	var v4ReservedIpObj, v6ReservedIpObj *spiderpoolv2beta1.SpiderReservedIP
+	var ipv4ReservedIPObj, ipv6ReservedIPObj *spiderpoolv2beta1.SpiderReservedIP
 	var err error
 	var v4SubnetName, v6SubnetName string
 	var v4SubnetObject, v6SubnetObject *spiderpoolv2beta1.SpiderSubnet
@@ -123,28 +123,28 @@ var _ = Describe("test reservedIP", Label("reservedIP"), func() {
 	It("S00001: an IP who is set in ReservedIP CRD, should not be assigned to a pod; S00003: Failed to set same IP in excludeIPs when an IP is assigned to a pod",
 		Label("S00001", "smoke", "S00003", "I00011"), func() {
 			const deployOriginialNum = int(1)
-			const fixedIPNumber string = "+1"
+			const fixedIPNumber = "+1"
 
 			if frame.Info.IpV4Enabled {
 				if frame.Info.SpiderSubnetEnabled {
-					v4ReservedIpName, v4ReservedIpObj = common.GenerateExampleV4ReservedIpObject(v4SubnetObject.Spec.IPs)
+					v4ReservedIPName, ipv4ReservedIPObj = common.GenerateExampleV4ReservedIPObject(v4SubnetObject.Spec.IPs)
 				} else {
-					v4ReservedIpName, v4ReservedIpObj = common.GenerateExampleV4ReservedIpObject(iPv4PoolObj.Spec.IPs)
+					v4ReservedIPName, ipv4ReservedIPObj = common.GenerateExampleV4ReservedIPObject(iPv4PoolObj.Spec.IPs)
 				}
-				err = common.CreateReservedIP(frame, v4ReservedIpObj)
+				err = common.CreateReservedIP(frame, ipv4ReservedIPObj)
 				Expect(err).NotTo(HaveOccurred())
-				GinkgoWriter.Printf("Successfully created v4 reservedIP: %v \n", v4ReservedIpName)
+				GinkgoWriter.Printf("Successfully created v4 reservedIP: %v \n", v4ReservedIPName)
 			}
 
 			if frame.Info.IpV6Enabled {
 				if frame.Info.SpiderSubnetEnabled {
-					v6ReservedIpName, v6ReservedIpObj = common.GenerateExampleV6ReservedIpObject(v6SubnetObject.Spec.IPs)
+					v6ReservedIPName, ipv6ReservedIPObj = common.GenerateExampleV6ReservedIPObject(v6SubnetObject.Spec.IPs)
 				} else {
-					v6ReservedIpName, v6ReservedIpObj = common.GenerateExampleV6ReservedIpObject(iPv6PoolObj.Spec.IPs)
+					v6ReservedIPName, ipv6ReservedIPObj = common.GenerateExampleV6ReservedIPObject(iPv6PoolObj.Spec.IPs)
 				}
-				err = common.CreateReservedIP(frame, v6ReservedIpObj)
+				err = common.CreateReservedIP(frame, ipv6ReservedIPObj)
 				Expect(err).NotTo(HaveOccurred())
-				GinkgoWriter.Printf("Successfully created v6 reservedIP : %v \n", v6ReservedIpName)
+				GinkgoWriter.Printf("Successfully created v6 reservedIP : %v \n", v6ReservedIPName)
 			}
 
 			// Generate IPPool annotation string
@@ -215,12 +215,12 @@ var _ = Describe("test reservedIP", Label("reservedIP"), func() {
 			ctx2, cancel2 := context.WithTimeout(context.Background(), common.ResourceDeleteTimeout)
 			defer cancel2()
 			if frame.Info.IpV4Enabled {
-				Expect(common.DeleteResverdIPUntilFinish(ctx2, frame, v4ReservedIpName)).To(Succeed())
-				GinkgoWriter.Printf("Delete v4 reservedIP: %v successfully \n", v4ReservedIpName)
+				Expect(common.DeleteResverdIPUntilFinish(ctx2, frame, v4ReservedIPName)).To(Succeed())
+				GinkgoWriter.Printf("Delete v4 reservedIP: %v successfully \n", v4ReservedIPName)
 			}
 			if frame.Info.IpV6Enabled {
-				Expect(common.DeleteResverdIPUntilFinish(ctx2, frame, v6ReservedIpName)).To(Succeed())
-				GinkgoWriter.Printf("Delete v6 reservedIP: %v successfully \n", v6ReservedIpName)
+				Expect(common.DeleteResverdIPUntilFinish(ctx2, frame, v6ReservedIPName)).To(Succeed())
+				GinkgoWriter.Printf("Delete v6 reservedIP: %v successfully \n", v6ReservedIPName)
 			}
 
 			GinkgoWriter.Println("After removing the reservedIP, wait for the Pod to restart until running.")
@@ -228,7 +228,7 @@ var _ = Describe("test reservedIP", Label("reservedIP"), func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Succeeded to assign IPv4、IPv6 ip for Deployment/Pod and Deployment/Pod IP recorded in IPPool
-			common.CheckPodIpReadyByLabel(frame, manualDeployObject.Spec.Selector.MatchLabels, v4PoolNameList, v6PoolNameList)
+			common.CheckPodIPReadyByLabel(frame, manualDeployObject.Spec.Selector.MatchLabels, v4PoolNameList, v6PoolNameList)
 			GinkgoWriter.Printf("Pod %v/%v IP recorded in IPPool %v %v \n", nsName, manualDeployName, v4PoolNameList, v6PoolNameList)
 
 			if frame.Info.SpiderSubnetEnabled {
@@ -239,12 +239,12 @@ var _ = Describe("test reservedIP", Label("reservedIP"), func() {
 				ctx3, cancel3 := context.WithTimeout(context.Background(), common.PodStartTimeout)
 				defer cancel3()
 				if frame.Info.IpV4Enabled {
-					Expect(common.WaitValidateSubnetAndPoolIpConsistency(ctx3, frame, v4SubnetName)).NotTo(HaveOccurred())
+					Expect(common.WaitValidateSubnetAndPoolIPConsistency(ctx3, frame, v4SubnetName)).NotTo(HaveOccurred())
 					v4PoolNameList, err = common.GetPoolNameListInSubnet(frame, v4SubnetName)
 					Expect(err).NotTo(HaveOccurred())
 				}
 				if frame.Info.IpV6Enabled {
-					Expect(common.WaitValidateSubnetAndPoolIpConsistency(ctx3, frame, v6SubnetName)).NotTo(HaveOccurred())
+					Expect(common.WaitValidateSubnetAndPoolIPConsistency(ctx3, frame, v6SubnetName)).NotTo(HaveOccurred())
 					v6PoolNameList, err = common.GetPoolNameListInSubnet(frame, v6SubnetName)
 					Expect(err).NotTo(HaveOccurred())
 				}
@@ -252,7 +252,7 @@ var _ = Describe("test reservedIP", Label("reservedIP"), func() {
 				// Check that the pod's ip is recorded in the ippool
 				restartPodList, err := frame.GetPodList(client.InNamespace(nsName))
 				Expect(err).NotTo(HaveOccurred())
-				ok, _, _, err := common.CheckPodIpRecordInIppool(frame, v4PoolNameList, v6PoolNameList, restartPodList)
+				ok, _, _, err := common.CheckPodIPRecordInIPPool(frame, v4PoolNameList, v6PoolNameList, restartPodList)
 				Expect(ok).To(BeTrue())
 				Expect(err).NotTo(HaveOccurred())
 			}

--- a/test/e2e/spidercoordinator/spidercoordinator_suite_test.go
+++ b/test/e2e/spidercoordinator/spidercoordinator_suite_test.go
@@ -33,8 +33,10 @@ func TestSpiderCoordinator(t *testing.T) {
 	RunSpecs(t, "SpiderCoordinator Suite")
 }
 
-var frame *e2e.Framework
-var v4PodCIDRString, v6PodCIDRString string
+var (
+	frame                            *e2e.Framework
+	v4PodCIDRString, v6PodCIDRString string
+)
 
 var _ = BeforeSuite(func() {
 	defer GinkgoRecover()
@@ -65,7 +67,7 @@ var _ = BeforeSuite(func() {
 	if common.CheckRunOverlayCNI() && common.CheckCiliumFeatureOn() && !common.CheckCalicoFeatureOn() {
 		// cilium(v1.17.3) can't start with ipv6 only, see https://github.com/cilium/cilium/issues/37817
 		// revert it if the issuce has been fixed
-		//if frame.Info.IpV4Enabled {
+		// if frame.Info.IpV4Enabled {
 		v4PodCIDRString = CILIUM_CLUSTER_POD_SUBNET_V4
 		// }
 		if frame.Info.IpV6Enabled {
@@ -88,12 +90,11 @@ func GetSpiderCoordinator(name string) (*spiderpoolv2beta1.SpiderCoordinator, er
 }
 
 func PatchSpiderCoordinator(desired, original *spiderpoolv2beta1.SpiderCoordinator, opts ...client.PatchOption) error {
-
 	mergePatch := client.MergeFrom(original)
 	d, err := mergePatch.Data(desired)
 	GinkgoWriter.Printf("the patch is: %v. \n", string(d))
 	if err != nil {
-		return fmt.Errorf("failed to generate patch, err is %v", err)
+		return fmt.Errorf("failed to generate patch, err is %w", err)
 	}
 
 	return frame.PatchResource(desired, mergePatch, opts...)

--- a/test/e2e/spidercoordinator/spidercoordinator_test.go
+++ b/test/e2e/spidercoordinator/spidercoordinator_test.go
@@ -24,15 +24,13 @@ import (
 )
 
 var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Serial, func() {
-
 	Context("auto mode of spidercoordinator", func() {
 		// This case adaptation runs in different network modes, such as macvlan, calico, and cilium.
 		// Prerequisite: The podCIDRType of the spidercoodinator deployed by default in the spiderpool environment is auto mode.
 		It("Switch podCIDRType to `auto`, see if it could auto fetch the type", Label("V00001"), func() {
-
 			By("Get the default spidercoodinator.")
 			spc, err := GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
-			Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator,error is %v", err)
+			Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator,error is %w", err)
 			GinkgoWriter.Printf("Display the default spider coordinator information, podCIDRType: %v, status: %v \n", *spc.Spec.PodCIDRType, spc.Status)
 
 			By("Checking podCIDRType for status.overlayPodCIDR in auto mode is as expected.")
@@ -56,7 +54,7 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 
 		BeforeEach(func() {
 			podList, err := frame.GetPodListByLabel(map[string]string{"app.kubernetes.io/component": constant.SpiderpoolController})
-			Expect(err).NotTo(HaveOccurred(), "failed to get SpiderpoolController, error is %v", err)
+			Expect(err).NotTo(HaveOccurred(), "failed to get SpiderpoolController, error is %w", err)
 
 			ctx, cancel := context.WithTimeout(context.Background(), common.ExecCommandTimeout)
 			defer cancel()
@@ -84,7 +82,7 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 
 			// Switch podCIDRType to cniType.
 			spc, err := GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
-			Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+			Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %w", err)
 			GinkgoWriter.Printf("Display the default spider coordinator information, podCIDRType: %v, status: %v \n", *spc.Spec.PodCIDRType, spc.Status)
 
 			spcCopy := spc.DeepCopy()
@@ -109,7 +107,7 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 
 				// Switch podCIDRType to cniType.
 				spc, err := GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
-				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %w", err)
 				GinkgoWriter.Printf("Display the default spider coordinator information, podCIDRType: %v, status: %v \n", *spc.Spec.PodCIDRType, spc.Status)
 
 				spcCopy := spc.DeepCopy()
@@ -125,7 +123,7 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 
 				// Switch podCIDRType to cniType.
 				sPodCIDRTypeCNI, err := GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
-				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %w", err)
 				sPodCIDRTypeCNICopy := sPodCIDRTypeCNI.DeepCopy()
 
 				GinkgoWriter.Printf("Display the default spider coordinator information, podCIDRType: %v, status: %v \n", *sPodCIDRTypeCNICopy.Spec.PodCIDRType, sPodCIDRTypeCNICopy.Status)
@@ -134,7 +132,7 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 
 				Eventually(func() bool {
 					spc, err := GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
-					Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+					Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %w", err)
 					GinkgoWriter.Printf("Display the default spider coordinator information, podCIDRType: %v, status: %v \n", *spc.Spec.PodCIDRType, spc.Status)
 
 					By("Checking podCIDRType if is auto.")
@@ -167,7 +165,7 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 		It("Switch podCIDRType to `auto` but no cni files in /etc/cni/net.d, Viewing should be consistent with `none`.", Label("V00002"), func() {
 			By("Change podCIDRType to auto, which can trigger the spidercoordinator updated.")
 			spc, err := GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
-			Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+			Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %w", err)
 
 			spcCopy := spc.DeepCopy()
 			spcCopy.Spec.PodCIDRType = ptr.To(common.PodCIDRTypeAuto)
@@ -176,7 +174,7 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 			Eventually(func() bool {
 				By("Get the default spidercoodinator.")
 				spc, err := GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
-				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %w", err)
 
 				By("Checking podCIDRType is auto.")
 				if *spc.Spec.PodCIDRType != common.PodCIDRTypeAuto {
@@ -230,7 +228,7 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 				// The default podCIDRType for all environments is `auto` and should eventually fall back to auto mode in any case.
 				// Avoid failure of other use cases.
 				spc, err := GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
-				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %w", err)
 				GinkgoWriter.Printf("Display the default spider coordinator information, podCIDRType: %v, status: %v \n", *spc.Spec.PodCIDRType, spc.Status)
 
 				// Switch podCIDRType to `auto`.
@@ -240,7 +238,7 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 
 				Eventually(func() bool {
 					spc, err := GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
-					Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+					Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %w", err)
 					GinkgoWriter.Printf("Display the default spider coordinator information, podCIDRType: %v, status: %v \n", *spc.Spec.PodCIDRType, spc.Status)
 
 					if len(spc.Status.OverlayPodCIDR) == 0 || spc.Status.Phase != coordinatormanager.Synced {
@@ -272,10 +270,9 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 		// This case adaptation runs in different network modes, such as macvlan, calico, and cilium.
 		// Prerequisite: The podCIDRType of the spidercoodinator deployed by default in the spiderpool environment is auto mode.
 		It("Switch podCIDRType to `calico` or `cilium`, see if it could auto fetch the cidr from calico ippools", Label("V00003", "V00004", "V00006", "V00008"), func() {
-
 			By("Get the default spidercoodinator.")
 			spc, err := GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
-			Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+			Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %w", err)
 			GinkgoWriter.Printf("Display the default spider coordinator information, podCIDRType: %v, status: %v \n", *spc.Spec.PodCIDRType, spc.Status)
 
 			// Switch podCIDRType to `calico` or `cilium`.
@@ -286,7 +283,7 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 			Expect(PatchSpiderCoordinator(spcCopy, spc)).NotTo(HaveOccurred())
 			Eventually(func() bool {
 				spc, err := GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
-				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %w", err)
 
 				if spc.Status.Phase == coordinatormanager.Synced {
 					GinkgoWriter.Printf("status.Phase and OverlayPodCIDR status is still synchronizing, status %+v \n", spc.Status.OverlayPodCIDR)
@@ -298,7 +295,7 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 				GinkgoWriter.Printf("status.Phase status is %+v \n", spc.Status.Phase)
 
 				// Pod creation in the Not Ready state should fail.
-				var annotations = make(map[string]string)
+				annotations := make(map[string]string)
 				annotations[common.MultusDefaultNetwork] = fmt.Sprintf("%s/%s", common.MultusNs, common.MacvlanUnderlayVlan0)
 				deployObject := common.GenerateExampleDeploymentYaml(depName, namespace, int32(1))
 				deployObject.Spec.Template.Annotations = annotations
@@ -319,7 +316,7 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 			}, common.ExecCommandTimeout, common.EventOccurTimeout*2).Should(BeTrue())
 
 			spc, err = GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
-			Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+			Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %w", err)
 			GinkgoWriter.Printf("Display the default spider coordinator information, podCIDRType: %v, status: %v \n", *spc.Spec.PodCIDRType, spc.Status)
 
 			spcCopy = spc.DeepCopy()
@@ -327,7 +324,7 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 			Expect(PatchSpiderCoordinator(spcCopy, spc)).NotTo(HaveOccurred())
 			Eventually(func() bool {
 				spc, err := GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
-				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %w", err)
 				GinkgoWriter.Printf("Display the default spider coordinator information, podCIDRType: %v, status: %v \n", *spc.Spec.PodCIDRType, spc.Status)
 
 				if len(spc.Status.OverlayPodCIDR) == 0 || spc.Status.Phase != coordinatormanager.Synced {
@@ -353,10 +350,9 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 		})
 
 		It("Switch podCIDRType to `none`, expect the cidr of status to be empty", Label("V00005"), func() {
-
 			By("Get the default spidercoodinator.")
 			spc, err := GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
-			Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+			Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %w", err)
 			GinkgoWriter.Printf("Display the default spider coordinator information, podCIDRType: %v, status: %v \n", *spc.Spec.PodCIDRType, spc.Status)
 
 			// Switch podCIDRType to `None`.
@@ -365,7 +361,7 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 			Expect(PatchSpiderCoordinator(spcCopy, spc)).NotTo(HaveOccurred())
 			Eventually(func() bool {
 				spc, err := GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
-				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %w", err)
 
 				if spc.Status.Phase != coordinatormanager.Synced {
 					GinkgoWriter.Printf("status.Phase status is still synchronizing, status %+v \n", spc.Status.Phase)
@@ -384,7 +380,6 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 	})
 
 	Context("It can get the clusterCIDR from kubeadmConfig and kube-controller-manager pod", func() {
-
 		var spc *spiderpoolv2beta1.SpiderCoordinator
 		var cm *corev1.ConfigMap
 		var masterNode string
@@ -406,7 +401,7 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 			Expect(err).NotTo(HaveOccurred())
 
 			spc, err = GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
-			Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+			Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %w", err)
 
 			// Switch podCIDRType to `cluster`.
 			spcCopy := spc.DeepCopy()
@@ -415,7 +410,7 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 
 			DeferCleanup(func() {
 				spc, err := GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
-				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %w", err)
 				GinkgoWriter.Printf("Display the default spider coordinator information, podCIDRType: %v, status: %v \n", *spc.Spec.PodCIDRType, spc.Status)
 
 				// Switch podCIDRType to `auto`.
@@ -430,12 +425,11 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 						return false
 					}
 					return true
-
 				}, common.ExecCommandTimeout, common.ForcedWaitingTime).Should(BeTrue())
 
 				Eventually(func() bool {
 					spc, err := GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
-					Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+					Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %w", err)
 					GinkgoWriter.Printf("Display the default spider coordinator information, podCIDRType: %v, status: %v \n", *spc.Spec.PodCIDRType, spc.Status)
 
 					if len(spc.Status.OverlayPodCIDR) == 0 || spc.Status.Phase != coordinatormanager.Synced {
@@ -466,12 +460,12 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 			GinkgoWriter.Printf("podCIDR and serviceCIDR from spidercoordinator: %v,%v\n", spc.Status.OverlayPodCIDR, spc.Status.ServiceCIDR)
 
 			podCIDR, serviceCIDr, err := utils.ExtractK8sCIDRFromKubeadmConfigMap(cm)
-			Expect(err).NotTo(HaveOccurred(), "Failed to extract k8s CIDR from Kubeadm configMap,  error is %v", err)
+			Expect(err).NotTo(HaveOccurred(), "Failed to extract k8s CIDR from Kubeadm configMap,  error is %w", err)
 			GinkgoWriter.Printf("podCIDR and serviceCIDR from kubeadm-config : %v,%v\n", podCIDR, serviceCIDr)
 
 			Eventually(func() bool {
 				spc, err = GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
-				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %w", err)
 
 				if spc.Status.Phase != coordinatormanager.Synced {
 					return false
@@ -506,7 +500,7 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 
 			Eventually(func() bool {
 				spc, err = GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
-				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %w", err)
 
 				if spc.Status.Phase != coordinatormanager.Synced {
 					return false
@@ -628,7 +622,6 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 				GinkgoWriter.Printf("got kube-controller-manage pod's status: %v\n", kcmPod.Status.Phase)
 				return kcmPod.Status.Phase == corev1.PodRunning
 			}, common.PodStartTimeout*2, common.ForcedWaitingTime).Should(BeTrue())
-
 		})
 	})
 
@@ -658,7 +651,7 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 
 		It("It can get service cidr from k8s serviceCIDR resources", func() {
 			spc, err = GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
-			Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+			Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %w", err)
 
 			originalServiceCIDR := spc.Status.ServiceCIDR
 			GinkgoWriter.Printf("serviceCIDR from original spidercoordinator: %v\n", spc.Status.ServiceCIDR)
@@ -672,7 +665,7 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 
 			Eventually(func() bool {
 				spc, err = GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
-				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %w", err)
 
 				if spc.Status.Phase != coordinatormanager.Synced {
 					return false
@@ -697,7 +690,7 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 
 			Eventually(func() bool {
 				spc, err = GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
-				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %w", err)
 
 				if spc.Status.Phase != coordinatormanager.Synced {
 					return false
@@ -725,7 +718,7 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 
 			DeferCleanup(func() {
 				spc, err := GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
-				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+				Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %w", err)
 
 				spcCopy := spc.DeepCopy()
 				spcCopy.Spec.HostRuleTable = ptr.To(500)
@@ -739,17 +732,16 @@ var _ = Describe("SpiderCoordinator", Label("spidercoordinator", "overlay"), Ser
 		})
 
 		It("The table name can be customized by hostRuleTable ", Label("C00016"), func() {
-
 			By("Get the default spidercoodinator.")
 			spc, err := GetSpiderCoordinator(common.SpidercoodinatorDefaultName)
-			Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %v", err)
+			Expect(err).NotTo(HaveOccurred(), "failed to get SpiderCoordinator, error is %w", err)
 
 			spcCopy := spc.DeepCopy()
 			hostRuleTable := 200
 			spcCopy.Spec.HostRuleTable = ptr.To(hostRuleTable)
 			Expect(PatchSpiderCoordinator(spcCopy, spc)).NotTo(HaveOccurred())
 
-			var annotations = make(map[string]string)
+			annotations := make(map[string]string)
 			annotations[common.MultusNetworks] = fmt.Sprintf("%s/%s", common.MultusNs, common.MacvlanUnderlayVlan0)
 			deployObject := common.GenerateExampleDeploymentYaml(depName, nsName, int32(1))
 			deployObject.Spec.Template.Annotations = annotations

--- a/test/e2e/spidermultus/spidermultus_test.go
+++ b/test/e2e/spidermultus/spidermultus_test.go
@@ -14,7 +14,6 @@ import (
 	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	netutils "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils"
 
-	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	api_errors "k8s.io/apimachinery/pkg/api/errors"
@@ -221,7 +220,7 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 			newSmc.Annotations = map[string]string{constant.AnnoNetAttachConfName: testSmc.Name}
 			GinkgoWriter.Printf("spidermultus cr with annotations: %+v \n", newSmc.Annotations)
 			err := frame.CreateSpiderMultusInstance(newSmc)
-			GinkgoWriter.Printf("should fail to create, the error is: %v", err.Error())
+			GinkgoWriter.Printf("should fail to create, the error is: %w", err.Error())
 			errorMsg := fmt.Sprintf("the net-attach-def %s/%s already exists and is managed by SpiderMultusConfig %s/%s.",
 				newSmc.Namespace, testSmc.Name, testSmc.Namespace, testSmc.Name)
 			Expect(err).To(MatchError(ContainSubstring(errorMsg)))
@@ -314,7 +313,7 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 	})
 
 	It("Already have multus cr, spidermultus should take care of it", Label("M00014"), func() {
-		var alreadyExistingNadName string = "already-multus-" + common.GenerateString(10, true)
+		alreadyExistingNadName := "already-multus-" + common.GenerateString(10, true)
 
 		// Create a multus cr in advance
 		nadObj := &v1.NetworkAttachmentDefinition{
@@ -362,7 +361,7 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 	})
 
 	It("The value of webhook verification cniType is inconsistent with cniConf", Label("M00015"), func() {
-		var smcName string = "multus-" + common.GenerateString(10, true)
+		smcName := "multus-" + common.GenerateString(10, true)
 
 		// Define Spidermultus cr where cniType does not agree with cniConf and create.
 		smc := &v2beta1.SpiderMultusConfig{
@@ -379,12 +378,12 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 		}
 		GinkgoWriter.Printf("spidermultus cr: %+v \n", smc)
 		err := frame.CreateSpiderMultusInstance(smc)
-		GinkgoWriter.Printf("should fail to create, the error is: %v", err.Error())
+		GinkgoWriter.Printf("should fail to create, the error is: %w", err.Error())
 		Expect(err).To(HaveOccurred())
 	})
 
 	It("vlanID is not in the range of 0-4094 and will not be created", Label("M00016"), func() {
-		var smcName string = "multus-" + common.GenerateString(10, true)
+		smcName := "multus-" + common.GenerateString(10, true)
 
 		// Define Spidermultus cr with vlanID -1
 		smc := &v2beta1.SpiderMultusConfig{
@@ -426,7 +425,7 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 	})
 
 	It("testing creating spiderMultusConfig with cniType: ipvlan and checking the net-attach-conf config if works", Label("M00002"), func() {
-		var smcName string = "ipvlan-" + common.GenerateString(10, true)
+		smcName := "ipvlan-" + common.GenerateString(10, true)
 
 		// Define Spidermultus cr with ipvlan
 		smc := &v2beta1.SpiderMultusConfig{
@@ -459,7 +458,7 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 	})
 
 	It("testing creating spiderMultusConfig with cniType: sriov and checking the net-attach-conf config if works", Label("M00003"), func() {
-		var smcName string = "sriov-" + common.GenerateString(10, true)
+		smcName := "sriov-" + common.GenerateString(10, true)
 
 		// Define Spidermultus cr with sriov
 		smc := &v2beta1.SpiderMultusConfig{
@@ -492,9 +491,9 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 	})
 
 	It("testing creating spiderMultusConfig with cniType: custom and invalid/valid json config", Label("M00005", "M00004"), func() {
-		var smcName string = "custom-multus" + common.GenerateString(10, true)
+		smcName := "custom-multus" + common.GenerateString(10, true)
 
-		invalidJson := `{ "invalid" }`
+		invalidJSON := `{ "invalid" }`
 		// Define Spidermultus cr with invalid json config
 		smc := &v2beta1.SpiderMultusConfig{
 			ObjectMeta: metav1.ObjectMeta{
@@ -503,23 +502,23 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 			},
 			Spec: v2beta1.MultusCNIConfigSpec{
 				CniType:         ptr.To(constant.CustomCNI),
-				CustomCNIConfig: &invalidJson,
+				CustomCNIConfig: &invalidJSON,
 			},
 		}
 
 		GinkgoWriter.Printf("spidermultus cr with invalid json config: %+v \n", smc)
 		err := frame.CreateSpiderMultusInstance(smc)
-		GinkgoWriter.Printf("failed to create spidermultusconfig with invalid json config, error is %v", err)
+		GinkgoWriter.Printf("failed to create spidermultusconfig with invalid json config, error is %w", err)
 		Expect(err).To(HaveOccurred())
 
 		// Define valid json config
 		validString := `{"cniVersion":"0.3.1","name":"macvlan-conf","plugins":[{"type":"macvlan","master":"eth0","mode":"bridge","ipam":{"type":"spiderpool",{"mode":"auto","type":"coordinator"}]}`
-		validJson, err := json.Marshal(validString)
+		validJSON, err := json.Marshal(validString)
 		Expect(err).NotTo(HaveOccurred())
-		validJsonString := string(validJson)
-		smc.Spec.CustomCNIConfig = &validJsonString
+		validJSONString := string(validJSON)
+		smc.Spec.CustomCNIConfig = &validJSONString
 		GinkgoWriter.Printf("spidermultus cr with invalid json config: %+v \n", smc)
-		Expect(frame.CreateSpiderMultusInstance(smc)).NotTo(HaveOccurred(), "failed to create spidermultusconfig with valid json config, error is %v", err)
+		Expect(frame.CreateSpiderMultusInstance(smc)).NotTo(HaveOccurred(), "failed to create spidermultusconfig with valid json config, error is %w", err)
 
 		Eventually(func() bool {
 			customMultusConfig, err := frame.GetMultusInstance(smcName, namespace)
@@ -587,7 +586,7 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 
 			configByte, err := netutils.GetCNIConfigFromSpec(netAttachDef.Spec.Config, netAttachDef.Name)
 			if nil != err {
-				return fmt.Errorf("GetCNIConfig: err in getCNIConfigFromSpec: %v", err)
+				return fmt.Errorf("GetCNIConfig: err in getCNIConfigFromSpec: %w", err)
 			}
 
 			networkConfigList, err := libcni.ConfListFromBytes(configByte)
@@ -626,7 +625,7 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 
 			configByte, err := netutils.GetCNIConfigFromSpec(netAttachDef.Spec.Config, netAttachDef.Name)
 			if nil != err {
-				return fmt.Errorf("GetCNIConfig: err in getCNIConfigFromSpec: %v", err)
+				return fmt.Errorf("GetCNIConfig: err in getCNIConfigFromSpec: %w", err)
 			}
 
 			networkConfigList, err := libcni.ConfListFromBytes(configByte)
@@ -644,7 +643,7 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 	})
 
 	It("test hostRPFilter and podRPFilter in spiderMultusConfig", Label("M00022"), func() {
-		var smcName string = "rpfilter-multus-" + common.GenerateString(10, true)
+		smcName := "rpfilter-multus-" + common.GenerateString(10, true)
 
 		smc := &v2beta1.SpiderMultusConfig{
 			ObjectMeta: metav1.ObjectMeta{
@@ -677,7 +676,7 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 
 			configByte, err := netutils.GetCNIConfigFromSpec(netAttachDef.Spec.Config, netAttachDef.Name)
 			if nil != err {
-				return fmt.Errorf("GetCNIConfig: err in getCNIConfigFromSpec: %v", err)
+				return fmt.Errorf("GetCNIConfig: err in getCNIConfigFromSpec: %w", err)
 			}
 
 			networkConfigList, err := libcni.ConfListFromBytes(configByte)
@@ -696,7 +695,7 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 	})
 
 	It("set podRPFilter to a invalid value", Label("M00023"), func() {
-		var smcName string = "invalid-rpfilter-multus-" + common.GenerateString(10, true)
+		smcName := "invalid-rpfilter-multus-" + common.GenerateString(10, true)
 
 		smc := &v2beta1.SpiderMultusConfig{
 			ObjectMeta: metav1.ObjectMeta{
@@ -720,7 +719,7 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 	})
 
 	It("rdmaResourceName and ippools config must be set when spidermutlus with annotation: cni.spidernet.io/rdma-resource-inject", Label("M00027"), func() {
-		var smcName string = "ann-rdma-resource" + common.GenerateString(10, true)
+		smcName := "ann-rdma-resource" + common.GenerateString(10, true)
 		smc := &v2beta1.SpiderMultusConfig{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      smcName,
@@ -750,7 +749,7 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 	})
 
 	It("return an err if no ippools config when spidermutlus with annotation: cni.spidernet.io/rdma-resource-inject", Label("M00029"), func() {
-		var smcName string = "ann-rdma-resource" + common.GenerateString(10, true)
+		smcName := "ann-rdma-resource" + common.GenerateString(10, true)
 		smc := &v2beta1.SpiderMultusConfig{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      smcName,
@@ -777,7 +776,7 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 	})
 
 	It("return an err if cniType is not in [macvlan,ipvlan,sriov,ib-sriov,ipoib] when spidermutlus with annotation: cni.spidernet.io/rdma-resource-inject", Label("M00030"), func() {
-		var smcName string = "ann-rdma-resource" + common.GenerateString(10, true)
+		smcName := "ann-rdma-resource" + common.GenerateString(10, true)
 		smc := &v2beta1.SpiderMultusConfig{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      smcName,
@@ -804,7 +803,7 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 	})
 
 	It("resoucename and ippools config must be both set when spidermutlus with annotation: cni.spidernet.io/network-resource-inject", Label("M00031"), func() {
-		var smcName string = "ann-network-resource" + common.GenerateString(10, true)
+		smcName := "ann-network-resource" + common.GenerateString(10, true)
 		smc := &v2beta1.SpiderMultusConfig{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      smcName,
@@ -834,7 +833,7 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 	})
 
 	It("return an err if resoucename is set without ippools config when spidermutlus with annotation: cni.spidernet.io/network-resource-inject", Label("M00032"), func() {
-		var smcName string = "ann-network-resource" + common.GenerateString(10, true)
+		smcName := "ann-network-resource" + common.GenerateString(10, true)
 		smc := &v2beta1.SpiderMultusConfig{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      smcName,
@@ -861,7 +860,7 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 	})
 
 	It("set disableIPAM to true and see if multus's nad has ipam config", Label("M00017"), func() {
-		var smcName string = "disable-ipam-multus-" + common.GenerateString(10, true)
+		smcName := "disable-ipam-multus-" + common.GenerateString(10, true)
 
 		// Define Spidermultus cr with DisableIPAM=true
 		smc := &v2beta1.SpiderMultusConfig{
@@ -892,7 +891,7 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 
 			configByte, err := netutils.GetCNIConfigFromSpec(netAttachDef.Spec.Config, netAttachDef.Name)
 			if nil != err {
-				return fmt.Errorf("GetCNIConfig: err in getCNIConfigFromSpec: %v", err)
+				return fmt.Errorf("GetCNIConfig: err in getCNIConfigFromSpec: %w", err)
 			}
 
 			networkConfigList, err := libcni.ConfListFromBytes(configByte)
@@ -912,9 +911,9 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 	})
 
 	It("create a spidermultusconfig to verify chainCNI json config", Label("M00021"), func() {
-		var smcName string = "chain-cni-multus" + common.GenerateString(10, true)
+		smcName := "chain-cni-multus" + common.GenerateString(10, true)
 
-		invalidJson := `{ "invalid" }`
+		invalidJSON := `{ "invalid" }`
 		// Define Spidermultus cr with invalid json config
 		smc := &v2beta1.SpiderMultusConfig{
 			ObjectMeta: metav1.ObjectMeta{
@@ -929,7 +928,7 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 						IPv4IPPool: []string{"spiderpool-ipv4-ippool"},
 					},
 				},
-				ChainCNIJsonData: []string{invalidJson},
+				ChainCNIJsonData: []string{invalidJSON},
 			},
 		}
 
@@ -945,7 +944,7 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 		GinkgoWriter.Printf("failed to create spidermultusconfig with invalid ChainCNIJsonData, error is %v\n", err)
 		Expect(err).To(HaveOccurred())
 
-		ginkgo.By("test chainCNI with valid json but empty cni type")
+		By("test chainCNI with valid json but empty cni type")
 		jsonNoType := "{\"sysctl\":{\"net.core.somaxconn\":\"4096\"}}"
 		smc.Spec.ChainCNIJsonData = []string{jsonNoType}
 		GinkgoWriter.Printf("spidermultus cr with empty cni type: %+v \n", smc)
@@ -953,7 +952,7 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 		GinkgoWriter.Printf("failed to create spidermultusconfig with no cni type config: %v\n", err)
 		Expect(err).To(HaveOccurred())
 
-		ginkgo.By("test chainCNI with valid json but not a map type")
+		By("test chainCNI with valid json but not a map type")
 		jsonNoMapType := "[{\"type\":\"tuning\",\"sysctl\":{\"net.core.somaxconn\":\"4096\"}}]"
 		smc.Spec.ChainCNIJsonData = []string{jsonNoMapType}
 		GinkgoWriter.Printf("spidermultus cr with no cni type config: %+v \n", smc)
@@ -962,7 +961,7 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 		Expect(err).To(HaveOccurred())
 
 		// Define valid json config
-		ginkgo.By("define valid json config")
+		By("define valid json config")
 		validString := "{\"type\":\"tuning\",\"sysctl\":{\"net.core.somaxconn\":\"4096\"}}"
 
 		var netConf *types.NetConf
@@ -971,7 +970,7 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 
 		smc.Spec.ChainCNIJsonData = []string{validString}
 		GinkgoWriter.Printf("spidermultus cr with valid ChainCNIJsonData: %+v \n", smc)
-		Expect(frame.CreateSpiderMultusInstance(smc)).NotTo(HaveOccurred(), "failed to create spidermultusconfig with valid ChainCNIJsonData: %v", err)
+		Expect(frame.CreateSpiderMultusInstance(smc)).NotTo(HaveOccurred(), "failed to create spidermultusconfig with valid ChainCNIJsonData: %w", err)
 
 		Eventually(func() bool {
 			config, err := frame.GetMultusInstance(smcName, namespace)
@@ -990,7 +989,7 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 		}, common.SpiderSyncMultusTime, common.ForcedWaitingTime).Should(BeTrue())
 
 		// create a pod
-		var annotations = make(map[string]string)
+		annotations := make(map[string]string)
 		annotations[common.MultusDefaultNetwork] = fmt.Sprintf("%s/%s", namespace, smcName)
 		deployObject := common.GenerateExampleDeploymentYaml(smcName, namespace, int32(1))
 		deployObject.Spec.Template.Annotations = annotations
@@ -1017,7 +1016,7 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 	It("check the enableVethLinkLocakAddress works", Label("M00026"), func() {
 		// create a pod
 		name := "veth-address-test"
-		var annotations = make(map[string]string)
+		annotations := make(map[string]string)
 		annotations[common.MultusDefaultNetwork] = fmt.Sprintf("%s/%s", common.MultusNs, common.MacvlanUnderlayVlan0)
 		deployObject := common.GenerateExampleDeploymentYaml("veth-address-test", namespace, int32(1))
 		deployObject.Spec.Template.Annotations = annotations
@@ -1061,7 +1060,7 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 			},
 		}
 
-		ginkgo.By("create a spiderMultusConfig with valid podMACPrefix")
+		By("create a spiderMultusConfig with valid podMACPrefix")
 		err := frame.CreateSpiderMultusInstance(smc)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -1086,9 +1085,9 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 			},
 		}
 
-		ginkgo.By("create a spiderMultusConfig with invalid podMACPrefix")
+		By("create a spiderMultusConfig with invalid podMACPrefix")
 		err = frame.CreateSpiderMultusInstance(invalid)
-		Expect(err).To(HaveOccurred(), "create invalid spiderMultusConfig should fail: %v", err)
+		Expect(err).To(HaveOccurred(), "create invalid spiderMultusConfig should fail: %w", err)
 	})
 
 	It("test the multusConfig with mtu size for macvlan", Label("M00033"), func() {
@@ -1108,9 +1107,9 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 			},
 		}
 
-		ginkgo.By("create a spiderMultusConfig with invalid mtu size")
+		By("create a spiderMultusConfig with invalid mtu size")
 		err := frame.CreateSpiderMultusInstance(smc)
-		Expect(err).To(HaveOccurred(), "create invalid spiderMultusConfig should fail: %v", err)
+		Expect(err).To(HaveOccurred(), "create invalid spiderMultusConfig should fail: %w", err)
 
 		smc.Spec.MacvlanConfig.MTU = ptr.To(int32(1400))
 		if frame.Info.IpV4Enabled {
@@ -1120,12 +1119,12 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 			smc.Spec.MacvlanConfig.SpiderpoolConfigPools.IPv6IPPool = []string{"default-v6-ippool"}
 		}
 
-		ginkgo.By("create a spiderMultusConfig with mtu size")
+		By("create a spiderMultusConfig with mtu size")
 		err = frame.CreateSpiderMultusInstance(smc)
 		Expect(err).NotTo(HaveOccurred())
 
 		depName := "macvlan-mtu"
-		var annotations = make(map[string]string)
+		annotations := make(map[string]string)
 		annotations[common.MultusDefaultNetwork] = fmt.Sprintf("%s/%s", namespace, smcName)
 		deployObject := common.GenerateExampleDeploymentYaml(depName, namespace, int32(1))
 		deployObject.Spec.Template.Annotations = annotations
@@ -1167,9 +1166,9 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 			},
 		}
 
-		ginkgo.By("create a spiderMultusConfig with invalid mtu size")
+		By("create a spiderMultusConfig with invalid mtu size")
 		err := frame.CreateSpiderMultusInstance(smc)
-		Expect(err).To(HaveOccurred(), "create invalid spiderMultusConfig should fail: %v", err)
+		Expect(err).To(HaveOccurred(), "create invalid spiderMultusConfig should fail: %w", err)
 
 		smc.Spec.IPVlanConfig.MTU = ptr.To(int32(1400))
 		if frame.Info.IpV4Enabled {
@@ -1179,7 +1178,7 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 			smc.Spec.IPVlanConfig.SpiderpoolConfigPools.IPv6IPPool = []string{"default-v6-ippool"}
 		}
 
-		ginkgo.By("create a spiderMultusConfig with mtu size")
+		By("create a spiderMultusConfig with mtu size")
 		err = frame.CreateSpiderMultusInstance(smc)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -1214,12 +1213,12 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 			},
 		}
 
-		ginkgo.By("create a spiderMultusConfig with invalid mtu size")
+		By("create a spiderMultusConfig with invalid mtu size")
 		err := frame.CreateSpiderMultusInstance(smc)
-		Expect(err).To(HaveOccurred(), "create invalid spiderMultusConfig should fail: %v", err)
+		Expect(err).To(HaveOccurred(), "create invalid spiderMultusConfig should fail: %w", err)
 
 		smc.Spec.SriovConfig.MTU = ptr.To(int32(1400))
-		ginkgo.By("create a spiderMultusConfig with mtu size")
+		By("create a spiderMultusConfig with mtu size")
 		err = frame.CreateSpiderMultusInstance(smc)
 		Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/subnet/subnet_test.go
+++ b/test/e2e/subnet/subnet_test.go
@@ -60,9 +60,9 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 		})
 	})
 
-	// Create a subnet and limit the number of ip's to `subnetIpNum`
+	// Create a subnet and limit the number of ip's to `subnetIPNum`
 	// Create `deployOriginiaNum` deployments with `deployReplicasOriginialNum` replicas
-	// and a fixed number of `fixedIPNumber` IPs from a subnet with `subnetIpNum` IPs
+	// and a fixed number of `fixedIPNumber` IPs from a subnet with `subnetIPNum` IPs
 	// Scale up `deployScaleupNum` deploy replicas from `deployReplicasOriginialNum` to `deployReplicasScaleupNum`
 	// Scale down other deploy replicas from `deployReplicasOriginialNum` to `deployReplicasScaledownNum`
 	// Delete all deploy
@@ -71,11 +71,11 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 
 		var (
 			// Available IP in Subnet
-			subnetIpNum int = 150
+			subnetIPNum = 150
 			// Number of deployments created
-			deployOriginiaNum int = 30
+			deployOriginiaNum = 30
 			// How much of the deployment is for scaling up?
-			deployScaleupNum int = 15
+			deployScaleupNum = 15
 			// Initial number of replicas of deploy
 			deployReplicasOriginialNum int32 = 2
 			// Number of Scaling up replicas of deploy
@@ -83,14 +83,14 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 			// Number of Scaling down replicas of deploy
 			deployReplicasScaledownNum int32 = 1
 			// Number of fixed IP
-			fixedIPNumber string = "5"
+			fixedIPNumber = "5"
 		)
 
 		BeforeEach(func() {
 			frame.EnableLog = false
 			Eventually(func() error {
 				if frame.Info.IpV4Enabled {
-					v4SubnetName, v4SubnetObject = common.GenerateExampleV4SubnetObject(frame, subnetIpNum)
+					v4SubnetName, v4SubnetObject = common.GenerateExampleV4SubnetObject(frame, subnetIPNum)
 					err := common.CreateSubnet(frame, v4SubnetObject)
 					if err != nil {
 						GinkgoWriter.Printf("Failed to create v4 Subnet %v: %v \n", v4SubnetName, err)
@@ -98,7 +98,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 					}
 				}
 				if frame.Info.IpV6Enabled {
-					v6SubnetName, v6SubnetObject = common.GenerateExampleV6SubnetObject(frame, subnetIpNum)
+					v6SubnetName, v6SubnetObject = common.GenerateExampleV6SubnetObject(frame, subnetIPNum)
 					err := common.CreateSubnet(frame, v6SubnetObject)
 					if err != nil {
 						GinkgoWriter.Printf("Failed to create v6 Subnet %v: %v \n", v6SubnetName, err)
@@ -147,15 +147,15 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 			GinkgoWriter.Println("Create deployments in bulk in the subnet and check that the IPs recorded in the subnet status match the IPs recorded in the ippool status.")
 			if frame.Info.IpV4Enabled {
 				Expect(common.WaitIppoolNumberInSubnet(ctx, frame, v4SubnetName, deployOriginiaNum)).NotTo(HaveOccurred())
-				Expect(common.WaitValidateSubnetAllocatedIPCount(ctx, frame, v4SubnetName, int64(subnetIpNum))).NotTo(HaveOccurred())
-				Expect(common.WaitValidateSubnetAndPoolIpConsistency(ctx, frame, v4SubnetName)).NotTo(HaveOccurred())
+				Expect(common.WaitValidateSubnetAllocatedIPCount(ctx, frame, v4SubnetName, int64(subnetIPNum))).NotTo(HaveOccurred())
+				Expect(common.WaitValidateSubnetAndPoolIPConsistency(ctx, frame, v4SubnetName)).NotTo(HaveOccurred())
 				v4PoolNameList, err = common.GetPoolNameListInSubnet(frame, v4SubnetName)
 				Expect(err).NotTo(HaveOccurred())
 			}
 			if frame.Info.IpV6Enabled {
 				Expect(common.WaitIppoolNumberInSubnet(ctx, frame, v6SubnetName, deployOriginiaNum)).NotTo(HaveOccurred())
-				Expect(common.WaitValidateSubnetAllocatedIPCount(ctx, frame, v6SubnetName, int64(subnetIpNum))).NotTo(HaveOccurred())
-				Expect(common.WaitValidateSubnetAndPoolIpConsistency(ctx, frame, v6SubnetName)).NotTo(HaveOccurred())
+				Expect(common.WaitValidateSubnetAllocatedIPCount(ctx, frame, v6SubnetName, int64(subnetIPNum))).NotTo(HaveOccurred())
+				Expect(common.WaitValidateSubnetAndPoolIPConsistency(ctx, frame, v6SubnetName)).NotTo(HaveOccurred())
 				v6PoolNameList, err = common.GetPoolNameListInSubnet(frame, v6SubnetName)
 				Expect(err).NotTo(HaveOccurred())
 			}
@@ -163,7 +163,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 			// Check pod ip record in ippool
 			podList, err := frame.GetPodList(client.InNamespace(namespace))
 			Expect(err).NotTo(HaveOccurred())
-			ok, _, _, err := common.CheckPodIpRecordInIppool(frame, v4PoolNameList, v6PoolNameList, podList)
+			ok, _, _, err := common.CheckPodIPRecordInIPPool(frame, v4PoolNameList, v6PoolNameList, podList)
 			Expect(ok).NotTo(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
 			endT1 := time.Since(startT1)
@@ -198,18 +198,18 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 			ctx, cancel = context.WithTimeout(context.Background(), common.PodReStartTimeout)
 			defer cancel()
 			if frame.Info.IpV4Enabled {
-				Expect(common.WaitValidateSubnetAllocatedIPCount(ctx, frame, v4SubnetName, int64(subnetIpNum))).NotTo(HaveOccurred())
-				Expect(common.WaitValidateSubnetAndPoolIpConsistency(ctx, frame, v4SubnetName)).NotTo(HaveOccurred())
+				Expect(common.WaitValidateSubnetAllocatedIPCount(ctx, frame, v4SubnetName, int64(subnetIPNum))).NotTo(HaveOccurred())
+				Expect(common.WaitValidateSubnetAndPoolIPConsistency(ctx, frame, v4SubnetName)).NotTo(HaveOccurred())
 			}
 			if frame.Info.IpV6Enabled {
-				Expect(common.WaitValidateSubnetAllocatedIPCount(ctx, frame, v6SubnetName, int64(subnetIpNum))).NotTo(HaveOccurred())
-				Expect(common.WaitValidateSubnetAndPoolIpConsistency(ctx, frame, v6SubnetName)).NotTo(HaveOccurred())
+				Expect(common.WaitValidateSubnetAllocatedIPCount(ctx, frame, v6SubnetName, int64(subnetIPNum))).NotTo(HaveOccurred())
+				Expect(common.WaitValidateSubnetAndPoolIPConsistency(ctx, frame, v6SubnetName)).NotTo(HaveOccurred())
 			}
 
 			// Check pod ip record in ippool
 			podList, err = frame.GetPodList(client.InNamespace(namespace))
 			Expect(err).NotTo(HaveOccurred())
-			ok, _, _, err = common.CheckPodIpRecordInIppool(frame, v4PoolNameList, v6PoolNameList, podList)
+			ok, _, _, err = common.CheckPodIPRecordInIPPool(frame, v4PoolNameList, v6PoolNameList, podList)
 			Expect(ok).NotTo(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
 			endT2 := time.Since(startT2)
@@ -253,8 +253,8 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 
 	Context("Automatic creation, extension and deletion of ippool by different controllers", func() {
 		var (
-			subnetAvailableIpNum int = 100
-			fixedIPNumber            = "+0"
+			subnetAvailableIPNum = 100
+			fixedIPNumber        = "+0"
 			v4PoolNameList       []string
 			v6PoolNameList       []string
 			podList              *corev1.PodList
@@ -269,7 +269,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 
 			Eventually(func() error {
 				if frame.Info.IpV4Enabled {
-					v4SubnetName, v4SubnetObject = common.GenerateExampleV4SubnetObject(frame, subnetAvailableIpNum)
+					v4SubnetName, v4SubnetObject = common.GenerateExampleV4SubnetObject(frame, subnetAvailableIPNum)
 					err = common.CreateSubnet(frame, v4SubnetObject)
 					if err != nil {
 						GinkgoWriter.Printf("Failed to create v4 Subnet %v: %v \n", v4SubnetName, err)
@@ -277,7 +277,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 					}
 				}
 				if frame.Info.IpV6Enabled {
-					v6SubnetName, v6SubnetObject = common.GenerateExampleV6SubnetObject(frame, subnetAvailableIpNum)
+					v6SubnetName, v6SubnetObject = common.GenerateExampleV6SubnetObject(frame, subnetAvailableIPNum)
 					err = common.CreateSubnet(frame, v6SubnetObject)
 					if err != nil {
 						GinkgoWriter.Printf("Failed to create v6 Subnet %v: %v \n", v6SubnetName, err)
@@ -300,17 +300,17 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 
 		It("Automatic creation, extension and deletion of ippool by different controllers", Label("I00003"), func() {
 			var (
-				stsName                 string = "sts-" + tools.RandomName()
-				stsReplicasOriginialNum int32  = 1
-				stsReplicasScaleupNum   int32  = 2
-				rsName                  string = "rs-" + tools.RandomName()
-				rsReplicasOriginialNum  int32  = 1
-				rsReplicasScaleupNum    int32  = 2
-				dsName                  string = "ds-" + tools.RandomName()
-				controllerNum           int    = 3
-				deployNum               int    = 10
-				deployReplicasNum       int32  = 1
-				deployPatchReplicasNum  int32  = 2
+				stsName                       = "sts-" + tools.RandomName()
+				stsReplicasOriginialNum int32 = 1
+				stsReplicasScaleupNum   int32 = 2
+				rsName                        = "rs-" + tools.RandomName()
+				rsReplicasOriginialNum  int32 = 1
+				rsReplicasScaleupNum    int32 = 2
+				dsName                        = "ds-" + tools.RandomName()
+				controllerNum                 = 3
+				deployNum                     = 10
+				deployReplicasNum       int32 = 1
+				deployPatchReplicasNum  int32 = 2
 			)
 
 			subnetAnno := types.AnnoSubnetItem{}
@@ -385,13 +385,13 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 			defer cancel()
 			if frame.Info.IpV4Enabled {
 				Expect(common.WaitIppoolNumberInSubnet(ctx, frame, v4SubnetName, (controllerNum + deployNum))).NotTo(HaveOccurred())
-				Expect(common.WaitValidateSubnetAndPoolIpConsistency(ctx, frame, v4SubnetName)).NotTo(HaveOccurred())
+				Expect(common.WaitValidateSubnetAndPoolIPConsistency(ctx, frame, v4SubnetName)).NotTo(HaveOccurred())
 				v4PoolNameList, err = common.GetPoolNameListInSubnet(frame, v4SubnetName)
 				Expect(err).NotTo(HaveOccurred())
 			}
 			if frame.Info.IpV6Enabled {
 				Expect(common.WaitIppoolNumberInSubnet(ctx, frame, v6SubnetName, (controllerNum + deployNum))).NotTo(HaveOccurred())
-				Expect(common.WaitValidateSubnetAndPoolIpConsistency(ctx, frame, v6SubnetName)).NotTo(HaveOccurred())
+				Expect(common.WaitValidateSubnetAndPoolIPConsistency(ctx, frame, v6SubnetName)).NotTo(HaveOccurred())
 				v6PoolNameList, err = common.GetPoolNameListInSubnet(frame, v6SubnetName)
 				Expect(err).NotTo(HaveOccurred())
 			}
@@ -405,7 +405,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 				}
 				return frame.CheckPodListRunning(podList)
 			}, 2*common.PodStartTimeout, common.ForcedWaitingTime).Should(BeTrue())
-			ok, _, _, err := common.CheckPodIpRecordInIppool(frame, v4PoolNameList, v6PoolNameList, podList)
+			ok, _, _, err := common.CheckPodIPRecordInIPPool(frame, v4PoolNameList, v6PoolNameList, podList)
 			Expect(ok).NotTo(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
 
@@ -422,7 +422,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 			// Check that the pod's ip is recorded in the ippool
 			podList, err = frame.GetPodList(client.InNamespace(namespace))
 			Expect(err).NotTo(HaveOccurred())
-			ok, _, _, err = common.CheckPodIpRecordInIppool(frame, v4PoolNameList, v6PoolNameList, podList)
+			ok, _, _, err = common.CheckPodIPRecordInIPPool(frame, v4PoolNameList, v6PoolNameList, podList)
 			Expect(ok).NotTo(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
 
@@ -430,14 +430,14 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 			ctx, cancel = context.WithTimeout(context.Background(), common.PodStartTimeout)
 			defer cancel()
 			if frame.Info.IpV4Enabled {
-				Expect(common.WaitValidateSubnetAndPoolIpConsistency(ctx, frame, v4SubnetName)).NotTo(HaveOccurred())
+				Expect(common.WaitValidateSubnetAndPoolIPConsistency(ctx, frame, v4SubnetName)).NotTo(HaveOccurred())
 			}
 			if frame.Info.IpV6Enabled {
-				Expect(common.WaitValidateSubnetAndPoolIpConsistency(ctx, frame, v6SubnetName)).NotTo(HaveOccurred())
+				Expect(common.WaitValidateSubnetAndPoolIPConsistency(ctx, frame, v6SubnetName)).NotTo(HaveOccurred())
 			}
 
 			// Check that the pod's ip is recorded in the ippool
-			ok, _, _, err = common.CheckPodIpRecordInIppool(frame, v4PoolNameList, v6PoolNameList, podList)
+			ok, _, _, err = common.CheckPodIPRecordInIPPool(frame, v4PoolNameList, v6PoolNameList, podList)
 			Expect(ok).NotTo(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
 
@@ -455,16 +455,16 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 			ctx2, cancel2 := context.WithTimeout(context.Background(), common.PodStartTimeout)
 			defer cancel2()
 			if frame.Info.IpV4Enabled {
-				Expect(common.WaitValidateSubnetAndPoolIpConsistency(ctx2, frame, v4SubnetName)).NotTo(HaveOccurred())
+				Expect(common.WaitValidateSubnetAndPoolIPConsistency(ctx2, frame, v4SubnetName)).NotTo(HaveOccurred())
 			}
 			if frame.Info.IpV6Enabled {
-				Expect(common.WaitValidateSubnetAndPoolIpConsistency(ctx2, frame, v6SubnetName)).NotTo(HaveOccurred())
+				Expect(common.WaitValidateSubnetAndPoolIPConsistency(ctx2, frame, v6SubnetName)).NotTo(HaveOccurred())
 			}
 
 			// Check that the pod's ip is recorded in the ippool
 			podList, err = frame.GetPodList(client.InNamespace(namespace))
 			Expect(err).NotTo(HaveOccurred())
-			ok, _, _, err = common.CheckPodIpRecordInIppool(frame, v4PoolNameList, v6PoolNameList, podList)
+			ok, _, _, err = common.CheckPodIPRecordInIPPool(frame, v4PoolNameList, v6PoolNameList, podList)
 			Expect(ok).NotTo(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
 
@@ -506,7 +506,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 	})
 
 	PContext("Validity of fields in subnet.spec", func() {
-		var fixedIPNumber string = "+0"
+		fixedIPNumber := "+0"
 		var deployOriginiaNum int32 = 1
 		var deployName string
 
@@ -529,7 +529,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 		})
 
 		It("valid fields succeed to create subnet. ", Label("I00001", "I00002", "I00005"), func() {
-			var v4Ipversion, v6Ipversion = new(types.IPVersion), new(types.IPVersion)
+			v4Ipversion, v6Ipversion := new(types.IPVersion), new(types.IPVersion)
 			var v4Object, v6Object *spiderpool.SpiderSubnet
 			var v4RouteValue, v6RouteValue []spiderpool.Route
 
@@ -601,7 +601,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 				defer cancel()
 				Expect(common.WaitIppoolNumberInSubnet(ctx, frame, v4SubnetName, 1)).NotTo(HaveOccurred())
 				Expect(common.WaitValidateSubnetAllocatedIPCount(ctx, frame, v4SubnetName, int64(deployOriginiaNum))).NotTo(HaveOccurred())
-				Expect(common.WaitValidateSubnetAndPoolIpConsistency(ctx, frame, v4SubnetName)).NotTo(HaveOccurred())
+				Expect(common.WaitValidateSubnetAndPoolIPConsistency(ctx, frame, v4SubnetName)).NotTo(HaveOccurred())
 				GinkgoWriter.Println("Check that the gateways and routes recorded in the automatically created ippool are correct")
 				v4poolList, err := common.GetIppoolsInSubnet(frame, v4SubnetName)
 				Expect(err).NotTo(HaveOccurred())
@@ -635,11 +635,11 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 				GinkgoWriter.Println("Add an ip belonging to the CIDR to the subnet.")
 				oldIPs, err := ip.ParseIPRanges(*v4Object.Spec.IPVersion, v4Object.Spec.IPs)
 				Expect(err).NotTo(HaveOccurred())
-				nextIp := ip.NextIP(oldIPs[len(oldIPs)-1])
-				newIps := append(oldIPs, nextIp)
-				newIpRange, err := ip.ConvertIPsToIPRanges(*v4Object.Spec.IPVersion, newIps)
+				nextIP := ip.NextIP(oldIPs[len(oldIPs)-1])
+				newIps := append(oldIPs, nextIP)
+				newIPRange, err := ip.ConvertIPsToIPRanges(*v4Object.Spec.IPVersion, newIps)
 				Expect(err).NotTo(HaveOccurred())
-				v4Object.Spec.IPs = newIpRange
+				v4Object.Spec.IPs = newIPRange
 				Expect(common.PatchSpiderSubnet(frame, v4Object, v4SubnetObject)).NotTo(HaveOccurred())
 
 				GinkgoWriter.Println("Add an ip that is not part of the CIDR to the subnet.")
@@ -658,17 +658,17 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 
 				// Delete an ip that is being used in the subnet
 				newV4Object = v4Object.DeepCopy()
-				nextIpRange, err := ip.ConvertIPsToIPRanges(*newV4Object.Spec.IPVersion, []net.IP{nextIp})
+				nextIPRange, err := ip.ConvertIPsToIPRanges(*newV4Object.Spec.IPVersion, []net.IP{nextIP})
 				Expect(err).NotTo(HaveOccurred())
-				newV4Object.Spec.IPs = nextIpRange
+				newV4Object.Spec.IPs = nextIPRange
 				err = common.PatchSpiderSubnet(frame, newV4Object, v4Object)
 				GinkgoWriter.Printf("failed to remove an ip in use: %v. \n", err)
 				Expect(err).To(HaveOccurred())
 
 				// Delete unused ip in the subnet
-				oldIpRange, err := ip.ConvertIPsToIPRanges(*newV4Object.Spec.IPVersion, oldIPs)
+				oldIPRange, err := ip.ConvertIPsToIPRanges(*newV4Object.Spec.IPVersion, oldIPs)
 				Expect(err).NotTo(HaveOccurred())
-				newV4Object.Spec.IPs = oldIpRange
+				newV4Object.Spec.IPs = oldIPRange
 				GinkgoWriter.Printf("Successfully deleted an unused IP %v.\n", newV4Object.Spec.IPs)
 				Expect(common.PatchSpiderSubnet(frame, newV4Object, v4Object)).NotTo(HaveOccurred(), err)
 
@@ -696,7 +696,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 				defer cancel()
 				Expect(common.WaitIppoolNumberInSubnet(ctx, frame, v6SubnetName, 1)).NotTo(HaveOccurred())
 				Expect(common.WaitValidateSubnetAllocatedIPCount(ctx, frame, v6SubnetName, int64(deployOriginiaNum))).NotTo(HaveOccurred())
-				Expect(common.WaitValidateSubnetAndPoolIpConsistency(ctx, frame, v6SubnetName)).NotTo(HaveOccurred())
+				Expect(common.WaitValidateSubnetAndPoolIPConsistency(ctx, frame, v6SubnetName)).NotTo(HaveOccurred())
 				v6poolList, err := common.GetIppoolsInSubnet(frame, v6SubnetName)
 				Expect(err).NotTo(HaveOccurred())
 				for _, pool := range v6poolList.Items {
@@ -729,11 +729,11 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 				GinkgoWriter.Println("Add an v6 ip belonging to the CIDR to the v6 subnet.")
 				oldIPs, err := ip.ParseIPRanges(*v6Object.Spec.IPVersion, v6Object.Spec.IPs)
 				Expect(err).NotTo(HaveOccurred())
-				nextIp := ip.NextIP(oldIPs[len(oldIPs)-1])
-				newIps := append(oldIPs, nextIp)
-				newIpRange, err := ip.ConvertIPsToIPRanges(*v6Object.Spec.IPVersion, newIps)
+				nextIP := ip.NextIP(oldIPs[len(oldIPs)-1])
+				newIps := append(oldIPs, nextIP)
+				newIPRange, err := ip.ConvertIPsToIPRanges(*v6Object.Spec.IPVersion, newIps)
 				Expect(err).NotTo(HaveOccurred())
-				v6Object.Spec.IPs = newIpRange
+				v6Object.Spec.IPs = newIPRange
 				Expect(common.PatchSpiderSubnet(frame, v6Object, v6SubnetObject)).NotTo(HaveOccurred())
 
 				GinkgoWriter.Println("Add an v6 ip that is not part of the CIDR to the v6 subnet.")
@@ -752,17 +752,17 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 
 				// Delete an v6 ip that is being used in the v6 subnet
 				newV6Object = v6Object.DeepCopy()
-				nextIpRange, err := ip.ConvertIPsToIPRanges(*v6Object.Spec.IPVersion, []net.IP{nextIp})
+				nextIPRange, err := ip.ConvertIPsToIPRanges(*v6Object.Spec.IPVersion, []net.IP{nextIP})
 				Expect(err).NotTo(HaveOccurred())
-				newV6Object.Spec.IPs = nextIpRange
+				newV6Object.Spec.IPs = nextIPRange
 				err = common.PatchSpiderSubnet(frame, newV6Object, v6Object)
 				GinkgoWriter.Printf("failed to remove an ip in use: %v. \n", err)
 				Expect(err).To(HaveOccurred())
 
 				// Delete unused v6 ip in the v6 subnet
-				oldIpRange, err := ip.ConvertIPsToIPRanges(*v6Object.Spec.IPVersion, oldIPs)
+				oldIPRange, err := ip.ConvertIPsToIPRanges(*v6Object.Spec.IPVersion, oldIPs)
 				Expect(err).NotTo(HaveOccurred())
-				newV6Object.Spec.IPs = oldIpRange
+				newV6Object.Spec.IPs = oldIPRange
 				GinkgoWriter.Printf("Successfully deleted an unused IP %v. \n", newV6Object.Spec.IPs)
 				Expect(common.PatchSpiderSubnet(frame, newV6Object, v6Object)).NotTo(HaveOccurred())
 
@@ -890,8 +890,8 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 		// the same spec is used to create the ippool and only one should succeed
 		PIt("the same spec is used to create the subnet/ippool and only one should succeed.", Label("I00009", "I00010"), func() {
 			var (
-				batchCreateSubnetNumber int = 2
-				batchCreateIPPoolNumber int = 2
+				batchCreateSubnetNumber = 2
+				batchCreateIPPoolNumber = 2
 			)
 
 			// Generate example v4 or v6 subnetObject/poolObject
@@ -1064,16 +1064,16 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 		// batch delete subnets and record time
 		PIt("the different spec is used to create the subnet/ippool and should all be successful.", Label("I00007", "D00007"), func() {
 			var (
-				batchCreateSubnetNumber int = 20
-				batchCreateIPPoolNumber int = 10
-				subnetIpNumber          int = 200
-				ippoolIpNumber          int = 2
+				batchCreateSubnetNumber = 20
+				batchCreateIPPoolNumber = 10
+				subnetIPNumber          = 200
+				ippoolIPNumber          = 2
 				err                     error
 			)
 			// batch create subnet and ippool and record time
 			if frame.Info.IpV4Enabled {
 				startT1 := time.Now()
-				v4SubnetNameList, err = common.BatchCreateSubnet(frame, constant.IPv4, batchCreateSubnetNumber, subnetIpNumber)
+				v4SubnetNameList, err = common.BatchCreateSubnet(frame, constant.IPv4, batchCreateSubnetNumber, subnetIPNumber)
 				Expect(err).NotTo(HaveOccurred())
 				GinkgoWriter.Printf("succeed to batch create %v v4 subnet \n", len(v4SubnetNameList))
 				endT1 := time.Since(startT1)
@@ -1081,19 +1081,19 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 				startT1 = time.Now()
 				v4SubnetObject, err = common.GetSubnetByName(frame, v4SubnetNameList[1])
 				Expect(err).NotTo(HaveOccurred())
-				v4PoolNameList, err = common.BatchCreateIPPoolsInSpiderSubnet(frame, constant.IPv4, v4SubnetObject.Spec.Subnet, v4SubnetObject.Spec.IPs, batchCreateIPPoolNumber, ippoolIpNumber)
+				v4PoolNameList, err = common.BatchCreateIPPoolsInSpiderSubnet(frame, constant.IPv4, v4SubnetObject.Spec.Subnet, v4SubnetObject.Spec.IPs, batchCreateIPPoolNumber, ippoolIPNumber)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(v4PoolNameList)).To(Equal(batchCreateIPPoolNumber))
 				ctx, cancel := context.WithTimeout(context.Background(), common.PodReStartTimeout)
 				defer cancel()
-				Expect(common.WaitValidateSubnetAndPoolIpConsistency(ctx, frame, v4SubnetNameList[1])).NotTo(HaveOccurred())
+				Expect(common.WaitValidateSubnetAndPoolIPConsistency(ctx, frame, v4SubnetNameList[1])).NotTo(HaveOccurred())
 				GinkgoWriter.Printf("succeed to batch create %v v4 pool \n", len(v4PoolNameList))
 				endT1 = time.Since(startT1)
 				GinkgoWriter.Printf("Time cost to create %v v4 ippool is %v \n", batchCreateIPPoolNumber, endT1)
 			}
 			if frame.Info.IpV6Enabled {
 				startT1 := time.Now()
-				v6SubnetNameList, err = common.BatchCreateSubnet(frame, constant.IPv6, batchCreateSubnetNumber, subnetIpNumber)
+				v6SubnetNameList, err = common.BatchCreateSubnet(frame, constant.IPv6, batchCreateSubnetNumber, subnetIPNumber)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(v6SubnetNameList)).To(Equal(batchCreateSubnetNumber))
 				GinkgoWriter.Printf("succeed to batch create %v v6 subnet \n", len(v6SubnetNameList))
@@ -1102,12 +1102,12 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 				startT1 = time.Now()
 				v6SubnetObject, err = common.GetSubnetByName(frame, v6SubnetNameList[1])
 				Expect(err).NotTo(HaveOccurred())
-				v6PoolNameList, err = common.BatchCreateIPPoolsInSpiderSubnet(frame, constant.IPv6, v6SubnetObject.Spec.Subnet, v6SubnetObject.Spec.IPs, batchCreateIPPoolNumber, ippoolIpNumber)
+				v6PoolNameList, err = common.BatchCreateIPPoolsInSpiderSubnet(frame, constant.IPv6, v6SubnetObject.Spec.Subnet, v6SubnetObject.Spec.IPs, batchCreateIPPoolNumber, ippoolIPNumber)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(v6PoolNameList)).To(Equal(batchCreateIPPoolNumber))
 				ctx, cancel := context.WithTimeout(context.Background(), common.PodReStartTimeout)
 				defer cancel()
-				Expect(common.WaitValidateSubnetAndPoolIpConsistency(ctx, frame, v6SubnetNameList[1])).NotTo(HaveOccurred())
+				Expect(common.WaitValidateSubnetAndPoolIPConsistency(ctx, frame, v6SubnetNameList[1])).NotTo(HaveOccurred())
 				GinkgoWriter.Printf("succeed to batch create %v v6 pool \n", len(v6PoolNameList))
 				endT1 = time.Since(startT1)
 				GinkgoWriter.Printf("Time cost to create %v v6 ippool is %v \n", batchCreateIPPoolNumber, endT1)
@@ -1349,7 +1349,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 		var v4PoolNameList, v6PoolNameList []string
 		var err error
 		var replicasNum int32 = 1
-		var controllerNum int = 4
+		controllerNum := 4
 		var controllerNameList []string
 		var podName, deployName, stsName, dsName, jobName string
 
@@ -1521,9 +1521,8 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 	})
 
 	Context("Reserved IPPool usage.", func() {
-
 		var (
-			subnetIpNum                        int   = 5
+			subnetIPNum                              = 5
 			replicasNum                        int32 = 1
 			longAppName                        string
 			v4PoolNameList, v6PoolNameList     []string
@@ -1540,7 +1539,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 
 			Eventually(func() error {
 				if frame.Info.IpV4Enabled {
-					v4SubnetName, v4SubnetObject = common.GenerateExampleV4SubnetObject(frame, subnetIpNum)
+					v4SubnetName, v4SubnetObject = common.GenerateExampleV4SubnetObject(frame, subnetIPNum)
 					err = common.CreateSubnet(frame, v4SubnetObject)
 					if err != nil {
 						GinkgoWriter.Printf("Failed to create v4 Subnet %v: %v \n", v4SubnetName, err)
@@ -1549,7 +1548,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 					v4SubnetNameList = append(v4SubnetNameList, v4SubnetName)
 				}
 				if frame.Info.IpV6Enabled {
-					v6SubnetName, v6SubnetObject = common.GenerateExampleV6SubnetObject(frame, subnetIpNum)
+					v6SubnetName, v6SubnetObject = common.GenerateExampleV6SubnetObject(frame, subnetIPNum)
 					err = common.CreateSubnet(frame, v6SubnetObject)
 					if err != nil {
 						GinkgoWriter.Printf("Failed to create v6 Subnet %v: %v \n", v6SubnetName, err)
@@ -1598,7 +1597,6 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 		// I00019: Change the annotation ipam.spidernet.io/ippool-reclaim to true and the reserved IPPool will be reclaimed.
 		// I00021: Pod works correctly when multiple NICs are specified by annotations for applications of the same name
 		It("Use of reserved IPPool by applications of the same name, same type/different types", Label("I00015", "I00016", "I00017", "I00018", "I00019", "I00021"), func() {
-
 			GinkgoWriter.Printf("Specify annotations for the application %v/%v, and create \n", namespace, longAppName)
 			deployObject := common.GenerateExampleDeploymentYaml(longAppName, namespace, replicasNum)
 			deployObject.Spec.Template.Annotations = annotationMap
@@ -1609,13 +1607,13 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 			defer cancel()
 			if frame.Info.IpV4Enabled {
 				Expect(common.WaitIppoolNumberInSubnet(ctx, frame, v4SubnetName, 1)).NotTo(HaveOccurred())
-				Expect(common.WaitValidateSubnetAndPoolIpConsistency(ctx, frame, v4SubnetName)).NotTo(HaveOccurred())
+				Expect(common.WaitValidateSubnetAndPoolIPConsistency(ctx, frame, v4SubnetName)).NotTo(HaveOccurred())
 				v4PoolNameList, err = common.GetPoolNameListInSubnet(frame, v4SubnetName)
 				Expect(err).NotTo(HaveOccurred())
 			}
 			if frame.Info.IpV6Enabled {
 				Expect(common.WaitIppoolNumberInSubnet(ctx, frame, v6SubnetName, 1)).NotTo(HaveOccurred())
-				Expect(common.WaitValidateSubnetAndPoolIpConsistency(ctx, frame, v6SubnetName)).NotTo(HaveOccurred())
+				Expect(common.WaitValidateSubnetAndPoolIPConsistency(ctx, frame, v6SubnetName)).NotTo(HaveOccurred())
 				v6PoolNameList, err = common.GetPoolNameListInSubnet(frame, v6SubnetName)
 				Expect(err).NotTo(HaveOccurred())
 			}
@@ -1626,7 +1624,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 			Expect(frame.WaitPodListRunning(deployObject.Spec.Template.Labels, int(replicasNum), ctx)).NotTo(HaveOccurred())
 			podList, err := frame.GetPodListByLabel(deployObject.Spec.Template.Labels)
 			Expect(err).NotTo(HaveOccurred())
-			ok, _, _, err := common.CheckPodIpRecordInIppool(frame, v4PoolNameList, v6PoolNameList, podList)
+			ok, _, _, err := common.CheckPodIPRecordInIPPool(frame, v4PoolNameList, v6PoolNameList, podList)
 			Expect(ok).NotTo(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
 
@@ -1683,18 +1681,18 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 			Expect(frame.WaitPodListRunning(stsObject.Spec.Template.Labels, newReplicasNum, ctx)).NotTo(HaveOccurred())
 			podList, err = frame.GetPodListByLabel(stsObject.Spec.Template.Labels)
 			Expect(err).NotTo(HaveOccurred())
-			ok, _, _, err = common.CheckPodIpRecordInIppool(frame, v4PoolNameList, v6PoolNameList, podList)
+			ok, _, _, err = common.CheckPodIPRecordInIPPool(frame, v4PoolNameList, v6PoolNameList, podList)
 			Expect(ok).To(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
 			if frame.Info.IpV4Enabled {
 				GinkgoWriter.Printf("Different types of applications with the same name will create a new v4 fixed IPPool. \n")
 				Expect(common.WaitIppoolNumberInSubnet(ctx, frame, v4SubnetName, 2)).NotTo(HaveOccurred())
-				Expect(common.WaitValidateSubnetAndPoolIpConsistency(ctx, frame, v4SubnetName)).NotTo(HaveOccurred())
+				Expect(common.WaitValidateSubnetAndPoolIPConsistency(ctx, frame, v4SubnetName)).NotTo(HaveOccurred())
 			}
 			if frame.Info.IpV6Enabled {
 				GinkgoWriter.Printf("Different types of applications with the same name will create a new v6 fixed IPPool. \n")
 				Expect(common.WaitIppoolNumberInSubnet(ctx, frame, v6SubnetName, 2)).NotTo(HaveOccurred())
-				Expect(common.WaitValidateSubnetAndPoolIpConsistency(ctx, frame, v6SubnetName)).NotTo(HaveOccurred())
+				Expect(common.WaitValidateSubnetAndPoolIPConsistency(ctx, frame, v6SubnetName)).NotTo(HaveOccurred())
 			}
 
 			// Delete the application
@@ -1715,7 +1713,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 
 			Eventually(func() error {
 				if frame.Info.IpV4Enabled {
-					newV4SubnetName, newV4SubnetObject = common.GenerateExampleV4SubnetObject(frame, subnetIpNum)
+					newV4SubnetName, newV4SubnetObject = common.GenerateExampleV4SubnetObject(frame, subnetIPNum)
 					err = common.CreateSubnet(frame, newV4SubnetObject)
 					if err != nil {
 						GinkgoWriter.Printf("Failed to create v4 Subnet %v: %v \n", newV4SubnetName, err)
@@ -1726,7 +1724,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 					subnetsAnno[1].IPv4 = []string{newV4SubnetName}
 				}
 				if frame.Info.IpV6Enabled {
-					newV6SubnetName, newV6SubnetObject = common.GenerateExampleV6SubnetObject(frame, subnetIpNum)
+					newV6SubnetName, newV6SubnetObject = common.GenerateExampleV6SubnetObject(frame, subnetIPNum)
 					err = common.CreateSubnet(frame, newV6SubnetObject)
 					if err != nil {
 						GinkgoWriter.Printf("Failed to create v6 Subnet %v: %v \n", newV6SubnetName, err)
@@ -1760,7 +1758,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 			Expect(frame.WaitPodListRunning(sameDeployNameObject.Spec.Selector.MatchLabels, int(replicasNum), ctx)).NotTo(HaveOccurred())
 			podList, err = frame.GetPodListByLabel(sameDeployNameObject.Spec.Template.Labels)
 			Expect(err).NotTo(HaveOccurred())
-			ok, _, _, err = common.CheckPodIpRecordInIppool(frame, v4PoolNameList, v6PoolNameList, podList)
+			ok, _, _, err = common.CheckPodIPRecordInIPPool(frame, v4PoolNameList, v6PoolNameList, podList)
 			Expect(ok).NotTo(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
 
@@ -1825,7 +1823,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 			if frame.Info.IpV4Enabled {
 				GinkgoWriter.Println("Waiting for the v4 fixed pool to be created.")
 				Expect(common.WaitIppoolNumberInSubnet(ctx, frame, v4SubnetName, 1)).NotTo(HaveOccurred())
-				Expect(common.WaitValidateSubnetAndPoolIpConsistency(ctx, frame, v4SubnetName)).NotTo(HaveOccurred())
+				Expect(common.WaitValidateSubnetAndPoolIPConsistency(ctx, frame, v4SubnetName)).NotTo(HaveOccurred())
 				v4PoolNameList, err = common.GetPoolNameListInSubnet(frame, v4SubnetName)
 				Expect(err).NotTo(HaveOccurred())
 				podAnno.IPv4Pools = v4PoolNameList
@@ -1833,7 +1831,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 			if frame.Info.IpV6Enabled {
 				GinkgoWriter.Println("Waiting for the v6 fixed pool to be created.")
 				Expect(common.WaitIppoolNumberInSubnet(ctx, frame, v6SubnetName, 1)).NotTo(HaveOccurred())
-				Expect(common.WaitValidateSubnetAndPoolIpConsistency(ctx, frame, v6SubnetName)).NotTo(HaveOccurred())
+				Expect(common.WaitValidateSubnetAndPoolIPConsistency(ctx, frame, v6SubnetName)).NotTo(HaveOccurred())
 				v6PoolNameList, err = common.GetPoolNameListInSubnet(frame, v6SubnetName)
 				Expect(err).NotTo(HaveOccurred())
 				podAnno.IPv6Pools = v6PoolNameList
@@ -1864,7 +1862,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 
 	It("Dirty data in the subnet should be recycled.", Label("I00022"), func() {
 		var (
-			subnetIpNum                    int = 5
+			subnetIPNum                    = 5
 			dirtyPoolName                  string
 			v4SubnetObject, v6SubnetObject *spiderpool.SpiderSubnet
 		)
@@ -1874,7 +1872,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 
 		if frame.Info.IpV4Enabled {
 			Eventually(func() error {
-				v4SubnetName, v4SubnetObject = common.GenerateExampleV4SubnetObject(frame, subnetIpNum)
+				v4SubnetName, v4SubnetObject = common.GenerateExampleV4SubnetObject(frame, subnetIPNum)
 				err := common.CreateSubnet(frame, v4SubnetObject)
 				if err != nil {
 					GinkgoWriter.Printf("Failed to create v4 Subnet %v: %v \n", v4SubnetName, err)
@@ -1898,7 +1896,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 				v4SubnetObject.Status.ControlledIPPools = MarshalPreAllocations
 				GinkgoWriter.Printf("update subnet %v for adding dirty record: %+v \n", v4SubnetName, *v4SubnetObject)
 				if err = frame.UpdateResourceStatus(v4SubnetObject); err != nil {
-					GinkgoWriter.Printf("failed to update v4 subnet status,error is: %v \n", err)
+					GinkgoWriter.Printf("failed to update v4 subnet status,error is: %w \n", err)
 					return false
 				}
 				return true
@@ -1921,7 +1919,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 		}
 		if frame.Info.IpV6Enabled {
 			Eventually(func() error {
-				v6SubnetName, v6SubnetObject = common.GenerateExampleV6SubnetObject(frame, subnetIpNum)
+				v6SubnetName, v6SubnetObject = common.GenerateExampleV6SubnetObject(frame, subnetIPNum)
 				err := common.CreateSubnet(frame, v6SubnetObject)
 				if err != nil {
 					GinkgoWriter.Printf("Failed to create v6 Subnet %v: %v \n", v6SubnetName, err)
@@ -1946,7 +1944,7 @@ var _ = Describe("test subnet", Label("subnet"), func() {
 				v6SubnetObject.Status.ControlledIPPools = MarshalPreAllocations
 				GinkgoWriter.Printf("update subnet %v for adding dirty record: %+v \n", v6SubnetName, *v6SubnetObject)
 				if err = frame.UpdateResourceStatus(v6SubnetObject); err != nil {
-					GinkgoWriter.Printf("failed to update v6 subnet status,error is: %v", err)
+					GinkgoWriter.Printf("failed to update v6 subnet status,error is: %w", err)
 					return false
 				}
 				return true


### PR DESCRIPTION
# Thanks for contributing!

**Notice**:

* [ ] unite test or E2E test
* [ ] do not forget essential code comment and log
* [ ] document for the PR
* [x] release note label
  "release/none"
  "release/bug"
  "release/feature"
* [ ] read about  Contribution notice: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>

**What issue(s) does this PR fix**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/spidernet-io/spiderpool/issues/5412

**Special notes for your reviewer**:

1. The format returned by scanAll logs is incorrect.

```bash
the endpoint %!v(MISSING)/%!v(MISSING) should be reclaimed"

{"level":"INFO","ts":"2026-01-13T09:18:59.636Z","logger":"IP-GarbageCollection","caller":"gcmanager/scanAll_IPPool.go:321","msg":"pod test/test-sts is a static Pod with a status of 172.27.216.79 and has been assigned an different IP address, the endpoint %!v(MISSING)/%!v(MISSING) should be reclaimed"
```

2. In the CI job (https://github.com/spidernet-io/spiderpool/actions/runs/20952107213/job/60207761720?pr=5409), there was an issue where Go code inspection failed. I noticed that this was due to a recent upgrade to the latest version, golanglint-ci (2.8). This issue was also addressed in the PR solution. See [cilium](https://github.com/cilium/cilium/blob/main/.golangci.yaml) for rules on enabling and disabling code inspection.


**Release note**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
