### PR TITLE
rbac: add resourceclaims/driver permissions for DRA v1.36

### DIFF
--- a/charts/spiderpool/templates/role.yaml
+++ b/charts/spiderpool/templates/role.yaml
@@ -154,6 +154,7 @@ rules:
   - podschedulingcontexts/status
   - resourceclaims
   - resourceclaims/status
+  - resourceclaims/driver
   - resourceclaimtemplates
   - resourceclasses
   verbs:
@@ -162,6 +163,8 @@ rules:
   - patch
   - update
   - watch
+  - "associated-node:update"
+  - "associated-node:patch"
 - apiGroups:
   - spiderpool.spidernet.io
   resources:

--- a/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/rbac.go
+++ b/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/rbac.go
@@ -9,6 +9,7 @@
 // +kubebuilder:rbac:groups="coordination.k8s.io",resources=leases,verbs=create;get;update
 // +kubebuilder:rbac:groups="apps",resources=statefulsets;deployments;replicasets;daemonsets,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups="resource.k8s.io",resources=resourceclaims;resourceclaims/status;podschedulingcontexts/status;resourceclaimtemplates;resourceclasses;podschedulingcontexts,verbs=get;list;patch;watch;update
+// +kubebuilder:rbac:groups="resource.k8s.io",resources=resourceclaims/driver,verbs=associated-node:update;associated-node:patch
 // +kubebuilder:rbac:groups="networking.k8s.io",resources=servicecidrs,verbs=get;list;watch
 // +kubebuilder:rbac:groups="batch",resources=jobs;cronjobs,verbs=get;list;watch;update;delete
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch


### PR DESCRIPTION
This adds the necessary granular status authorization permissions for ResourceClaims as required by the Kubernetes v1.36 migration guide.

# Thanks for contributing!

Relates to kubernetes/kubernetes#138149

**Notice**:

* [ ] unite test or E2E test
* [x] do not forget essential code comment and log
* [x] document for the PR
* [x] release note label
  "release/none"
  "release/bug"
  "release/feature"
* [x] read about  Contribution notice: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>

**What issue(s) does this PR fix**:

Usage: `Fixes #<138149>` or `Fixes ( Relates to https://github.com/kubernetes/kubernetes/issues/138149)`.


**Special notes for your reviewer**: This PR adds the required resourceclaims/driver subresource and associated node verbs to the RBAC configuration. This is necessary for compatibility with the DRA Granular Status Authorization feature coming in Kubernetes v1.36.

**Release note**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add RBAC permissions for DRA Granular Status Authorization to support Kubernetes v1.36.
```
