### PR TITLE
fix: IPAM cannot allocate IP when k8s.v1.cni.cncf.io/networks is JSON array

### DIFF
--- a/charts/spiderpool/templates/role.yaml
+++ b/charts/spiderpool/templates/role.yaml
@@ -154,7 +154,6 @@ rules:
   - podschedulingcontexts/status
   - resourceclaims
   - resourceclaims/status
-  - resourceclaims/driver
   - resourceclaimtemplates
   - resourceclasses
   verbs:
@@ -163,8 +162,13 @@ rules:
   - patch
   - update
   - watch
-  - "associated-node:update"
+- apiGroups:
+  - resource.k8s.io
+  resources:
+  - resourceclaims/driver
+  verbs:
   - "associated-node:patch"
+  - "associated-node:update"
 - apiGroups:
   - spiderpool.spidernet.io
   resources:

--- a/pkg/ipam/allocate.go
+++ b/pkg/ipam/allocate.go
@@ -611,7 +611,7 @@ func (i *ipam) allocateIPFromCandidate(ctx context.Context, c *PoolCandidate, ni
 	for _, pool := range c.Pools {
 		ip, err := i.ipPoolManager.AllocateIP(ctx, pool, nic, pod, podController)
 		if err != nil {
-			logger.Sugar().Warnf("Failed to allocate IPv%d IP address to NIC %s from IPPool %s: %w", c.IPVersion, nic, pool, err)
+			logger.Sugar().Warnf("Failed to allocate IPv%d IP address to NIC %s from IPPool %s: %v", c.IPVersion, nic, pool, err)
 			errs = append(errs, err)
 			continue
 		}
@@ -676,7 +676,7 @@ func (i *ipam) filterPoolCandidates(ctx context.Context, t *ToBeAllocated, pod *
 		for j := 0; j < len(c.Pools); j++ {
 			pool := c.Pools[j]
 			if err := i.selectByPod(ctx, c.IPVersion, c.PToIPPool[pool], pod, podTopController, t.NIC, addArgs.NetNamespace, addArgs.MatchMasterSubnet); err != nil {
-				logger.Sugar().Warnf("IPPool %s is filtered by Pod: %w", pool, err)
+				logger.Sugar().Warnf("IPPool %s is filtered by Pod: %v", pool, err)
 				errs = append(errs, err)
 
 				delete(c.PToIPPool, pool)
@@ -787,18 +787,23 @@ func (i *ipam) selectByPod(ctx context.Context, version types.IPVersion, ipPool 
 			defaultMultusObj = *i.config.MultusClusterNetwork
 		}
 
-		netNsName, networkName, _, err := multuscniconfig.ParsePodNetworkObjectName(defaultMultusObj)
+		// Use ParsePodNetworkAnnotation (not ParsePodNetworkObjectName) to handle
+		// both JSON and comma-delimited formats, consistent with upstream multus-cni.
+		networks, err := multuscniconfig.ParsePodNetworkAnnotation(defaultMultusObj, i.config.AgentNamespace)
 		if nil != err {
 			return fmt.Errorf("failed to parse Annotation '%s' value '%s', error: %w", constant.MultusDefaultNetAnnot, defaultMultusObj, err)
 		}
+		if len(networks) == 0 {
+			return fmt.Errorf("failed to parse Annotation '%s' value '%s': empty result", constant.MultusDefaultNetAnnot, defaultMultusObj)
+		}
 
-		multusNS = netNsName
+		multusNS = networks[0].Namespace
 		if multusNS == "" {
 			// Reference from Multus source codes: The CRD object of default network should only be defined in multusNamespace
 			// In multus, multusNamespace serves for (clusterNetwork/defaultNetworks)
 			multusNS = i.config.AgentNamespace
 		}
-		multusName = networkName
+		multusName = networks[0].Name
 	} else {
 		// the additional NICs must own a Multus CR object
 		networkSelectionElements, err := multuscniconfig.ParsePodNetworkAnnotation(podAnno[constant.MultusNetworkAttachmentAnnot], pod.Namespace)

--- a/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/rbac.go
+++ b/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1/rbac.go
@@ -9,7 +9,8 @@
 // +kubebuilder:rbac:groups="coordination.k8s.io",resources=leases,verbs=create;get;update
 // +kubebuilder:rbac:groups="apps",resources=statefulsets;deployments;replicasets;daemonsets,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups="resource.k8s.io",resources=resourceclaims;resourceclaims/status;podschedulingcontexts/status;resourceclaimtemplates;resourceclasses;podschedulingcontexts,verbs=get;list;patch;watch;update
-// +kubebuilder:rbac:groups="resource.k8s.io",resources=resourceclaims/driver,verbs=associated-node:update;associated-node:patch
+// NOTE: resourceclaims/driver requires "associated-node:update" and "associated-node:patch" verbs
+// which contain colons that controller-gen cannot parse. This rule is injected by update-controller-gen.sh.
 // +kubebuilder:rbac:groups="networking.k8s.io",resources=servicecidrs,verbs=get;list;watch
 // +kubebuilder:rbac:groups="batch",resources=jobs;cronjobs,verbs=get;list;watch;update;delete
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch

--- a/pkg/multuscniconfig/multuscniconfig_suite_test.go
+++ b/pkg/multuscniconfig/multuscniconfig_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright 2022 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+
+package multuscniconfig
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMultusCNIConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "MultusCNIConfig Suite")
+}

--- a/pkg/multuscniconfig/utils.go
+++ b/pkg/multuscniconfig/utils.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"regexp"
 	"strings"
+	"syscall"
 
 	netv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
@@ -123,7 +124,9 @@ func ParsePodNetworkAnnotation(podNetworks, defaultNamespace string) ([]*netv1.N
 		return nil, fmt.Errorf("parsePodNetworkAnnotation: %s, %s", podNetworks, defaultNamespace)
 	}
 
-	if strings.HasPrefix(podNetworks, "[{\"") {
+	// Match Multus / network-attachment-definition-client ParseNetworkAnnotation: any of `[`, `{`, `"`
+	// indicates JSON (including pretty-printed arrays that do not start with `[{"`).
+	if strings.ContainsAny(strings.TrimSpace(podNetworks), "[{\"") {
 		if err := json.Unmarshal([]byte(podNetworks), &networks); err != nil {
 			return nil, fmt.Errorf("parsePodNetworkAnnotation: failed to parse pod Network Attachment Selection Annotation JSON format: %w", err)
 		}
@@ -211,19 +214,21 @@ func ParsePodNetworkObjectName(podnetwork string) (string, string, string, error
 	// Check and see if each item matches the specification for valid attachment name.
 	// "Valid attachment names must be comprised of units of the DNS-1123 label format"
 	// [a-z0-9]([-a-z0-9]*[a-z0-9])?
-	// And we allow at (@), and forward slash (/) (units separated by commas)
 	// It must start and end alphanumerically.
-	regexpStr := "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-	compile, err := regexp.Compile(regexpStr)
-	if nil != err {
-		return "", "", "", fmt.Errorf("failed to parse regexp expression for %s, error: %w", regexpStr, err)
-	}
-
-	allItems := []string{netNsName, networkName, netIfName}
+	expr := regexp.MustCompile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+	allItems := []string{netNsName, networkName}
 	for i := range allItems {
-		matched := compile.MatchString(allItems[i])
+		matched := expr.MatchString(allItems[i])
 		if !matched && len([]rune(allItems[i])) > 0 {
 			return "", "", "", fmt.Errorf("parsePodNetworkObjectName: Failed to parse: one or more items did not match comma-delimited format (must consist of lower case alphanumeric characters). Must start and end with an alphanumeric character), mismatch @ '%v'", allItems[i])
+		}
+	}
+
+	// Validate interface name: must be shorter than IFNAMSIZ (typically 16) and
+	// must not contain spaces or forward slashes, matching upstream multus-cni.
+	if len(netIfName) > 0 {
+		if len(netIfName) > (syscall.IFNAMSIZ-1) || strings.ContainsAny(netIfName, " \t\n\v\f\r/") {
+			return "", "", "", fmt.Errorf("parsePodNetworkObjectName: Failed to parse interface name: must be less than %d chars and not contain '/' or spaces. interface name '%s'", syscall.IFNAMSIZ-1, netIfName)
 		}
 	}
 

--- a/pkg/multuscniconfig/utils_test.go
+++ b/pkg/multuscniconfig/utils_test.go
@@ -1,0 +1,128 @@
+// Copyright 2022 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+
+package multuscniconfig
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("MultusCNIConfig utils", Label("multuscniconfig_utils_test"), func() {
+	Describe("Test ParsePodNetworkAnnotation", func() {
+		It("parses pretty-printed JSON array", func() {
+			const prettyJSON = `[
+  {
+    "name": "sriov-net-a",
+    "namespace": "kube-system",
+    "interface": "net1"
+  },
+  {
+    "name": "bond-net",
+    "namespace": "kube-system",
+    "interface": "bond0"
+  }
+]`
+			elems, err := ParsePodNetworkAnnotation(prettyJSON, "default")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(elems).To(HaveLen(2))
+			Expect(elems[0].Name).To(Equal("sriov-net-a"))
+			Expect(elems[0].Namespace).To(Equal("kube-system"))
+			Expect(elems[0].InterfaceRequest).To(Equal("net1"))
+			Expect(elems[1].Name).To(Equal("bond-net"))
+			Expect(elems[1].InterfaceRequest).To(Equal("bond0"))
+		})
+
+		It("parses compact JSON array", func() {
+			const compact = `[{"name":"net-a","namespace":"ns1","interface":"eth1"}]`
+			elems, err := ParsePodNetworkAnnotation(compact, "default")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(elems).To(HaveLen(1))
+			Expect(elems[0].Name).To(Equal("net-a"))
+			Expect(elems[0].Namespace).To(Equal("ns1"))
+		})
+
+		It("parses comma-delimited list", func() {
+			const csv = "kube-system/sriov-net-a,kube-system/sriov-net-b,kube-system/bond-net"
+			elems, err := ParsePodNetworkAnnotation(csv, "default")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(elems).To(HaveLen(3))
+			Expect(elems[0].Name).To(Equal("sriov-net-a"))
+			Expect(elems[2].Name).To(Equal("bond-net"))
+		})
+
+		It("fills default namespace for JSON without namespace", func() {
+			const jsonNoNS = `[{"name":"macvlan","interface":"net1"}]`
+			elems, err := ParsePodNetworkAnnotation(jsonNoNS, "my-ns")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(elems).To(HaveLen(1))
+			Expect(elems[0].Namespace).To(Equal("my-ns"))
+		})
+
+		It("returns error for empty input", func() {
+			_, err := ParsePodNetworkAnnotation("", "default")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns error for invalid JSON", func() {
+			_, err := ParsePodNetworkAnnotation(`[{"name":}]`, "default")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("Test ParsePodNetworkObjectName", func() {
+		It("parses plain text with namespace and interface", func() {
+			ns, name, iface, err := ParsePodNetworkObjectName("kube-system/macvlan-conf@net1")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ns).To(Equal("kube-system"))
+			Expect(name).To(Equal("macvlan-conf"))
+			Expect(iface).To(Equal("net1"))
+		})
+
+		It("parses plain text without namespace", func() {
+			ns, name, iface, err := ParsePodNetworkObjectName("macvlan-conf@net1")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ns).To(BeEmpty())
+			Expect(name).To(Equal("macvlan-conf"))
+			Expect(iface).To(Equal("net1"))
+		})
+
+		It("parses plain text without interface", func() {
+			ns, name, iface, err := ParsePodNetworkObjectName("kube-system/macvlan-conf")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ns).To(Equal("kube-system"))
+			Expect(name).To(Equal("macvlan-conf"))
+			Expect(iface).To(BeEmpty())
+		})
+
+		It("returns error for invalid plain text with multiple slashes", func() {
+			_, _, _, err := ParsePodNetworkObjectName("a/b/c")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns error for invalid plain text with multiple @", func() {
+			_, _, _, err := ParsePodNetworkObjectName("net@if1@if2")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("accepts underscore in interface name", func() {
+			_, name, iface, err := ParsePodNetworkObjectName("my-net@my_iface")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(name).To(Equal("my-net"))
+			Expect(iface).To(Equal("my_iface"))
+		})
+
+		It("returns error when interface name contains a space", func() {
+			_, _, _, err := ParsePodNetworkObjectName("my-net@bad iface")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns error when interface name exceeds IFNAMSIZ-1", func() {
+			longIface := strings.Repeat("a", 16) // IFNAMSIZ is 16, so max name length is 15
+			_, _, _, err := ParsePodNetworkObjectName("my-net@" + longIface)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/test/doc/spidermultus.md
+++ b/test/doc/spidermultus.md
@@ -36,3 +36,5 @@
 | M00033  |    test the multusConfig with mtu size for macvlan                                            | p3       |       | done   |       |
 | M00034  |    test the multusConfig with mtu size for ipvlan                                             | p3       |       | done   |       |
 | M00035  |    test the multusConfig with mtu size for sriov                                             | p3       |       | done   |       |
+| M00036  | Pod with multi-NIC compact JSON k8s.v1.cni.cncf.io/networks annotation (name/namespace/interface fields) should be parsed correctly and get IPs allocated on both interfaces | p2       |       | done   |       |
+| M00037  | Pod with pretty-printed JSON k8s.v1.cni.cncf.io/networks annotation (multi-line indented array) should be parsed correctly and get IP allocated | p2       |       | done   |       |

--- a/test/e2e/spidermultus/spidermultus_test.go
+++ b/test/e2e/spidermultus/spidermultus_test.go
@@ -1253,4 +1253,144 @@ var _ = Describe("test spidermultus", Label("SpiderMultusConfig"), func() {
 			return false
 		}, common.SpiderSyncMultusTime, common.ForcedWaitingTime).Should(BeTrue())
 	})
+
+	It("Pod with multi-NIC compact JSON k8s.v1.cni.cncf.io/networks annotation (name/namespace/interface fields) should be parsed correctly and get IPs allocated on both interfaces",
+		Label("M00036"), func() {
+			smcName1 := "json-multi-a-" + common.GenerateString(10, true)
+			smcName2 := "json-multi-b-" + common.GenerateString(10, true)
+
+			newSMC := func(name string) *v2beta1.SpiderMultusConfig {
+				s := &v2beta1.SpiderMultusConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: namespace,
+					},
+					Spec: v2beta1.MultusCNIConfigSpec{
+						CniType: ptr.To(constant.MacvlanCNI),
+						MacvlanConfig: &v2beta1.SpiderMacvlanCniConfig{
+							Master:                []string{common.NIC1},
+							SpiderpoolConfigPools: &v2beta1.SpiderpoolPools{},
+						},
+					},
+				}
+				if frame.Info.IpV4Enabled {
+					s.Spec.MacvlanConfig.SpiderpoolConfigPools.IPv4IPPool = []string{"default-v4-ippool"}
+				}
+				if frame.Info.IpV6Enabled {
+					s.Spec.MacvlanConfig.SpiderpoolConfigPools.IPv6IPPool = []string{"default-v6-ippool"}
+				}
+				return s
+			}
+
+			By("create two spiderMultusConfig instances for net1 and net2")
+			Expect(frame.CreateSpiderMultusInstance(newSMC(smcName1))).NotTo(HaveOccurred())
+			Expect(frame.CreateSpiderMultusInstance(newSMC(smcName2))).NotTo(HaveOccurred())
+
+			Eventually(func() bool {
+				_, err1 := frame.GetMultusInstance(smcName1, namespace)
+				_, err2 := frame.GetMultusInstance(smcName2, namespace)
+				return err1 == nil && err2 == nil
+			}, common.SpiderSyncMultusTime, common.ForcedWaitingTime).Should(BeTrue())
+
+			By("create a deployment with multi-NIC JSON annotation using separate name/namespace/interface fields")
+			depName := "json-multi-dep-" + common.GenerateString(10, true)
+			netSelections := []v1.NetworkSelectionElement{
+				{Name: smcName1, Namespace: namespace, InterfaceRequest: "net1"},
+				{Name: smcName2, Namespace: namespace, InterfaceRequest: "net2"},
+			}
+			multiJSON, err := json.Marshal(netSelections)
+			Expect(err).NotTo(HaveOccurred())
+			GinkgoWriter.Printf("multi-NIC JSON annotation: %s\n", string(multiJSON))
+
+			deployObject := common.GenerateExampleDeploymentYaml(depName, namespace, int32(1))
+			deployObject.Spec.Template.Annotations = map[string]string{
+				common.MultusNetworks: string(multiJSON),
+			}
+			Expect(frame.CreateDeployment(deployObject)).NotTo(HaveOccurred())
+
+			ctx, cancel := context.WithTimeout(context.Background(), common.PodStartTimeout)
+			defer cancel()
+
+			By("wait for deployment to be ready, which verifies that IPAM correctly parsed the multi-NIC JSON annotation")
+			depObject, err := frame.WaitDeploymentReady(depName, namespace, ctx)
+			Expect(err).NotTo(HaveOccurred(), "waiting for deploy ready failed: %v", err)
+			podList, err := frame.GetPodListByLabel(depObject.Spec.Template.Labels)
+			Expect(err).NotTo(HaveOccurred(), "failed to get podList: %v", err)
+			Expect(podList.Items).NotTo(BeEmpty())
+
+			By("verify the pod has network status annotation with allocated IPs on both interfaces")
+			podIPs, err := common.ParsePodNetworkAnnotation(frame, &podList.Items[0])
+			Expect(err).NotTo(HaveOccurred(), "failed to parse pod network annotation: %v", err)
+			Expect(podIPs).NotTo(BeEmpty(), "pod should have allocated IPs")
+			GinkgoWriter.Printf("Pod %s/%s allocated IPs: %v\n", podList.Items[0].Namespace, podList.Items[0].Name, podIPs)
+		})
+
+	It("Pod with pretty-printed JSON k8s.v1.cni.cncf.io/networks annotation (multi-line indented array) should be parsed correctly and get IP allocated",
+		Label("M00037"), func() {
+			smcName := "json-pretty-" + common.GenerateString(10, true)
+			smc := &v2beta1.SpiderMultusConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      smcName,
+					Namespace: namespace,
+				},
+				Spec: v2beta1.MultusCNIConfigSpec{
+					CniType: ptr.To(constant.MacvlanCNI),
+					MacvlanConfig: &v2beta1.SpiderMacvlanCniConfig{
+						Master:                []string{common.NIC1},
+						SpiderpoolConfigPools: &v2beta1.SpiderpoolPools{},
+					},
+				},
+			}
+
+			if frame.Info.IpV4Enabled {
+				smc.Spec.MacvlanConfig.SpiderpoolConfigPools.IPv4IPPool = []string{"default-v4-ippool"}
+			}
+			if frame.Info.IpV6Enabled {
+				smc.Spec.MacvlanConfig.SpiderpoolConfigPools.IPv6IPPool = []string{"default-v6-ippool"}
+			}
+
+			By("create a spiderMultusConfig")
+			Expect(frame.CreateSpiderMultusInstance(smc)).NotTo(HaveOccurred())
+
+			Eventually(func() bool {
+				_, err := frame.GetMultusInstance(smcName, namespace)
+				return err == nil
+			}, common.SpiderSyncMultusTime, common.ForcedWaitingTime).Should(BeTrue())
+
+			By("create a deployment with pretty-printed JSON format k8s.v1.cni.cncf.io/networks annotation")
+			depName := "json-pretty-dep-" + common.GenerateString(10, true)
+			// Pretty-printed JSON format with newlines and indentation (as kubectl/client-go might produce)
+			netSelections := []v1.NetworkSelectionElement{
+				{
+					Name:      smcName,
+					Namespace: namespace,
+				},
+			}
+			prettyJSON, err := json.MarshalIndent(netSelections, "", "  ")
+			Expect(err).NotTo(HaveOccurred())
+			GinkgoWriter.Printf("pretty-printed JSON annotation: %s\n", string(prettyJSON))
+
+			annotations := map[string]string{
+				common.MultusNetworks: string(prettyJSON),
+			}
+			deployObject := common.GenerateExampleDeploymentYaml(depName, namespace, int32(1))
+			deployObject.Spec.Template.Annotations = annotations
+			Expect(frame.CreateDeployment(deployObject)).NotTo(HaveOccurred())
+
+			ctx, cancel := context.WithTimeout(context.Background(), common.PodStartTimeout)
+			defer cancel()
+
+			By("wait for deployment to be ready, which verifies that IPAM correctly parsed the pretty-printed JSON annotation")
+			depObject, err := frame.WaitDeploymentReady(depName, namespace, ctx)
+			Expect(err).NotTo(HaveOccurred(), "waiting for deploy ready failed: %v", err)
+			podList, err := frame.GetPodListByLabel(depObject.Spec.Template.Labels)
+			Expect(err).NotTo(HaveOccurred(), "failed to get podList: %v", err)
+			Expect(podList.Items).NotTo(BeEmpty())
+
+			By("verify the pod has network status annotation with allocated IPs")
+			podIPs, err := common.ParsePodNetworkAnnotation(frame, &podList.Items[0])
+			Expect(err).NotTo(HaveOccurred(), "failed to parse pod network annotation: %v", err)
+			Expect(podIPs).NotTo(BeEmpty(), "pod should have allocated IPs")
+			GinkgoWriter.Printf("Pod %s/%s allocated IPs: %v\n", podList.Items[0].Namespace, podList.Items[0].Name, podIPs)
+		})
 })

--- a/tools/k8s-controller-gen/update-controller-gen.sh
+++ b/tools/k8s-controller-gen/update-controller-gen.sh
@@ -48,6 +48,28 @@ manifests_gen() {
     paths="${PWD}/${PROJECT_ROOT}/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1" \
     output:crd:artifacts:config="${output_dir}/crds" \
     output:rbac:artifacts:config="${output_dir}/templates"
+
+  # controller-gen cannot express colon-containing verbs such as
+  # "associated-node:update" required by DRA resourceclaims/driver.
+  # Inject the rule right after the resource.k8s.io block it generates.
+  local role_file="${output_dir}/templates/role.yaml"
+  if [ -f "${role_file}" ]; then
+    awk '
+      /^- apiGroups:/ { if (rk8s) { inject=1 }; rk8s=0 }
+      /resource\.k8s\.io/ { rk8s=1 }
+      inject {
+        print "- apiGroups:"
+        print "  - resource.k8s.io"
+        print "  resources:"
+        print "  - resourceclaims/driver"
+        print "  verbs:"
+        print "  - \"associated-node:patch\""
+        print "  - \"associated-node:update\""
+        inject=0
+      }
+      { print }
+    ' "${role_file}" > "${role_file}.tmp" && mv "${role_file}.tmp" "${role_file}"
+  fi
 }
 
 deepcopy_gen() {


### PR DESCRIPTION
# Thanks for contributing!

**Notice**:

* [x] unite test or E2E test
* [ ] do not forget essential code comment and log
* [ ] document for the PR
* [x] release note label
  "release/none"
  "release/bug"
  "release/feature"
* [ ] read about  Contribution notice: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>

**What issue(s) does this PR fix**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/spidernet-io/spiderpool/issues/5450

**Special notes for your reviewer**:
The documentation at https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/docs/how-to-use.md supports JSON format. See https://github.com/k8snetworkplumbingwg/multus-cni/blob/e10870dbcf114dc5c6b964d5ff5a38842644b52b/pkg/k8sclient/k8sclient.go#L230 for improved handling of JSON format.

**Release note**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
IPAM's annotation k8s.v1.cni.cncf.io/networks supports JSON arrays, consistent with multus.
```
