### PR TITLE
fix: returns a result other than nil when both bond and VLAN exist

### DIFF
--- a/cmd/ifacer/cmd/cmd_add.go
+++ b/cmd/ifacer/cmd/cmd_add.go
@@ -68,7 +68,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 					return fmt.Errorf("failed to set %s up: %w", vlanLink.Attrs().Name, err)
 				}
 			}
-			return nil
+			return types.PrintResult(result, conf.CNIVersion)
 		}
 
 		var notFoundErr netlink.LinkNotFoundError


### PR DESCRIPTION
# Thanks for contributing!

**Notice**:

* [ ] unite test or E2E test
* [ ] do not forget essential code comment and log
* [ ] document for the PR
* [ ] release note label
  "release/none"
  "release/bug"
  "release/feature"
* [ ] read about  Contribution notice: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>

**What issue(s) does this PR fix**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://github.com/spidernet-io/spiderpool/issues/5423

**Special notes for your reviewer**:

**Release note**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```

release/bug