### PR TITLE
fix: docker higher versions could not obtain image IDs

### DIFF
--- a/.github/workflows/e2e-init.yaml
+++ b/.github/workflows/e2e-init.yaml
@@ -126,7 +126,7 @@ jobs:
               echo ${IMAGE_NAME}
               docker load -i test/.download/${ITEM}
               echo "list docker images" && docker images
-              ITEM_IMAGE_ID=$(docker images | grep ${IMAGE_NAME}| grep ${{ inputs.image_tag }} | awk '{print $1}')
+              ITEM_IMAGE_ID=$(docker images --format "table {{.ID}}\t{{.Repository}}\t{{.Tag}}" | grep ${IMAGE_NAME%*-race}| grep ${{ inputs.image_tag }} | awk '{print $1}')
               docker tag ${ITEM_IMAGE_ID} ${IMAGE_NAME}:${{ inputs.image_tag }}
           done
           echo "list all docker images"


### PR DESCRIPTION
# Thanks for contributing!

**Notice**:

* [ ] unite test or E2E test
* [ ] do not forget essential code comment and log
* [ ] document for the PR
* [x] release note label
  "release/none"
  "release/bug"
  "release/feature"
* [ ] read about  Contribution notice: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>

**What issue(s) does this PR fix**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/spidernet-io/spiderpool/issues/5482
Fixes https://github.com/spidernet-io/spiderpool/issues/5481
Fixes https://github.com/spidernet-io/spiderpool/issues/5480
Fixes https://github.com/spidernet-io/spiderpool/issues/5476
Fixes https://github.com/spidernet-io/spiderpool/issues/5468
Fixes https://github.com/spidernet-io/spiderpool/issues/5467
Fixes https://github.com/spidernet-io/spiderpool/issues/5466
Fixes https://github.com/spidernet-io/spiderpool/issues/5460
Fixes https://github.com/spidernet-io/spiderpool/issues/5459
Fixes https://github.com/spidernet-io/spiderpool/issues/5458
Fixes https://github.com/spidernet-io/spiderpool/issues/5456
Fixes https://github.com/spidernet-io/spiderpool/issues/5455
Fixes https://github.com/spidernet-io/spiderpool/issues/5454
Fixes https://github.com/spidernet-io/spiderpool/issues/5453
Fixes https://github.com/spidernet-io/spiderpool/issues/5452
Fixes https://github.com/spidernet-io/spiderpool/issues/5451


**Special notes for your reviewer**:

For higher Docker versions, the Docker images are as follows:
```
pass   'docker' installed:  Docker version 29.1.5, build 0e6fee6 

~# docker images
IMAGE                                                                                               ID             DISK USAGE   CONTENT SIZE   EXTRA
ghcr.io/spidernet-io/spiderpool/spiderpool-agent-ci:3338d9435c2bf0b73a5d7603d6fc5e36cb81e219-race   928aa742c6db        417MB          109MB        
```

For older versions of Docker, the Docker image is as follows:
```
pass   'docker' installed:  Docker version 28.0.4, build b8034c0 


~# docker images
REPOSITORY                                                 TAG                                             IMAGE ID       CREATED         SIZE
spiderpool-agent-race                                      3338d9435c2bf0b73a5d7603d6fc5e36cb81e219        6b969dec8363   6 minutes ago   296MB
ghcr.io/spidernet-io/spiderpool/spiderpool-agent-ci        3338d9435c2bf0b73a5d7603d6fc5e36cb81e219-race   6b969dec8363   6 minutes ago   296MB
ghcr.io/spidernet-io/spiderpool/spiderpool-controller-ci   3338d9435c2bf0b73a5d7603d6fc5e36cb81e219-race   e560b6210bd8   6 minutes ago   211MB
```

the old command, using `awk '{print $3}`, would retrieve the value of `DISK USAGE`, which is not as expected:
```
ITEM_IMAGE_ID=$(docker images | grep ${IMAGE_NAME%*-race}| grep ${{ inputs.image_tag }} | awk '{print $3}')
```

The `--format` option formats the output of Docker images, adapting them to both high and low Docker versions.
```
 --format "table {{.ID}}\t{{.Repository}}\t{{.Tag}}
```


**Release note**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
