### PR TITLE
fix: log tmp multus config

### DIFF
--- a/charts/spiderpool/templates/configmap.yaml
+++ b/charts/spiderpool/templates/configmap.yaml
@@ -187,10 +187,11 @@ data:
     generateKubeConfig
     log "multus kubeconfig is generated."
 
+    log "cat tmp multus-cni config: ${MULTUS_TEMP_CONFIG}"
+    cat ${MULTUS_TEMP_CONFIG}
+
     cp $MULTUS_TEMP_CONFIG /host/etc/cni/net.d
     log "multus config file ${MULTUS_TEMP_CONFIG} is copied to ${CNI_CONF_DIR}."
-    log "cat ${CNI_CONF_DIR}/00-multus.conf"
-    cat ${CNI_CONF_DIR}/00-multus.conf
 
     log "Entering watch loop..."
     while true; do


### PR DESCRIPTION
**What issue(s) does this PR fix**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #https://github.com/spidernet-io/spiderpool/issues/5427

**Special notes for your reviewer**:

Cilium move CNI configuration management to the agent. 
The cilium daemon monitors and renames files in the default CNI configuration path; you can see details in this PR.
https://github.com/cilium/cilium/pull/24389

```go
// cleanupOtherCNI renames any existing CNI configuration files with the suffix
// ".cilium_bak", excepting files in keep
```


**Release note**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```
