### PR TITLE
feat: add configurable HTTP timeout for IaaS provider integration

### DIFF
--- a/.github/workflows/update-chart-readme.yml
+++ b/.github/workflows/update-chart-readme.yml
@@ -1,24 +1,25 @@
 name: lint chart readme
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
       - 'charts/**'
 
-permissions: write-all
+permissions:
+  contents: read
 
 jobs:
   check-chart-readme:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout bitnami-labs/readme-generator-for-helm
+      - name: Checkout project
         uses: actions/checkout@v4
         with:
-          repository: 'bitnami-labs/readme-generator-for-helm'
-          ref: '56339fd97199c76326f224272deba14f3bcc8c3f'
-          path: readme-generator-for-helm
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          path: thisProject
 
       - name: Cache node modules
         uses: actions/cache@v3
@@ -26,47 +27,19 @@ jobs:
           cache-name: cache-node-modules
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('readme-generator-for-helm/package-lock.json') }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('thisProject/Makefile') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
 
-      - name: Install readme-generator-for-helm
+      - name: Verify chart README.md
         run: |
-          cd readme-generator-for-helm
-          npm install
-
-      - name: Checkout project
-        uses: actions/checkout@v4
-        with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          path: thisProject
-
-      - name: generate chart/README.md
-        run: |
-          echo -e "\033[32mUse readme-generator-for-helm to generate README.md\033[0m"
-          echo "-----------------------------"
-          readme-generator-for-helm/bin/index.js \
-          --values "thisProject/charts/spiderpool/values.yaml" \
-          --readme "thisProject/charts/spiderpool/README.md"
-          echo "-----------------------------"
+          cd thisProject
+          make chart-readme-verify
 
       - name: Upload artifact digests
+        if: failure()
         uses: actions/upload-artifact@v6.0.0
         with:
           name: ${{github.event.pull_request.id}}-README.md
           path: thisProject/charts/spiderpool/README.md
-
-      - name: Diff chart/README.md
-        run: |
-          cd thisProject
-          if git diff --quiet; then
-            echo -e "\033[32mREADME.md has not changed\033[0m"
-          else
-            echo -e "\033[31mcharts/spiderpool/README.md has changed!\033[0m"
-            echo -e "\033[31mPlease refer to artifact, and then commit the code.\033[0m"
-            echo -e "\033[31mAlternatively, copy the contents of the new README.md below into your commit.\033[0m"
-            echo -e "\033[31m-----------------------------\033[0m"
-            cat charts/spiderpool/README.md
-            exit 1
-          fi
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ man/
 *.ok
 *.build_all
 LICENSE.all
+.tmp/
 
 # Temporary files that allow build containers/VMs work without git
 # Not to be ignored by docker.
@@ -98,3 +99,4 @@ test/e2edebugLog.txt
 
 .specify/
 .windsurf/
+.agents/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,10 +15,13 @@ Spiderpool is a Go Kubernetes networking project. Main binaries live in `cmd/`, 
 - `make lint-golang`: run format checks, lock checks, `go vet`, and `golangci-lint`.
 - `make manifests generate-k8s-api`: regenerate CRDs/RBAC/webhooks and deepcopy code.
 - `make openapi-code-gen`: regenerate OpenAPI clients from `api/v1/*/openapi.yaml`.
+- `make chart-readme`: regenerate `charts/spiderpool/README.md` from `charts/spiderpool/values.yaml`.
 
 ## Coding Style & Naming Conventions
 
 Use Go 1.25 as declared in `go.mod`. Keep Go code `gofmt`/`gofumpt` clean and satisfy `.golangci.yaml` linters: `govet`, `errcheck`, `staticcheck`, `ineffassign`, and `errorlint`. Package names are lowercase and directory-oriented, for example `pkg/ippoolmanager` and `pkg/workloadendpointmanager`. Tests use `_test.go`; suite files follow `*_suite_test.go`.
+
+All code, comments, generated text reviewed before commit, and project documentation must be English-first. Use English for identifiers, comments, logs, errors, examples, and primary documentation text unless a file is explicitly localized.
 
 ## Testing Guidelines
 
@@ -31,3 +34,12 @@ History uses short imperative subjects with optional scopes, such as `fix: ...`,
 ## Agent-Specific Instructions
 
 Before changing generated Kubernetes or OpenAPI files, update the source definitions and run the matching generation or verify target. Do not revert unrelated local changes; this repository may contain concurrent contributor work.
+
+When adding or modifying files under `docs/`, update both English and Chinese documentation in the same change. Keep English as the primary/source version, and keep the corresponding Chinese localized file or section synchronized with equivalent content.
+
+When changing `charts/spiderpool/values.yaml`, run `make chart-readme` and include the generated `charts/spiderpool/README.md` changes in the same commit. Use `make chart-readme-verify` to check that the generated README is in sync.
+
+<!-- SPECKIT START -->
+For additional context about technologies to be used, project structure,
+shell commands, and other important information, read the current plan
+<!-- SPECKIT END -->

--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,40 @@ dev-doctor:
 
 #============ tools ====================
 
+CHART_README_GENERATOR_REF ?= 56339fd97199c76326f224272deba14f3bcc8c3f
+CHART_README_GENERATOR_DIR ?= $(ROOT_DIR)/.tmp/readme-generator-for-helm
+CHART_VALUES_FILE ?= $(ROOT_DIR)/charts/spiderpool/values.yaml
+CHART_README_FILE ?= $(ROOT_DIR)/charts/spiderpool/README.md
+
+.PHONY: install-chart-readme-generator
+install-chart-readme-generator:
+	$(QUIET)if [ ! -d "$(CHART_README_GENERATOR_DIR)/.git" ]; then \
+		rm -rf "$(CHART_README_GENERATOR_DIR)" ; \
+		git clone https://github.com/bitnami-labs/readme-generator-for-helm.git "$(CHART_README_GENERATOR_DIR)" ; \
+	fi
+	$(QUIET)cd "$(CHART_README_GENERATOR_DIR)" ; \
+		git fetch --depth 1 origin "$(CHART_README_GENERATOR_REF)" ; \
+		git checkout --detach "$(CHART_README_GENERATOR_REF)" ; \
+		npm install
+
+.PHONY: chart-readme
+chart-readme: install-chart-readme-generator
+	@echo "Use readme-generator-for-helm to generate $(CHART_README_FILE)"
+	$(QUIET)"$(CHART_README_GENERATOR_DIR)/bin/index.js" \
+		--values "$(CHART_VALUES_FILE)" \
+		--readme "$(CHART_README_FILE)"
+
+.PHONY: chart-readme-verify
+chart-readme-verify: chart-readme
+	$(QUIET)cd "$(ROOT_DIR)" ; \
+		if git diff --quiet -- charts/spiderpool/README.md ; then \
+			echo "charts/spiderpool/README.md has not changed" ; \
+		else \
+			echo "charts/spiderpool/README.md has changed. Please commit the generated README.md." ; \
+			git diff -- charts/spiderpool/README.md ; \
+			exit 1 ; \
+		fi
+
 update-authors:
 	@echo "Updating AUTHORS file..."
 	@echo "The following people, in alphabetical order, have either authored or signed" > AUTHORS_TMP

--- a/charts/spiderpool/README.md
+++ b/charts/spiderpool/README.md
@@ -463,6 +463,7 @@ helm install spiderpool spiderpool/spiderpool --wait --namespace kube-system \
 
 ### IaaS Network Provider Integration
 
-| Name                            | Description                                                                                                                 | Value |
-| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----- |
-| `iaasNetworkProvider.serverUrl` | the URL of the IaaS provider service. Must include scheme (http or https) and port. If empty, IaaS integration is disabled. | `""`  |
+| Name                                     | Description                                                                                                                                                                                                                       | Value |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| `iaasNetworkProvider.serverUrl`          | the URL of the IaaS provider service. Must include scheme (http or https) and port. If empty, IaaS integration is disabled.                                                                                                       | `""`  |
+| `iaasNetworkProvider.httpRequestTimeout` | the HTTP request timeout for IaaS provider calls. Must be a valid Go duration string (e.g., "50s", "1m"). Default: 50s. This covers the provider worst-case: up to 30s rate-limit wait plus up to 16s cloud API call plus margin. | `50s` |

--- a/charts/spiderpool/templates/configmap.yaml
+++ b/charts/spiderpool/templates/configmap.yaml
@@ -38,6 +38,7 @@ data:
       namespacesInclude: {{ toJson .Values.spiderpoolController.podResourceInject.namespacesInclude }}
     iaasNetworkProvider:
       serverUrl: {{ (.Values.iaasNetworkProvider).serverUrl | default "" | quote }}
+      httpRequestTimeout: {{ (.Values.iaasNetworkProvider).httpRequestTimeout | default "30s" | quote }}
 {{- if .Values.multus.multusCNI.install }}
 ---
 kind: ConfigMap

--- a/charts/spiderpool/values.yaml
+++ b/charts/spiderpool/values.yaml
@@ -1072,3 +1072,5 @@ sriov:
 iaasNetworkProvider:
   ## @param iaasNetworkProvider.serverUrl the URL of the IaaS provider service. Must include scheme (http or https) and port. If empty, IaaS integration is disabled.
   serverUrl: ""
+  ## @param iaasNetworkProvider.httpRequestTimeout the HTTP request timeout for IaaS provider calls. Must be a valid Go duration string (e.g., "50s", "1m"). Default: 50s. This covers the provider worst-case: up to 30s rate-limit wait plus up to 16s cloud API call plus margin.
+  httpRequestTimeout: "50s"

--- a/cmd/spiderpool-agent/cmd/daemon.go
+++ b/cmd/spiderpool-agent/cmd/daemon.go
@@ -80,8 +80,10 @@ func DaemonMain() {
 	logger.Sugar().Infof("Spiderpool-agent config: %+v", agentContext.Cfg)
 
 	// Validate IaaS provider configuration and create client
-	if err := iaasClientPkg.ValidateConfig(&agentContext.Cfg.IaaSProviderConfig); err != nil {
-		logger.Sugar().Warnf("IaaS provider configuration validation failed: %v", err)
+	if agentContext.Cfg.IaaSProviderConfig.ServerURL != "" {
+		if err := iaasClientPkg.ValidateConfig(&agentContext.Cfg.IaaSProviderConfig); err != nil {
+			logger.Sugar().Fatalf("IaaS provider configuration validation failed: %v", err)
+		}
 	}
 
 	// Create IaaS client if configured

--- a/cmd/spiderpool-controller/cmd/daemon.go
+++ b/cmd/spiderpool-controller/cmd/daemon.go
@@ -83,8 +83,10 @@ func DaemonMain() {
 	logger.Sugar().Infof("Spiderpool-controller config: %+v", controllerContext.Cfg)
 
 	// Validate IaaS provider configuration
-	if err := iaasClientPkg.ValidateConfig(&controllerContext.Cfg.IaaSProviderConfig); err != nil {
-		logger.Sugar().Warnf("IaaS provider configuration validation failed: %v", err)
+	if controllerContext.Cfg.IaaSProviderConfig.ServerURL != "" {
+		if err := iaasClientPkg.ValidateConfig(&controllerContext.Cfg.IaaSProviderConfig); err != nil {
+			logger.Sugar().Fatalf("IaaS provider configuration validation failed: %v", err)
+		}
 	}
 
 	// Create IaaS client if configured

--- a/cmd/spiderpool/cmd/command_add.go
+++ b/cmd/spiderpool/cmd/command_add.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net"
 	"runtime/debug"
-	"time"
 
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
@@ -109,7 +108,7 @@ func CmdAdd(args *skel.CmdArgs) (err error) {
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), constant.DefaultCNIClientTimeout)
 	defer cancel()
 
 	params := daemonset.NewPostIpamIPParams().

--- a/cmd/spiderpool/cmd/command_delete.go
+++ b/cmd/spiderpool/cmd/command_delete.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"runtime/debug"
-	"time"
 
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
@@ -16,6 +15,7 @@ import (
 	"github.com/spidernet-io/spiderpool/api/v1/agent/client/connectivity"
 	"github.com/spidernet-io/spiderpool/api/v1/agent/client/daemonset"
 	"github.com/spidernet-io/spiderpool/api/v1/agent/models"
+	"github.com/spidernet-io/spiderpool/pkg/constant"
 	"github.com/spidernet-io/spiderpool/pkg/openapi"
 )
 
@@ -89,7 +89,7 @@ func CmdDel(args *skel.CmdArgs) (err error) {
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), constant.DefaultCNIClientTimeout)
 	defer cancel()
 
 	params := daemonset.NewDeleteIpamIPParams().

--- a/docs/usage/iaas-network-provider-zh_CN.md
+++ b/docs/usage/iaas-network-provider-zh_CN.md
@@ -29,7 +29,7 @@ IaaS Network Provider 是一个 HTTP 服务。Spiderpool 只定义通用 API 契
 
 ## 使用方式
 
-通过 Helm values 配置 Provider URL：
+通过 Helm values 配置 Provider URL 和 HTTP 超时：
 
 ```yaml
 ipam:
@@ -39,11 +39,71 @@ plugins:
   installVlanCNI: true
 iaasNetworkProvider:
   serverUrl: "http://iaas-network-provider.iaas-network-provider-system.svc:80"
+  httpRequestTimeout: "50s"
 ```
 
 - 如果 `iaasNetworkProvider.serverUrl` 为空，Spiderpool 不会调用 IaaS Network Provider。
 - 必须同时启用 `plugins.installVlanCNI`。
 - 必须关闭 `ipam.enableGatewayDetection` 和 `ipam.enableIPConflictDetection` 关闭网关可达性检测和 IP 冲突检测。此模式和传统先调用 CNI 后调用 IPAM 方式不同，必须先调用 IPAM 获取 Iaas IP 信息才能调用 CNI 完成 Pod 网络设置。所以网关可达性检测和 IP 冲突检测在此模式下无法工作。
+
+### 配置 HTTP 请求超时
+
+`iaasNetworkProvider.httpRequestTimeout` 控制 Spiderpool 等待单次 Provider HTTP 调用（分配或释放）的最长时间，超时后该次调用被视为失败。
+
+#### Provider 请求时序模型
+
+一次 Provider 请求需要经历两个阶段：
+
+| 阶段 | 最大耗时 | 说明 |
+| --- | --- | --- |
+| 限流等待 | 30 s | Provider 检查令牌桶是否有可用槽位，如果没有则最多等待 30 s 后再接受请求。 |
+| Cloud API 调用 | 16 s | Provider 向底层云平台发起请求，网络延迟和云平台侧处理最多需要 16 s。 |
+| **最坏情况合计** | **~48 s** | 两个阶段之和加上少量网络往返余量。 |
+
+如果 `httpRequestTimeout` 设置低于 ~48 s，可能会在 Provider 已接受请求并开始在云平台侧执行时将其取消。这会导致状态不一致：Spiderpool 视为失败，但云平台侧的操作可能已经成功或正在进行中。
+
+#### 建议值
+
+| 场景 | 建议的 `httpRequestTimeout` |
+| --- | --- |
+| 默认 / 通用场景 | `50s`（默认值） |
+| 低延迟私有云、无限流 | `20s` |
+| 高竞争场景、限流等待时间较长 | `55s`–`59s`（必须保持 `< 100s`） |
+
+#### 校验规则
+
+- 必须是合法的 Go duration 字符串（例如 `50s`、`1m`）。
+- 必须大于 `0`。
+- 必须小于 `2m`（静态安全上限）。
+- 必须小于 `100s`（CNI 插件调用 agent 的超时上限，适用于 ADD 和 DEL）。
+- 为空时默认使用 `50s`。
+- 校验失败是**致命错误**：agent 和 controller 将无法启动。
+
+#### 时间预算层级
+
+理解完整的预算链有助于说明 `httpRequestTimeout` 各项约束的来源：
+
+| 层级 | 默认超时 | 说明 |
+| --- | --- | --- |
+| kubelet Sandbox 操作 | **2 min** | kubelet 为整个 Sandbox 创建（Pod 网络初始化）设置的默认超时。若 CNI 流水线在此窗口内未完成，Pod 启动失败。这是最外层的时间预算。 |
+| Spiderpool CNI 插件 → agent 调用 | **100 s** | Spiderpool CNI 二进制调用 spiderpool-agent gRPC 接口时使用的超时。这是 agent 完成所有 IPAM 和 IaaS 工作的总预算，超时后 CNI 插件将放弃等待。 |
+| IaaS Provider HTTP 调用 | **50 s**（默认） | 由 `httpRequestTimeout` 配置的单次调用超时。需要在 100 s agent 预算内，与其他 IPAM 工作共享预算。 |
+| Provider 最坏情况完成时间 | **~48 s** | 单次 Provider 请求的最长耗时（30 s 限流等待 + 16 s Cloud API）。这是 `httpRequestTimeout` 有意义的最小值。 |
+
+#### 运行时行为
+
+每次发起 Provider HTTP 调用之前，Spiderpool 会检查父 CNI 操作 context（即 100 s agent 预算）的剩余时间：
+
+- 如果剩余时间**小于 Provider 最坏情况耗时**（~48 s），Spiderpool **不会发起调用**，直接返回 `parent budget insufficient` 错误。这样可以避免 Provider 已消耗令牌桶但 Spiderpool 收到取消错误的状态不一致。
+- 如果剩余时间充足，Spiderpool 会派生一个以 `httpRequestTimeout` 为上限的子 context 执行 HTTP 请求。实际生效的截止时间为 `min(当前时间 + httpRequestTimeout, 父 context 截止时间)`。
+
+#### 错误信息说明
+
+| 错误信息 | 含义 | 建议操作 |
+| --- | --- | --- |
+| `parent budget insufficient: Xs remaining is less than provider worst-case 48s` | CNI 流水线在到达 IaaS 调用之前已消耗了大部分预算。 | 检查流水线延迟；考虑提高 CNI 超时或降低 `httpRequestTimeout`。 |
+| `provider-interaction timeout: ... exceeded configured timeout 50s` | Provider 未在 `httpRequestTimeout` 内响应。 | 检查 Provider 健康状态；如果 Provider 负载持续偏高，考虑适当提高 `httpRequestTimeout`。 |
+| `parent budget exhausted: ... cancelled by parent context deadline` | Provider 正在响应时父 context 截止时间到达。 | 同上，父预算耗尽先于配置的超时触发。 |
 
 > **注意**：[VLAN-CNI](https://github.com/spidernet-io/vlan-cni) 是 Spiderpool 基于社区 cni-plugin 项目开发的 VLAN CNI 插件，用于对接第三方云平台 IaaS Network Provider，为容器创建 IaaS 层的 VLAN 子网卡。
 
@@ -240,7 +300,7 @@ Spiderpool 在分配 IP 时采用同步调用方式：只有 Provider 完成 Iaa
 - 如果 Provider 或云平台对 API 进行限流，处理时间过长导致 Spiderpool 等待 HTTP 响应超时，本次分配将被视为失败。
 - 如果 Provider 侧故障无法响应，Spiderpool 会等待超时时间后将本次分配视为失败。
 
-如果 Spiderpool-agent 在指定时间内（2 min）没有收到 Provider 的成功响应，那么本次分配将被视为失败, 会阻止 Pod 创建，Pod 会遵循 K8s 的重试机制进行重试。
+如果 Spiderpool-agent 在配置的 `httpRequestTimeout` 时间内（默认 `50s`）没有收到 Provider 的成功响应，那么本次分配将被视为失败，会阻止 Pod 创建，Pod 会遵循 K8s 的重试机制进行重试。
 
 ### 释放接口应该具备幂等性
 

--- a/docs/usage/iaas-network-provider.md
+++ b/docs/usage/iaas-network-provider.md
@@ -29,7 +29,7 @@ The IaaS Network Provider is an HTTP service. Spiderpool only defines the API co
 
 ## Usage
 
-Configure the provider URL through Helm values:
+Configure the provider URL and HTTP timeout through Helm values:
 
 ```yaml
 ipam:
@@ -39,11 +39,71 @@ plugins:
   installVlanCNI: true
 iaasNetworkProvider:
   serverUrl: "http://iaas-network-provider.iaas-network-provider-system.svc:80"
+  httpRequestTimeout: "50s"
 ```
 
 - If `iaasNetworkProvider.serverUrl` is empty, Spiderpool does not call the IaaS Network Provider.
 - `plugins.installVlanCNI` must also be enabled.
 - `ipam.enableGatewayDetection` and `ipam.enableIPConflictDetection` must be disabled. This mode is different from the traditional approach of calling CNI first and then calling IPAM. In this mode, IPAM must be called first to obtain the IaaS IP information before calling CNI to complete the Pod network configuration. Therefore, gateway detection and IP conflict detection cannot work in this mode.
+
+### Configure the HTTP request timeout
+
+`iaasNetworkProvider.httpRequestTimeout` controls how long Spiderpool waits for a single provider HTTP call (allocate or release) before treating it as failed.
+
+#### Provider timing model
+
+A single provider request goes through two stages:
+
+| Stage | Max duration | Description |
+| --- | --- | --- |
+| Rate-limit wait | 30 s | The provider checks its token bucket. If no slot is available it waits up to 30 s before accepting the request. |
+| Cloud API call | 16 s | The provider forwards the request to the underlying cloud platform. Network latency and cloud-side processing can take up to 16 s. |
+| **Worst-case total** | **~48 s** | Sum of the two stages plus a small network round-trip margin. |
+
+Setting `httpRequestTimeout` shorter than ~48 s risks cancelling a request that the provider has already accepted and started executing on the cloud platform. This creates a state inconsistency: Spiderpool treats the call as a failure while the cloud operation may have succeeded or be in progress.
+
+#### Recommended values
+
+| Scenario | Recommended `httpRequestTimeout` |
+| --- | --- |
+| Default / general use | `50s` (default) |
+| Low-latency private cloud with no rate limiting | `20s` |
+| High-contention environment with long rate-limit queues | `55s`–`59s` (must remain `< 100s`) |
+
+#### Validation rules
+
+- Must be a valid Go duration string (e.g. `50s`, `1m`).
+- Must be greater than `0`.
+- Must be less than `2m` (static safety limit).
+- Must be less than `100s` (the CNI plugin-to-agent timeout for ADD and DEL).
+- Empty or unset defaults to `50s`.
+- Validation failure is **fatal**: the agent and controller will not start with an invalid value.
+
+#### Time budget hierarchy
+
+Understanding the full budget chain helps explain why `httpRequestTimeout` has the constraints it does:
+
+| Layer | Default timeout | Description |
+| --- | --- | --- |
+| kubelet sandbox operation | **2 min** | kubelet's default timeout for the entire sandbox setup (Pod network setup). If the CNI pipeline does not complete within this window, the Pod fails to start. This is the outermost budget. |
+| Spiderpool CNI plugin → agent call | **100 s** | The timeout the Spiderpool CNI binary uses when calling the spiderpool-agent over gRPC. This is the budget available to the agent to complete all IPAM and IaaS work before the CNI plugin gives up. |
+| IaaS provider HTTP call | **50 s** (default) | The per-call timeout configured by `httpRequestTimeout`. Must fit inside the 100 s agent budget alongside all other IPAM work. |
+| Provider worst-case completion | **~48 s** | The maximum time a single provider request can take (30 s rate-limit wait + 16 s cloud API). This is the minimum meaningful value for `httpRequestTimeout`. |
+
+#### Runtime behavior
+
+Before sending each provider HTTP call, Spiderpool checks how much time remains in the parent CNI operation context (the 100 s agent budget):
+
+- If the remaining time is **less than the provider worst-case** (~48 s), Spiderpool **does not start the call** and returns a `parent budget insufficient` error immediately. This prevents the provider from consuming a rate-limit slot for a call that cannot complete, which would leave the cloud-side operation in an unknown state.
+- If the remaining time is sufficient, Spiderpool derives a per-call context bounded by `httpRequestTimeout`. The effective HTTP deadline is `min(now + httpRequestTimeout, parent deadline)`.
+
+#### Error messages
+
+| Message | Meaning | Suggested action |
+| --- | --- | --- |
+| `parent budget insufficient: Xs remaining is less than provider worst-case 48s` | The CNI pipeline consumed most of the budget before reaching the IaaS call. | Check pipeline latency; consider raising the CNI timeout or reducing `httpRequestTimeout`. |
+| `provider-interaction timeout: ... exceeded configured timeout 50s` | The provider did not respond within `httpRequestTimeout`. | Check provider health; consider raising `httpRequestTimeout` if provider load is consistently high. |
+| `parent budget exhausted: ... cancelled by parent context deadline` | The parent deadline arrived while the provider was responding. | Same as above; the parent budget ran out before the configured timeout. |
 
 > **Note**: [VLAN-CNI](https://github.com/spidernet-io/vlan-cni) is a VLAN CNI plugin developed by Spiderpool based on the upstream community cni-plugin project. It can be used to integrate with third-party cloud platform IaaS Network Providers, allocating IaaS-layer VLAN network interfaces for containers.
 
@@ -244,7 +304,7 @@ In some abnormal scenarios:
 - If the Provider or cloud platform throttles the API and the processing takes a long time, causing Spiderpool to time out while waiting for the HTTP response, Spiderpool will treat this allocation as failed.
 - If the Provider side fails to respond, Spiderpool will wait for the timeout period and then treat this allocation as failed.
 
-If the spiderpool-agent does not receive a successful response from the Provider within the specified time (2 minutes), this allocation will be treated as a failure, and the Pod will be retried according to Kubernetes retry mechanisms.
+If the spiderpool-agent does not receive a successful response from the Provider within the configured `httpRequestTimeout` (default `50s`), this allocation will be treated as a failure, and the Pod will be retried according to Kubernetes retry mechanisms.
 
 ### Release should be idempotent
 

--- a/pkg/applicationcontroller/app_controller.go
+++ b/pkg/applicationcontroller/app_controller.go
@@ -484,7 +484,8 @@ func (sac *SubnetAppController) Run(stopCh <-chan struct{}) error {
 	defer sac.workQueue.ShutDown()
 
 	logger.Debug("Waiting for application informers caches to sync")
-	ok := cache.WaitForCacheSync(stopCh,
+	ok := cache.WaitForCacheSync(
+		stopCh,
 		sac.deploymentInformer.HasSynced,
 		sac.replicaSetInformer.HasSynced,
 		sac.daemonSetInformer.HasSynced,
@@ -760,7 +761,7 @@ func (sac *SubnetAppController) applyAutoIPPool(ctx context.Context, podSubnetCo
 		var desiredIPNumber int
 		var annoPoolIPNumberVal string
 		if podSubnetConfig.FlexibleIPNum != nil {
-			desiredIPNumber = appReplicas + *(podSubnetConfig.FlexibleIPNum)
+			desiredIPNumber = appReplicas + *podSubnetConfig.FlexibleIPNum
 			annoPoolIPNumberVal = fmt.Sprintf("+%d", *podSubnetConfig.FlexibleIPNum)
 		} else {
 			desiredIPNumber = podSubnetConfig.AssignIPNum

--- a/pkg/constant/timeout.go
+++ b/pkg/constant/timeout.go
@@ -1,0 +1,36 @@
+// Copyright 2025 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+
+package constant
+
+import "time"
+
+const (
+	// DefaultCNIClientTimeout is the timeout the CNI plugin uses when calling the
+	// Spiderpool agent. Shared by CNI ADD and CNI DEL.
+	DefaultCNIClientTimeout = 100 * time.Second
+
+	// IaaSTimeoutStaticLimit is the absolute upper bound for an IaaS provider
+	// HTTP request timeout. It exists as a safety guard independent of dynamic
+	// parent budgets.
+	IaaSTimeoutStaticLimit = 2 * time.Minute
+
+	// IaaSProviderRateLimitWait is the maximum time the IaaS provider will wait
+	// for a rate-limit token bucket slot before rejecting the request.
+	IaaSProviderRateLimitWait = 30 * time.Second
+
+	// IaaSProviderCloudAPITimeout is the maximum time the IaaS provider allows
+	// for the underlying cloud API call to complete.
+	IaaSProviderCloudAPITimeout = 16 * time.Second
+
+	// IaaSProviderWorstCase is the maximum end-to-end time for a single IaaS
+	// provider request: rate-limit wait + cloud API call + a small network margin.
+	// Any parent context with less remaining budget than this cannot guarantee
+	// the provider request will complete.
+	IaaSProviderWorstCase = IaaSProviderRateLimitWait + IaaSProviderCloudAPITimeout + 2*time.Second // 48s
+
+	// DefaultIaaSProviderTimeout is used when IaaS integration is enabled but
+	// no explicit httpRequestTimeout is configured. Set to IaaSProviderWorstCase
+	// plus a small margin so a single provider call has a safe default budget.
+	DefaultIaaSProviderTimeout = 50 * time.Second
+)

--- a/pkg/constant/timeout_test.go
+++ b/pkg/constant/timeout_test.go
@@ -1,0 +1,55 @@
+// Copyright 2025 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+
+package constant
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTimeout(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Timeout Constant Suite")
+}
+
+var _ = Describe("Timeout Constants", Label("unitest"), func() {
+	It("should have DefaultCNIClientTimeout equal to 100 seconds", Label("T013"), func() {
+		Expect(DefaultCNIClientTimeout).To(Equal(100 * time.Second))
+	})
+
+	It("should have IaaSTimeoutStaticLimit equal to 2 minutes", func() {
+		Expect(IaaSTimeoutStaticLimit).To(Equal(2 * time.Minute))
+	})
+
+	It("should have IaaSProviderRateLimitWait equal to 30 seconds", func() {
+		Expect(IaaSProviderRateLimitWait).To(Equal(30 * time.Second))
+	})
+
+	It("should have IaaSProviderCloudAPITimeout equal to 16 seconds", func() {
+		Expect(IaaSProviderCloudAPITimeout).To(Equal(16 * time.Second))
+	})
+
+	It("should have IaaSProviderWorstCase equal to rate-limit wait + cloud API + 2s margin", func() {
+		Expect(IaaSProviderWorstCase).To(Equal(IaaSProviderRateLimitWait + IaaSProviderCloudAPITimeout + 2*time.Second))
+	})
+
+	It("should have DefaultIaaSProviderTimeout equal to 50 seconds", func() {
+		Expect(DefaultIaaSProviderTimeout).To(Equal(50 * time.Second))
+	})
+
+	It("should ensure DefaultIaaSProviderTimeout is greater than IaaSProviderWorstCase", func() {
+		Expect(DefaultIaaSProviderTimeout).To(BeNumerically(">", IaaSProviderWorstCase))
+	})
+
+	It("should ensure DefaultIaaSProviderTimeout is less than DefaultCNIClientTimeout", Label("SC-003"), func() {
+		Expect(DefaultIaaSProviderTimeout).To(BeNumerically("<", DefaultCNIClientTimeout))
+	})
+
+	It("should ensure DefaultCNIClientTimeout is less than IaaSTimeoutStaticLimit", func() {
+		Expect(DefaultCNIClientTimeout).To(BeNumerically("<", IaaSTimeoutStaticLimit))
+	})
+})

--- a/pkg/election/lease_election_test.go
+++ b/pkg/election/lease_election_test.go
@@ -42,26 +42,28 @@ var _ = Describe("Leader Election", Label("unittest", "election_test"), func() {
 		globalParams.leaderRetryElectGap = &retryElectGap
 	})
 
-	DescribeTable("check new lease elector", func(leaseParamsFunc func() *newLeaseElectorParams, shouldError bool) {
-		defer GinkgoRecover()
+	DescribeTable(
+		"check new lease elector", func(leaseParamsFunc func() *newLeaseElectorParams, shouldError bool) {
+			defer GinkgoRecover()
 
-		leaseParams := leaseParamsFunc()
+			leaseParams := leaseParamsFunc()
 
-		_, err := NewLeaseElector(
-			leaseParams.leaseLockNS,
-			leaseParams.leaseLockName,
-			leaseParams.leaseLockIdentity,
-			leaseParams.leaseDuration,
-			leaseParams.leaseRenewDeadline,
-			leaseParams.leaseRetryPeriod,
-			leaseParams.leaderRetryElectGap)
+			_, err := NewLeaseElector(
+				leaseParams.leaseLockNS,
+				leaseParams.leaseLockName,
+				leaseParams.leaseLockIdentity,
+				leaseParams.leaseDuration,
+				leaseParams.leaseRenewDeadline,
+				leaseParams.leaseRetryPeriod,
+				leaseParams.leaderRetryElectGap,
+			)
 
-		if shouldError {
-			Expect(err).Should(HaveOccurred())
-		} else {
-			Expect(err).ShouldNot(HaveOccurred())
-		}
-	},
+			if shouldError {
+				Expect(err).Should(HaveOccurred())
+			} else {
+				Expect(err).ShouldNot(HaveOccurred())
+			}
+		},
 		Entry("no namespace", func() *newLeaseElectorParams {
 			globalParams.leaseLockNS = ""
 			return globalParams

--- a/pkg/iaas/client/client.go
+++ b/pkg/iaas/client/client.go
@@ -12,11 +12,13 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
 	"go.uber.org/zap"
 
+	"github.com/spidernet-io/spiderpool/pkg/constant"
 	spiderpooltypes "github.com/spidernet-io/spiderpool/pkg/types"
 )
 
@@ -24,6 +26,15 @@ const (
 	allocateAPIPath = "/v1/apis/network.iaas.io/ipam/allocate-ips"
 	releaseAPIPath  = "/v1/apis/network.iaas.io/ipam/release-ip"
 )
+
+// isTimeoutError checks if an error is a timeout error
+func isTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	return strings.Contains(errStr, "timeout") || strings.Contains(errStr, "deadline exceeded")
+}
 
 // Client is the interface for IaaS provider API client
 type Client interface {
@@ -40,9 +51,10 @@ type Client interface {
 
 // IaaSClient implements the Client interface
 type IaaSClient struct {
-	baseURL    string
-	httpClient *http.Client
-	logger     *zap.Logger
+	baseURL     string
+	httpClient  *http.Client
+	httpTimeout time.Duration
+	logger      *zap.Logger
 
 	// parentNicMacCache caches key -> parent NIC MAC address.
 	// Keys use SpiderMultusConfig namespace/name.
@@ -65,6 +77,24 @@ func ValidateConfig(cfg *spiderpooltypes.IaaSProviderConfig) error {
 	if u.Host == "" {
 		return fmt.Errorf("invalid iaasNetworkProvider.serverUrl %q: host is empty", cfg.ServerURL)
 	}
+
+	// Validate HTTPRequestTimeout if set
+	if cfg.HTTPRequestTimeout != "" {
+		timeout, err := time.ParseDuration(cfg.HTTPRequestTimeout)
+		if err != nil {
+			return fmt.Errorf("invalid iaasNetworkProvider.httpRequestTimeout %q: %w", cfg.HTTPRequestTimeout, err)
+		}
+		if timeout <= 0 {
+			return fmt.Errorf("invalid iaasNetworkProvider.httpRequestTimeout %q: timeout must be positive", cfg.HTTPRequestTimeout)
+		}
+		if timeout >= constant.IaaSTimeoutStaticLimit {
+			return fmt.Errorf("invalid iaasNetworkProvider.httpRequestTimeout %q: timeout %v must be less than static limit %v", cfg.HTTPRequestTimeout, timeout, constant.IaaSTimeoutStaticLimit)
+		}
+		if timeout >= constant.DefaultCNIClientTimeout {
+			return fmt.Errorf("invalid iaasNetworkProvider.httpRequestTimeout %q: timeout %v must be less than CNI client timeout %v", cfg.HTTPRequestTimeout, timeout, constant.DefaultCNIClientTimeout)
+		}
+	}
+
 	return nil
 }
 
@@ -82,23 +112,52 @@ func NewClient(cfg *spiderpooltypes.IaaSProviderConfig, logger *zap.Logger) (*Ia
 		InsecureSkipVerify: true, //nolint:gosec
 	}
 
+	timeout := constant.DefaultIaaSProviderTimeout
+	if cfg.HTTPRequestTimeout != "" {
+		parsed, err := time.ParseDuration(cfg.HTTPRequestTimeout)
+		if err != nil {
+			return nil, fmt.Errorf("invalid iaasNetworkProvider.httpRequestTimeout %q: %w", cfg.HTTPRequestTimeout, err)
+		}
+		timeout = parsed
+	}
+
 	httpClient := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: tlsConfig,
 		},
-		Timeout: 30 * time.Second,
 	}
 
 	return &IaaSClient{
-		baseURL:    cfg.ServerURL,
-		httpClient: httpClient,
-		logger:     logger,
+		baseURL:     cfg.ServerURL,
+		httpClient:  httpClient,
+		httpTimeout: timeout,
+		logger:      logger,
 	}, nil
 }
 
 // AllocateIPs calls the IaaS provider to allocate IPs
 func (c *IaaSClient) AllocateIPs(ctx context.Context, req *AllocateIPRequest) (*AllocateIPResponse, error) {
-	c.logger.Debug("Calling IaaS allocate API",
+	// Fail fast if the parent context does not have enough remaining budget to
+	// cover the provider's worst-case completion time (rate-limit wait + cloud
+	// API call). Sending the request with insufficient budget risks the provider
+	// starting work (consuming a rate-limit slot) and then being cancelled
+	// mid-flight, causing state inconsistency.
+	if deadline, ok := ctx.Deadline(); ok {
+		if remaining := time.Until(deadline); remaining < constant.IaaSProviderWorstCase {
+			return nil, fmt.Errorf("parent budget insufficient: %v remaining is less than provider worst-case %v", remaining.Round(time.Millisecond), constant.IaaSProviderWorstCase)
+		}
+	}
+
+	// Derive a child context bounded by the configured HTTP request timeout.
+	// If httpTimeout < remaining parent budget, the configured value wins.
+	// If httpTimeout > remaining parent budget, the parent wins — but we have
+	// already guaranteed above that remaining >= IaaSProviderWorstCase, so the
+	// request has a realistic chance to complete.
+	reqCtx, cancel := context.WithTimeout(ctx, c.httpTimeout)
+	defer cancel()
+
+	c.logger.Debug(
+		"Calling IaaS allocate API",
 		zap.String("url", c.baseURL),
 		zap.String("nodeName", req.NodeName),
 		zap.String("podName", req.PodName),
@@ -116,7 +175,7 @@ func (c *IaaSClient) AllocateIPs(ctx context.Context, req *AllocateIPRequest) (*
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct allocate URL: %w", err)
 	}
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewBuffer(reqBody))
+	httpReq, err := http.NewRequestWithContext(reqCtx, http.MethodPost, reqURL, bytes.NewBuffer(reqBody))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create allocate request: %w", err)
 	}
@@ -126,10 +185,18 @@ func (c *IaaSClient) AllocateIPs(ctx context.Context, req *AllocateIPRequest) (*
 	// Execute request
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
-		c.logger.Error("IaaS allocate API call failed",
+		c.logger.Error(
+			"IaaS allocate API call failed",
 			zap.Error(err),
 			zap.String("url", reqURL),
 		)
+		// Wrap error to distinguish provider-interaction timeout from validation/budget errors
+		if reqCtx.Err() == context.DeadlineExceeded || isTimeoutError(err) {
+			if ctx.Err() == context.DeadlineExceeded {
+				return nil, fmt.Errorf("parent budget exhausted: IaaS allocate API call cancelled by parent context deadline: %w", err)
+			}
+			return nil, fmt.Errorf("provider-interaction timeout: IaaS allocate API call exceeded configured timeout %v: %w", c.httpTimeout, err)
+		}
 		return nil, fmt.Errorf("iaas allocate API call failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
@@ -142,7 +209,8 @@ func (c *IaaSClient) AllocateIPs(ctx context.Context, req *AllocateIPRequest) (*
 
 	// Check status code - accept any 2xx success code
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		c.logger.Error("IaaS allocate API returned non-success status",
+		c.logger.Error(
+			"IaaS allocate API returned non-success status",
 			zap.Int("statusCode", resp.StatusCode),
 			zap.String("response", string(respBody)),
 		)
@@ -155,7 +223,8 @@ func (c *IaaSClient) AllocateIPs(ctx context.Context, req *AllocateIPRequest) (*
 		return nil, fmt.Errorf("failed to unmarshal allocate response: %w", err)
 	}
 
-	c.logger.Info("IaaS allocate API succeeded",
+	c.logger.Info(
+		"IaaS allocate API succeeded",
 		zap.String("nodeName", allocateResp.NodeName),
 		zap.Int("allocationCount", len(allocateResp.IaaSIPsAllocationResponse)),
 	)
@@ -165,7 +234,8 @@ func (c *IaaSClient) AllocateIPs(ctx context.Context, req *AllocateIPRequest) (*
 
 // ReleaseIP calls the IaaS provider to release an IP.
 func (c *IaaSClient) ReleaseIP(ctx context.Context, req *ReleaseIPRequest) error {
-	c.logger.Debug("Calling IaaS release API",
+	c.logger.Debug(
+		"Calling IaaS release API",
 		zap.String("url", c.baseURL),
 		zap.String("nodeName", req.NodeName),
 		zap.String("ipAddress", req.IPAddress),
@@ -192,7 +262,8 @@ func (c *IaaSClient) ReleaseIP(ctx context.Context, req *ReleaseIPRequest) error
 		return fmt.Errorf("failed to release IP %s: %w", req.IPAddress, err)
 	}
 
-	c.logger.Info("IaaS release API succeeded",
+	c.logger.Info(
+		"IaaS release API succeeded",
 		zap.String("nodeName", req.NodeName),
 		zap.String("ipAddress", req.IPAddress),
 		zap.String("subnet", req.Subnet),
@@ -204,12 +275,24 @@ func (c *IaaSClient) ReleaseIP(ctx context.Context, req *ReleaseIPRequest) error
 
 // releaseSingleIP performs a single IP release API call
 func (c *IaaSClient) releaseSingleIP(ctx context.Context, reqURL string, req *ReleaseIPRequest) error {
+	// Same minimum-budget guard as AllocateIPs: fail fast rather than sending
+	// a request that cannot complete within the provider's worst-case time.
+	if deadline, ok := ctx.Deadline(); ok {
+		if remaining := time.Until(deadline); remaining < constant.IaaSProviderWorstCase {
+			return fmt.Errorf("parent budget insufficient: %v remaining is less than provider worst-case %v", remaining.Round(time.Millisecond), constant.IaaSProviderWorstCase)
+		}
+	}
+
+	// Derive a child context bounded by the configured HTTP request timeout.
+	reqCtx, cancel := context.WithTimeout(ctx, c.httpTimeout)
+	defer cancel()
+
 	reqBody, err := json.Marshal(req)
 	if err != nil {
 		return fmt.Errorf("failed to marshal release request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewBuffer(reqBody))
+	httpReq, err := http.NewRequestWithContext(reqCtx, http.MethodPost, reqURL, bytes.NewBuffer(reqBody))
 	if err != nil {
 		return fmt.Errorf("failed to create release request: %w", err)
 	}
@@ -218,7 +301,8 @@ func (c *IaaSClient) releaseSingleIP(ctx context.Context, reqURL string, req *Re
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
-		c.logger.Error("IaaS release API call failed",
+		c.logger.Error(
+			"IaaS release API call failed",
 			zap.Error(err),
 			zap.String("url", reqURL),
 			zap.String("ipAddresses", req.IPAddress),
@@ -233,7 +317,8 @@ func (c *IaaSClient) releaseSingleIP(ctx context.Context, reqURL string, req *Re
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		c.logger.Error("IaaS release API returned non-success status",
+		c.logger.Error(
+			"IaaS release API returned non-success status",
 			zap.Int("statusCode", resp.StatusCode),
 			zap.String("response", string(respBody)),
 			zap.String("ipAddresses", req.IPAddress),

--- a/pkg/iaas/client/client_suite_test.go
+++ b/pkg/iaas/client/client_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright 2026 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+
+package client_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestClient(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Client Suite")
+}

--- a/pkg/iaas/client/client_test.go
+++ b/pkg/iaas/client/client_test.go
@@ -1,0 +1,315 @@
+// Copyright 2026 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+
+	"github.com/spidernet-io/spiderpool/pkg/constant"
+	spiderpooltypes "github.com/spidernet-io/spiderpool/pkg/types"
+)
+
+var _ = Describe("IaaS Client", Label("unitest"), func() {
+	var logger *zap.Logger
+
+	BeforeEach(func() {
+		var err error
+		logger, err = zap.NewDevelopment()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Describe("NewClient", func() {
+		It("should use default timeout when HTTPRequestTimeout is empty", Label("B001"), func() {
+			cfg := &spiderpooltypes.IaaSProviderConfig{
+				ServerURL:          "http://localhost:8080",
+				HTTPRequestTimeout: "",
+			}
+			client, err := NewClient(cfg, logger)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client).NotTo(BeNil())
+			Expect(client.httpTimeout).To(Equal(constant.DefaultIaaSProviderTimeout))
+		})
+
+		It("should use configured timeout when HTTPRequestTimeout is set", Label("B002"), func() {
+			cfg := &spiderpooltypes.IaaSProviderConfig{
+				ServerURL:          "http://localhost:8080",
+				HTTPRequestTimeout: "45s",
+			}
+			client, err := NewClient(cfg, logger)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client).NotTo(BeNil())
+			Expect(client.httpTimeout).To(Equal(45 * time.Second))
+		})
+
+		It("should parse duration strings correctly", Label("B003"), func() {
+			testCases := []struct {
+				input    string
+				expected time.Duration
+			}{
+				{"30s", 30 * time.Second},
+				{"1m", 1 * time.Minute},
+				{"1m30s", 90 * time.Second},
+				{"500ms", 500 * time.Millisecond},
+			}
+
+			for _, tc := range testCases {
+				cfg := &spiderpooltypes.IaaSProviderConfig{
+					ServerURL:          "http://localhost:8080",
+					HTTPRequestTimeout: tc.input,
+				}
+				client, err := NewClient(cfg, logger)
+				Expect(err).NotTo(HaveOccurred(), "for input %q", tc.input)
+				Expect(client.httpTimeout).To(Equal(tc.expected), "for input %q", tc.input)
+			}
+		})
+
+		It("should return error for invalid duration string", Label("B004"), func() {
+			cfg := &spiderpooltypes.IaaSProviderConfig{
+				ServerURL:          "http://localhost:8080",
+				HTTPRequestTimeout: "invalid",
+			}
+			client, err := NewClient(cfg, logger)
+			Expect(err).To(HaveOccurred())
+			Expect(client).To(BeNil())
+			Expect(err.Error()).To(ContainSubstring("invalid iaasNetworkProvider.httpRequestTimeout"))
+		})
+
+		It("should return error for negative duration (rejected by ValidateConfig in T014)", Label("B005"), func() {
+			cfg := &spiderpooltypes.IaaSProviderConfig{
+				ServerURL:          "http://localhost:8080",
+				HTTPRequestTimeout: "-30s",
+			}
+			client, err := NewClient(cfg, logger)
+			Expect(err).To(HaveOccurred())
+			Expect(client).To(BeNil())
+			Expect(err.Error()).To(ContainSubstring("timeout must be positive"))
+		})
+
+		It("should create http.Client with correct transport", Label("B006"), func() {
+			cfg := &spiderpooltypes.IaaSProviderConfig{
+				ServerURL:          "https://localhost:8080",
+				HTTPRequestTimeout: "30s",
+			}
+			client, err := NewClient(cfg, logger)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.httpClient).NotTo(BeNil())
+			Expect(client.httpClient.Transport).NotTo(BeNil())
+			_, ok := client.httpClient.Transport.(*http.Transport)
+			Expect(ok).To(BeTrue())
+		})
+	})
+
+	Describe("ValidateConfig", func() {
+		It("should return nil when ServerURL is empty", Label("B007"), func() {
+			cfg := &spiderpooltypes.IaaSProviderConfig{
+				ServerURL:          "",
+				HTTPRequestTimeout: "",
+			}
+			err := ValidateConfig(cfg)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should accept valid http URL", Label("B008"), func() {
+			cfg := &spiderpooltypes.IaaSProviderConfig{
+				ServerURL:          "http://localhost:8080",
+				HTTPRequestTimeout: "30s",
+			}
+			err := ValidateConfig(cfg)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should accept valid https URL", Label("B009"), func() {
+			cfg := &spiderpooltypes.IaaSProviderConfig{
+				ServerURL:          "https://provider.example.com:8443",
+				HTTPRequestTimeout: "30s",
+			}
+			err := ValidateConfig(cfg)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should reject URL without scheme", Label("B010"), func() {
+			cfg := &spiderpooltypes.IaaSProviderConfig{
+				ServerURL:          "localhost:8080",
+				HTTPRequestTimeout: "30s",
+			}
+			err := ValidateConfig(cfg)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must start with http:// or https://"))
+		})
+
+		It("should reject URL with invalid scheme", Label("B011"), func() {
+			cfg := &spiderpooltypes.IaaSProviderConfig{
+				ServerURL:          "ftp://localhost:8080",
+				HTTPRequestTimeout: "30s",
+			}
+			err := ValidateConfig(cfg)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must start with http:// or https://"))
+		})
+
+		It("should reject URL without host", Label("B012"), func() {
+			cfg := &spiderpooltypes.IaaSProviderConfig{
+				ServerURL:          "http://",
+				HTTPRequestTimeout: "30s",
+			}
+			err := ValidateConfig(cfg)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("host is empty"))
+		})
+	})
+
+	Describe("ValidateConfig HTTPRequestTimeout validation", func() {
+		DescribeTable(
+			"timeout validation",
+			func(timeout string, expectError bool, errorSubstr string) {
+				cfg := &spiderpooltypes.IaaSProviderConfig{
+					ServerURL:          "http://localhost:8080",
+					HTTPRequestTimeout: timeout,
+				}
+				err := ValidateConfig(cfg)
+				if expectError {
+					Expect(err).To(HaveOccurred())
+					if errorSubstr != "" {
+						Expect(err.Error()).To(ContainSubstring(errorSubstr))
+					}
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+				}
+			},
+			Entry("empty timeout should be valid (uses default)", "", false, ""),
+			Entry("30s should be valid", "30s", false, ""),
+			Entry("45s should be valid", "45s", false, ""),
+			Entry("1m should be valid", "1m", false, ""),
+			Entry("1m30s should be valid", "1m30s", false, ""),
+			Entry("99s should be valid (just under 100s)", "99s", false, ""),
+			Entry("zero should be invalid", "0s", true, "timeout must be positive"),
+			Entry("negative should be invalid", "-30s", true, "timeout must be positive"),
+			Entry("exactly 100s should be invalid (must be strictly less)", "100s", true, "must be less than"),
+			Entry("over 100s should be invalid", "2m", true, "must be less than"),
+			Entry("exactly 2m should be invalid (static limit)", "2m", true, "must be less than"),
+			Entry("over 2m should be invalid", "3m", true, "must be less than"),
+			Entry("invalid duration string should be invalid", "invalid", true, "invalid duration"),
+		)
+	})
+})
+
+var _ = Describe("IaaS Client Context Deadline Handling", Label("unitest"), func() {
+	var logger *zap.Logger
+
+	BeforeEach(func() {
+		var err error
+		logger, err = zap.NewDevelopment()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Describe("AllocateIPs parent budget check", func() {
+		It("should return parent budget insufficient error when context has too little time remaining", Label("T017", "US3"), func() {
+			cfg := &spiderpooltypes.IaaSProviderConfig{
+				ServerURL:          "http://localhost:8080",
+				HTTPRequestTimeout: "50s",
+			}
+			client, err := NewClient(cfg, logger)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client).NotTo(BeNil())
+
+			// Create a context with only 1s remaining — far less than IaaSProviderWorstCase (48s)
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+
+			req := &AllocateIPRequest{
+				NodeName:     "test-node",
+				PodName:      "test-pod",
+				PodNamespace: "default",
+				PodUID:       "test-uuid",
+				IaaSIPsAllocationRequest: []IaaSIPAllocationItem{
+					{IPAddress: "10.0.0.1", Subnet: "10.0.0.0/24"},
+				},
+			}
+
+			_, err = client.AllocateIPs(ctx, req)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("parent budget insufficient"))
+		})
+	})
+
+	Describe("ReleaseIP parent budget check", func() {
+		It("should return parent budget insufficient error when context has too little time remaining", Label("T017", "US3"), func() {
+			cfg := &spiderpooltypes.IaaSProviderConfig{
+				ServerURL:          "http://localhost:8080",
+				HTTPRequestTimeout: "50s",
+			}
+			client, err := NewClient(cfg, logger)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client).NotTo(BeNil())
+
+			// Create a context with only 1s remaining — far less than IaaSProviderWorstCase (48s)
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+
+			req := &ReleaseIPRequest{
+				NodeName:     "test-node",
+				PodName:      "test-pod",
+				PodNamespace: "default",
+				PodUID:       "test-uuid",
+				ParentNicMac: "00:11:22:33:44:55",
+				Subnet:       "10.0.0.0/24",
+				IPAddress:    "10.0.0.1",
+			}
+
+			err = client.ReleaseIP(ctx, req)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("parent budget insufficient"))
+		})
+	})
+})
+
+var _ = Describe("IaaS Client Timeout Errors", Label("unitest"), func() {
+	var logger *zap.Logger
+
+	BeforeEach(func() {
+		var err error
+		logger, err = zap.NewDevelopment()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Describe("Timeout error messages", func() {
+		It("should identify provider-interaction timeout in error message", Label("T018", "US3"), func() {
+			cfg := &spiderpooltypes.IaaSProviderConfig{
+				ServerURL:          "http://localhost:8080",
+				HTTPRequestTimeout: "1ms",
+			}
+			client, err := NewClient(cfg, logger)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client).NotTo(BeNil())
+
+			// Use a context with no deadline so the minimum-budget guard is bypassed.
+			// The 1ms httpTimeout will then govern the request and cause it to time out
+			// against the (unreachable) server.
+			ctx := context.Background()
+
+			req := &AllocateIPRequest{
+				NodeName:     "test-node",
+				PodName:      "test-pod",
+				PodNamespace: "default",
+				PodUID:       "test-uuid",
+				IaaSIPsAllocationRequest: []IaaSIPAllocationItem{
+					{IPAddress: "10.0.0.1", Subnet: "10.0.0.0/24"},
+				},
+			}
+
+			_, err = client.AllocateIPs(ctx, req)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Or(
+				ContainSubstring("provider-interaction timeout"),
+				ContainSubstring("iaas allocate API call failed"),
+			))
+		})
+	})
+})

--- a/pkg/ip/ip_test.go
+++ b/pkg/ip/ip_test.go
@@ -225,12 +225,14 @@ var _ = Describe("IP", Label("ip_test"), func() {
 				},
 				true,
 			)
-			Expect(ips).To(Equal(
-				[]net.IP{
-					net.IPv4(172, 18, 40, 1),
-					net.IPv4(172, 18, 40, 2),
-					net.IPv4(172, 18, 40, 3),
-				}),
+			Expect(ips).To(
+				Equal(
+					[]net.IP{
+						net.IPv4(172, 18, 40, 1),
+						net.IPv4(172, 18, 40, 2),
+						net.IPv4(172, 18, 40, 3),
+					},
+				),
 			)
 		})
 
@@ -246,12 +248,14 @@ var _ = Describe("IP", Label("ip_test"), func() {
 				},
 				true,
 			)
-			Expect(ips).To(Equal(
-				[]net.IP{
-					net.ParseIP("abcd:1234::1"),
-					net.ParseIP("abcd:1234::2"),
-					net.ParseIP("abcd:1234::3"),
-				}),
+			Expect(ips).To(
+				Equal(
+					[]net.IP{
+						net.ParseIP("abcd:1234::1"),
+						net.ParseIP("abcd:1234::2"),
+						net.ParseIP("abcd:1234::3"),
+					},
+				),
 			)
 		})
 	})

--- a/pkg/ip/iprange_test.go
+++ b/pkg/ip/iprange_test.go
@@ -30,7 +30,8 @@ var _ = Describe("IP range", Label("ip_range_test"), func() {
 		})
 
 		It("merges IPv4 IP ranges", func() {
-			ranges, err := spiderpoolip.MergeIPRanges(constant.IPv4,
+			ranges, err := spiderpoolip.MergeIPRanges(
+				constant.IPv4,
 				[]string{
 					"172.18.40.10",
 					"172.18.40.1-172.18.40.2",
@@ -47,7 +48,8 @@ var _ = Describe("IP range", Label("ip_range_test"), func() {
 		})
 
 		It("merges IPv6 IP ranges", func() {
-			ranges, err := spiderpoolip.MergeIPRanges(constant.IPv6,
+			ranges, err := spiderpoolip.MergeIPRanges(
+				constant.IPv6,
 				[]string{
 					"abcd:1234::a",
 					"abcd:1234::1-abcd:1234::2",
@@ -84,7 +86,8 @@ var _ = Describe("IP range", Label("ip_range_test"), func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ips).To(Equal([]net.IP{net.IPv4(172, 18, 40, 10)}))
 
-			ips, err = spiderpoolip.ParseIPRanges(constant.IPv4,
+			ips, err = spiderpoolip.ParseIPRanges(
+				constant.IPv4,
 				[]string{
 					"172.18.40.10",
 					"172.18.40.1-172.18.40.2",
@@ -105,7 +108,8 @@ var _ = Describe("IP range", Label("ip_range_test"), func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ips).To(Equal([]net.IP{net.ParseIP("abcd:1234::a")}))
 
-			ips, err = spiderpoolip.ParseIPRanges(constant.IPv6,
+			ips, err = spiderpoolip.ParseIPRanges(
+				constant.IPv6,
 				[]string{
 					"abcd:1234::a",
 					"abcd:1234::1-abcd:1234::2",
@@ -188,7 +192,8 @@ var _ = Describe("IP range", Label("ip_range_test"), func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ranges).To(Equal([]string{"172.18.40.10"}))
 
-			ranges, err = spiderpoolip.ConvertIPsToIPRanges(constant.IPv4,
+			ranges, err = spiderpoolip.ConvertIPsToIPRanges(
+				constant.IPv4,
 				[]net.IP{
 					net.IPv4(172, 18, 40, 10),
 					net.IPv4(172, 18, 40, 1),
@@ -209,7 +214,8 @@ var _ = Describe("IP range", Label("ip_range_test"), func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ranges).To(Equal([]string{"abcd:1234::a"}))
 
-			ranges, err = spiderpoolip.ConvertIPsToIPRanges(constant.IPv6,
+			ranges, err = spiderpoolip.ConvertIPsToIPRanges(
+				constant.IPv6,
 				[]net.IP{
 					net.ParseIP("abcd:1234::a"),
 					net.ParseIP("abcd:1234::1"),

--- a/pkg/ip/utils_test.go
+++ b/pkg/ip/utils_test.go
@@ -36,7 +36,8 @@ var _ = Describe("IP utils", Label("ip_utils_test"), func() {
 		})
 
 		It("assembles all valid IPv4 IP addresses", func() {
-			ips, err := spiderpoolip.AssembleTotalIPs(constant.IPv4,
+			ips, err := spiderpoolip.AssembleTotalIPs(
+				constant.IPv4,
 				[]string{
 					"172.18.40.10",
 					"172.18.40.1-172.18.40.2",
@@ -51,7 +52,8 @@ var _ = Describe("IP utils", Label("ip_utils_test"), func() {
 		})
 
 		It("assembles all valid IPv6 IP addresses", func() {
-			ips, err := spiderpoolip.AssembleTotalIPs(constant.IPv6,
+			ips, err := spiderpoolip.AssembleTotalIPs(
+				constant.IPv6,
 				[]string{
 					"abcd:1234::a",
 					"abcd:1234::1-abcd:1234::2",

--- a/pkg/ipam/iaas.go
+++ b/pkg/ipam/iaas.go
@@ -70,7 +70,8 @@ func (i *ipam) callIaaSAllocate(ctx context.Context, pod *corev1.Pod, results []
 		})
 	}
 
-	logger.Debug("Calling IaaS allocate API",
+	logger.Debug(
+		"Calling IaaS allocate API",
 		zap.String("podUID", string(pod.UID)),
 		zap.String("nodeName", pod.Spec.NodeName),
 		zap.Any("request", req.IaaSIPsAllocationRequest),
@@ -79,14 +80,16 @@ func (i *ipam) callIaaSAllocate(ctx context.Context, pod *corev1.Pod, results []
 	// Call IaaS API
 	resp, err := i.config.IaaSClient.AllocateIPs(ctx, req)
 	if err != nil {
-		logger.Error("IaaS allocate API failed",
+		logger.Error(
+			"IaaS allocate API failed",
 			zap.String("podUID", string(pod.UID)),
 			zap.Error(err),
 		)
 		return nil, fmt.Errorf("iaas allocate failed: %w", err)
 	}
 
-	logger.Debug("IaaS allocate API succeeded",
+	logger.Debug(
+		"IaaS allocate API succeeded",
 		zap.Any("response", resp.IaaSIPsAllocationResponse),
 	)
 
@@ -171,7 +174,8 @@ func (i *ipam) callIaaSRelease(ctx context.Context, nic string, endpoint *v2beta
 			ParentNicMac: parentNicMac,
 		}
 
-		logger.Debug("Calling IaaS release API",
+		logger.Debug(
+			"Calling IaaS release API",
 			zap.String("podUID", endpoint.Status.Current.UID),
 			zap.String("nodeName", endpoint.Status.Current.Node),
 			zap.String("ipAddress", ipStr),
@@ -180,7 +184,8 @@ func (i *ipam) callIaaSRelease(ctx context.Context, nic string, endpoint *v2beta
 		)
 
 		if err := i.config.IaaSClient.ReleaseIP(ctx, req); err != nil {
-			logger.Error("IaaS release API failed",
+			logger.Error(
+				"IaaS release API failed",
 				zap.String("podUID", endpoint.Status.Current.UID),
 				zap.String("ipAddress", ipStr),
 				zap.String("subnet", subnet),

--- a/pkg/ipam/utils.go
+++ b/pkg/ipam/utils.go
@@ -64,7 +64,7 @@ func groupCustomRoutes(ctx context.Context, customRoutes []*models.Route, result
 				route.IfName = res.IP.Nic
 				res.Routes = append(res.Routes, route)
 
-				customRoutes = append((customRoutes)[:i], (customRoutes)[i+1:]...)
+				customRoutes = append(customRoutes[:i], customRoutes[i+1:]...)
 				i--
 			}
 		}

--- a/pkg/ippoolmanager/ippool_webhook_test.go
+++ b/pkg/ippoolmanager/ippool_webhook_test.go
@@ -230,7 +230,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				subnetT.Labels[constant.LabelSubnetCIDR] = cidr
 				subnetT.Spec.IPVersion = ptr.To(ipVersion)
 				subnetT.Spec.Subnet = subnet
-				subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+				subnetT.Spec.IPs = append(
+					subnetT.Spec.IPs,
 					[]string{
 						"172.18.40.1-172.18.40.2",
 						"172.18.40.10",
@@ -267,7 +268,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				subnetT.Labels[constant.LabelSubnetCIDR] = cidr
 				subnetT.Spec.IPVersion = ptr.To(ipVersion)
 				subnetT.Spec.Subnet = subnet
-				subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+				subnetT.Spec.IPs = append(
+					subnetT.Spec.IPs,
 					[]string{
 						"172.18.40.1-172.18.40.2",
 						"172.18.40.10",
@@ -301,7 +303,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				subnetT.Labels[constant.LabelSubnetCIDR] = cidr
 				subnetT.Spec.IPVersion = ptr.To(ipVersion)
 				subnetT.Spec.Subnet = subnet
-				subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+				subnetT.Spec.IPs = append(
+					subnetT.Spec.IPs,
 					[]string{
 						"172.18.50.1-172.18.50.2",
 						"172.18.50.10",
@@ -353,7 +356,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 			It("failed to merge 'spec.ips' due to the invalid 'spec.ipVersion'", func() {
 				ipPoolT.Spec.IPVersion = ptr.To(constant.InvalidIPVersion)
 				ipPoolT.Spec.Subnet = "172.18.40.0/24"
-				ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+				ipPoolT.Spec.IPs = append(
+					ipPoolT.Spec.IPs,
 					[]string{
 						"172.18.40.10",
 						"172.18.40.1-172.18.40.2",
@@ -375,7 +379,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 			It("failed to merge 'spec.ips' due to the invalid 'spec.ips'", func() {
 				ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 				ipPoolT.Spec.Subnet = "172.18.40.0/24"
-				ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+				ipPoolT.Spec.IPs = append(
+					ipPoolT.Spec.IPs,
 					[]string{
 						constant.InvalidIPRange,
 						"172.18.40.10",
@@ -398,7 +403,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 
 			It("merges IPv4 'spec.ips'", func() {
 				ipPoolT.Spec.Subnet = "172.18.40.0/24"
-				ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+				ipPoolT.Spec.IPs = append(
+					ipPoolT.Spec.IPs,
 					[]string{
 						"172.18.40.10",
 						"172.18.40.1-172.18.40.2",
@@ -418,7 +424,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 
 			It("merges IPv6 'spec.ips'", func() {
 				ipPoolT.Spec.Subnet = "abcd:1234::/120"
-				ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+				ipPoolT.Spec.IPs = append(
+					ipPoolT.Spec.IPs,
 					[]string{
 						"abcd:1234::a",
 						"abcd:1234::1-abcd:1234::2",
@@ -439,7 +446,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 			It("failed to merge 'spec.excludeIPs' due to the invalid 'spec.ipVersion'", func() {
 				ipPoolT.Spec.IPVersion = ptr.To(constant.InvalidIPVersion)
 				ipPoolT.Spec.Subnet = "172.18.40.0/24"
-				ipPoolT.Spec.ExcludeIPs = append(ipPoolT.Spec.ExcludeIPs,
+				ipPoolT.Spec.ExcludeIPs = append(
+					ipPoolT.Spec.ExcludeIPs,
 					[]string{
 						"172.18.40.10",
 						"172.18.40.1-172.18.40.2",
@@ -461,7 +469,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 			It("failed to merge 'spec.excludeIPs' due to the invalid 'spec.ips'", func() {
 				ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 				ipPoolT.Spec.Subnet = "172.18.40.0/24"
-				ipPoolT.Spec.ExcludeIPs = append(ipPoolT.Spec.ExcludeIPs,
+				ipPoolT.Spec.ExcludeIPs = append(
+					ipPoolT.Spec.ExcludeIPs,
 					[]string{
 						constant.InvalidIPRange,
 						"172.18.40.10",
@@ -484,7 +493,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 
 			It("merges IPv4 'spec.excludeIPs'", func() {
 				ipPoolT.Spec.Subnet = "172.18.40.0/24"
-				ipPoolT.Spec.ExcludeIPs = append(ipPoolT.Spec.ExcludeIPs,
+				ipPoolT.Spec.ExcludeIPs = append(
+					ipPoolT.Spec.ExcludeIPs,
 					[]string{
 						"172.18.40.10",
 						"172.18.40.1-172.18.40.2",
@@ -504,7 +514,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 
 			It("merges IPv6 'spec.excludeIPs'", func() {
 				ipPoolT.Spec.Subnet = "abcd:1234::/120"
-				ipPoolT.Spec.ExcludeIPs = append(ipPoolT.Spec.ExcludeIPs,
+				ipPoolT.Spec.ExcludeIPs = append(
+					ipPoolT.Spec.ExcludeIPs,
 					[]string{
 						"abcd:1234::a",
 						"abcd:1234::1-abcd:1234::2",
@@ -534,7 +545,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				subnetT.Labels[constant.LabelSubnetCIDR] = cidr
 				subnetT.Spec.IPVersion = ptr.To(ipVersion)
 				subnetT.Spec.Subnet = subnet
-				subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+				subnetT.Spec.IPs = append(
+					subnetT.Spec.IPs,
 					[]string{
 						"172.18.50.1-172.18.50.2",
 						"172.18.50.10",
@@ -572,7 +584,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 			When("Validating 'spec.ipVersion'", func() {
 				It("inputs nil 'spec.ipVersion'", func() {
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -587,7 +600,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("inputs invalid 'spec.ipVersion'", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.InvalidIPVersion)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -603,7 +617,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 					ipPoolWebhook.EnableIPv4 = false
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -619,7 +634,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 					ipPoolWebhook.EnableIPv6 = false
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv6)
 					ipPoolT.Spec.Subnet = "adbc:1234::/120"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"adbc:1234::1-adbc:1234::2",
 							"adbc:1234::a",
@@ -636,7 +652,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("inputs invalid 'spec.subnet'", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = constant.InvalidCIDR
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -654,7 +671,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -669,7 +687,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("creates an existing IPPool", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -711,7 +730,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -733,7 +753,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -782,7 +803,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("inputs 'spec.ips' that do not pertains to 'spec.subnet'", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.41.10",
@@ -820,7 +842,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 
 					ipPoolT.Spec.IPVersion = ptr.To(ipVersion)
 					ipPoolT.Spec.Subnet = subnet
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -849,7 +872,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 
 					ipPoolT.Spec.IPVersion = ptr.To(ipVersion)
 					ipPoolT.Spec.Subnet = subnet
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -866,7 +890,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("inputs invalid 'spec.excludeIPs'", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -882,7 +907,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("inputs 'spec.excludeIPs' that do not pertains to 'spec.subnet'", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -900,7 +926,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("inputs invalid 'spec.gateway'", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -916,7 +943,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("inputs 'spec.gateway' that do not pertains to 'spec.subnet'", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -932,7 +960,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("duplicate with 'spec.ips'", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -948,7 +977,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("excludes gateway address through 'spec.excludeIPs'", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -967,13 +997,15 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("inputs default route", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.2-172.18.40.3",
 							"172.18.40.10",
 						}...,
 					)
-					ipPoolT.Spec.Routes = append(ipPoolT.Spec.Routes,
+					ipPoolT.Spec.Routes = append(
+						ipPoolT.Spec.Routes,
 						spiderpoolv2beta1.Route{
 							Dst: "0.0.0.0/0",
 							Gw:  "172.18.40.1",
@@ -988,13 +1020,15 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("inputs duplicate routes", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.2-172.18.40.3",
 							"172.18.40.10",
 						}...,
 					)
-					ipPoolT.Spec.Routes = append(ipPoolT.Spec.Routes,
+					ipPoolT.Spec.Routes = append(
+						ipPoolT.Spec.Routes,
 						spiderpoolv2beta1.Route{
 							Dst: "192.168.40.0/24",
 							Gw:  "172.18.40.1",
@@ -1013,13 +1047,15 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("inputs invalid destination", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.2-172.18.40.3",
 							"172.18.40.10",
 						}...,
 					)
-					ipPoolT.Spec.Routes = append(ipPoolT.Spec.Routes,
+					ipPoolT.Spec.Routes = append(
+						ipPoolT.Spec.Routes,
 						spiderpoolv2beta1.Route{
 							Dst: constant.InvalidCIDR,
 							Gw:  "172.18.40.1",
@@ -1034,13 +1070,15 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("inputs invalid gateway", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.2-172.18.40.3",
 							"172.18.40.10",
 						}...,
 					)
-					ipPoolT.Spec.Routes = append(ipPoolT.Spec.Routes,
+					ipPoolT.Spec.Routes = append(
+						ipPoolT.Spec.Routes,
 						spiderpoolv2beta1.Route{
 							Dst: "192.168.40.0/24",
 							Gw:  constant.InvalidIP,
@@ -1055,13 +1093,15 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("inputs gateway that do not pertains to 'spec.subnet'", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.2-172.18.40.3",
 							"172.18.40.10",
 						}...,
 					)
-					ipPoolT.Spec.Routes = append(ipPoolT.Spec.Routes,
+					ipPoolT.Spec.Routes = append(
+						ipPoolT.Spec.Routes,
 						spiderpoolv2beta1.Route{
 							Dst: "192.168.40.0/24",
 							Gw:  "172.18.41.1",
@@ -1082,7 +1122,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("succeed to create orphan IPPool", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1098,7 +1139,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 					subnetT.SetUID(uuid.NewUUID())
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1110,7 +1152,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1126,7 +1169,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 					subnetT.SetUID(uuid.NewUUID())
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1151,7 +1195,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 					subnetT.SetUID(uuid.NewUUID())
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1166,7 +1211,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.40",
@@ -1293,7 +1339,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				subnetT.SetUID(uuid.NewUUID())
 				subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 				subnetT.Spec.Subnet = "172.18.40.0/24"
-				subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+				subnetT.Spec.IPs = append(
+					subnetT.Spec.IPs,
 					[]string{
 						"172.18.40.2-172.18.40.3",
 						"172.18.40.10",
@@ -1308,7 +1355,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 
 				ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 				ipPoolT.Spec.Subnet = "172.18.40.0/24"
-				ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+				ipPoolT.Spec.IPs = append(
+					ipPoolT.Spec.IPs,
 					[]string{
 						"172.18.40.2-172.18.40.3",
 						"172.18.40.10",
@@ -1316,7 +1364,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				)
 				ipPoolT.Spec.ExcludeIPs = append(ipPoolT.Spec.ExcludeIPs, "172.18.40.10")
 				ipPoolT.Spec.Gateway = ptr.To("172.18.40.1")
-				ipPoolT.Spec.Routes = append(ipPoolT.Spec.Routes,
+				ipPoolT.Spec.Routes = append(
+					ipPoolT.Spec.Routes,
 					spiderpoolv2beta1.Route{
 						Dst: "192.168.40.0/24",
 						Gw:  "172.18.40.40",
@@ -1334,7 +1383,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				subnetT.SetUID(uuid.NewUUID())
 				subnetT.Spec.IPVersion = ptr.To(constant.IPv6)
 				subnetT.Spec.Subnet = "abcd:1234::/120"
-				subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+				subnetT.Spec.IPs = append(
+					subnetT.Spec.IPs,
 					[]string{
 						"abcd:1234::2-abcd:1234::3",
 						"abcd:1234::a",
@@ -1349,7 +1399,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 
 				ipPoolT.Spec.IPVersion = ptr.To(constant.IPv6)
 				ipPoolT.Spec.Subnet = "abcd:1234::/120"
-				ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+				ipPoolT.Spec.IPs = append(
+					ipPoolT.Spec.IPs,
 					[]string{
 						"abcd:1234::2-abcd:1234::3",
 						"abcd:1234::a",
@@ -1357,7 +1408,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				)
 				ipPoolT.Spec.ExcludeIPs = append(ipPoolT.Spec.ExcludeIPs, "abcd:1234::a")
 				ipPoolT.Spec.Gateway = ptr.To("abcd:1234::1")
-				ipPoolT.Spec.Routes = append(ipPoolT.Spec.Routes,
+				ipPoolT.Spec.Routes = append(
+					ipPoolT.Spec.Routes,
 					spiderpoolv2beta1.Route{
 						Dst: "fd00:40::/120",
 						Gw:  "abcd:1234::28",
@@ -1376,7 +1428,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("updates 'spec.ipVersion' to nil", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1394,7 +1447,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("changes 'spec.ipVersion'", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1442,7 +1496,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("changes 'spec.subnet'", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1477,7 +1532,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("appends invalid IP range to 'spec.ips'", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1577,7 +1633,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("appends invalid IP range to 'spec.excludeIPs'", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1595,7 +1652,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("appends IP range that do not pertains to 'spec.subnet' to 'spec.excludeIPs'", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1615,7 +1673,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("updates 'spec.gateway' to invalid gateway", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1633,7 +1692,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("updates 'spec.gateway' to a gateway that do not pertains to 'spec.subnet'", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1651,7 +1711,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("duplicate with 'spec.ips'", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1669,7 +1730,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("excludes gateway address through 'spec.excludeIPs'", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1690,7 +1752,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("appends default route", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.2-172.18.40.3",
 							"172.18.40.10",
@@ -1698,7 +1761,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 					)
 
 					newIPPoolT := ipPoolT.DeepCopy()
-					newIPPoolT.Spec.Routes = append(newIPPoolT.Spec.Routes,
+					newIPPoolT.Spec.Routes = append(
+						newIPPoolT.Spec.Routes,
 						spiderpoolv2beta1.Route{
 							Dst: "0.0.0.0/0",
 							Gw:  "172.18.40.1",
@@ -1713,13 +1777,15 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("appends duplicate route", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.2-172.18.40.3",
 							"172.18.40.10",
 						}...,
 					)
-					ipPoolT.Spec.Routes = append(ipPoolT.Spec.Routes,
+					ipPoolT.Spec.Routes = append(
+						ipPoolT.Spec.Routes,
 						spiderpoolv2beta1.Route{
 							Dst: "192.168.40.0/24",
 							Gw:  "172.18.40.1",
@@ -1727,7 +1793,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 					)
 
 					newIPPoolT := ipPoolT.DeepCopy()
-					newIPPoolT.Spec.Routes = append(newIPPoolT.Spec.Routes,
+					newIPPoolT.Spec.Routes = append(
+						newIPPoolT.Spec.Routes,
 						spiderpoolv2beta1.Route{
 							Dst: "192.168.40.0/24",
 							Gw:  "172.18.40.2",
@@ -1742,7 +1809,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("appends route with invalid destination", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.2-172.18.40.3",
 							"172.18.40.10",
@@ -1750,7 +1818,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 					)
 
 					newIPPoolT := ipPoolT.DeepCopy()
-					newIPPoolT.Spec.Routes = append(newIPPoolT.Spec.Routes,
+					newIPPoolT.Spec.Routes = append(
+						newIPPoolT.Spec.Routes,
 						spiderpoolv2beta1.Route{
 							Dst: constant.InvalidCIDR,
 							Gw:  "172.18.40.1",
@@ -1765,7 +1834,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("appends route with invalid gateway", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.2-172.18.40.3",
 							"172.18.40.10",
@@ -1773,7 +1843,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 					)
 
 					newIPPoolT := ipPoolT.DeepCopy()
-					newIPPoolT.Spec.Routes = append(newIPPoolT.Spec.Routes,
+					newIPPoolT.Spec.Routes = append(
+						newIPPoolT.Spec.Routes,
 						spiderpoolv2beta1.Route{
 							Dst: "192.168.40.0/24",
 							Gw:  constant.InvalidIP,
@@ -1788,7 +1859,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("appends route whose gateway does not pertains to 'spec.subnet'", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(ipPoolT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						ipPoolT.Spec.IPs,
 						[]string{
 							"172.18.40.2-172.18.40.3",
 							"172.18.40.10",
@@ -1796,7 +1868,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 					)
 
 					newIPPoolT := ipPoolT.DeepCopy()
-					newIPPoolT.Spec.Routes = append(newIPPoolT.Spec.Routes,
+					newIPPoolT.Spec.Routes = append(
+						newIPPoolT.Spec.Routes,
 						spiderpoolv2beta1.Route{
 							Dst: "192.168.40.0/24",
 							Gw:  "172.18.41.1",
@@ -1813,7 +1886,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				It("removes IP range that is being used by IPPool", func() {
 					ipPoolT.Spec.IPVersion = ptr.To(constant.IPv4)
 					ipPoolT.Spec.Subnet = "172.18.40.0/24"
-					ipPoolT.Spec.IPs = append(subnetT.Spec.IPs,
+					ipPoolT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1862,7 +1936,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 					subnetT.SetUID(uuid.NewUUID())
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -2075,7 +2150,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				subnetT.SetUID(uuid.NewUUID())
 				subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 				subnetT.Spec.Subnet = "172.18.40.0/24"
-				subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+				subnetT.Spec.IPs = append(
+					subnetT.Spec.IPs,
 					[]string{
 						"172.18.40.2-172.18.40.3",
 						"172.18.40.10",
@@ -2096,7 +2172,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				newIPPoolT.Spec.IPs = append(newIPPoolT.Spec.IPs, "172.18.40.10")
 				newIPPoolT.Spec.ExcludeIPs = append(newIPPoolT.Spec.ExcludeIPs, "172.18.40.10")
 				newIPPoolT.Spec.Gateway = ptr.To("172.18.40.1")
-				newIPPoolT.Spec.Routes = append(newIPPoolT.Spec.Routes,
+				newIPPoolT.Spec.Routes = append(
+					newIPPoolT.Spec.Routes,
 					spiderpoolv2beta1.Route{
 						Dst: "192.168.40.0/24",
 						Gw:  "172.18.40.40",
@@ -2113,7 +2190,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				subnetT.SetUID(uuid.NewUUID())
 				subnetT.Spec.IPVersion = ptr.To(constant.IPv6)
 				subnetT.Spec.Subnet = "abcd:1234::/120"
-				subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+				subnetT.Spec.IPs = append(
+					subnetT.Spec.IPs,
 					[]string{
 						"abcd:1234::2-abcd:1234::3",
 						"abcd:1234::a",
@@ -2134,7 +2212,8 @@ var _ = Describe("IPPoolWebhook", Label("ippool_webhook_test"), func() {
 				newIPPoolT.Spec.IPs = append(newIPPoolT.Spec.IPs, "abcd:1234::a")
 				newIPPoolT.Spec.ExcludeIPs = append(newIPPoolT.Spec.ExcludeIPs, "abcd:1234::a")
 				newIPPoolT.Spec.Gateway = ptr.To("abcd:1234::1")
-				newIPPoolT.Spec.Routes = append(newIPPoolT.Spec.Routes,
+				newIPPoolT.Spec.Routes = append(
+					newIPPoolT.Spec.Routes,
 					spiderpoolv2beta1.Route{
 						Dst: "fd00:40::/120",
 						Gw:  "abcd:1234::28",

--- a/pkg/lock/lock_debug.go
+++ b/pkg/lock/lock_debug.go
@@ -116,11 +116,13 @@ func printStackTo(sec float64, stack []byte, writer io.Writer) {
 	//   ...
 	// To know which trace belongs to which go routine we will append the
 	// go routine number to every line of the stack trace.
-	writer.Write(bytes.Replace(
-		stack,
-		[]byte{'\n'},
-		append([]byte{'\n'}, goRoutineNumber...),
-		// Don't replace the last '\n'
-		newLines-1),
+	writer.Write(
+		bytes.Replace(
+			stack,
+			[]byte{'\n'},
+			append([]byte{'\n'}, goRoutineNumber...),
+			// Don't replace the last '\n'
+			newLines-1,
+		),
 	)
 }

--- a/pkg/logutils/log_test.go
+++ b/pkg/logutils/log_test.go
@@ -86,12 +86,13 @@ var _ = Describe("Log", Label("unittest", "log_test"), func() {
 		})
 	})
 
-	DescribeTable("check convert log level", func(levelStr string, expectedLogLevel logutils.LogLevel) {
-		logLevel := logutils.ConvertLogLevel(levelStr)
-		if logLevel != nil {
-			Expect(*logLevel).Should(Equal(expectedLogLevel))
-		}
-	},
+	DescribeTable(
+		"check convert log level", func(levelStr string, expectedLogLevel logutils.LogLevel) {
+			logLevel := logutils.ConvertLogLevel(levelStr)
+			if logLevel != nil {
+				Expect(*logLevel).Should(Equal(expectedLogLevel))
+			}
+		},
 		Entry("expected debug level", "debug", logutils.DebugLevel),
 		Entry("expected info level;", "info", logutils.InfoLevel),
 		Entry("expected warn level", "warn", logutils.WarnLevel),

--- a/pkg/metric/metrics_instance.go
+++ b/pkg/metric/metrics_instance.go
@@ -152,7 +152,8 @@ func (a *asyncFloat64Gauge) initGauge(metricName string, description string, isD
 
 	a.gaugeMetric = tmpGauge
 	_, err = m.RegisterCallback(func(_ context.Context, observer api.Observer) error {
-		observer.ObserveFloat64(a.gaugeMetric,
+		observer.ObserveFloat64(
+			a.gaugeMetric,
 			a.observerValueToReport,
 			api.WithAttributes(a.observerAttrsToReport...),
 		)
@@ -198,7 +199,8 @@ func (a *asyncInt64Gauge) initGauge(metricName string, description string, isDeb
 
 	a.gaugeMetric = tmpGauge
 	_, err = m.RegisterCallback(func(_ context.Context, observer api.Observer) error {
-		observer.ObserveInt64(a.gaugeMetric,
+		observer.ObserveInt64(
+			a.gaugeMetric,
 			a.observerValueToReport,
 			api.WithAttributes(a.observerAttrsToReport...),
 		)

--- a/pkg/multuscniconfig/multusconfig_validate.go
+++ b/pkg/multuscniconfig/multusconfig_validate.go
@@ -117,7 +117,7 @@ func validateCNIConfig(multusConfig *spiderpoolv2beta1.SpiderMultusConfig) *fiel
 			return field.Invalid(macvlanConfigField, *multusConfig.Spec.MacvlanConfig, err.Error())
 		}
 
-		if checkExistedConfig(&(multusConfig.Spec), constant.MacvlanCNI) {
+		if checkExistedConfig(&multusConfig.Spec, constant.MacvlanCNI) {
 			return field.Forbidden(cniTypeField, fmt.Sprintf("the cniType %s only supports %s, please remove other CNI configs", *multusConfig.Spec.CniType, macvlanConfigField.String()))
 		}
 
@@ -154,7 +154,7 @@ func validateCNIConfig(multusConfig *spiderpoolv2beta1.SpiderMultusConfig) *fiel
 			return field.Invalid(ipvlanConfigField, *multusConfig.Spec.IPVlanConfig, err.Error())
 		}
 
-		if checkExistedConfig(&(multusConfig.Spec), constant.IPVlanCNI) {
+		if checkExistedConfig(&multusConfig.Spec, constant.IPVlanCNI) {
 			return field.Forbidden(cniTypeField, fmt.Sprintf("the cniType %s only supports %s, please remove other CNI configs", *multusConfig.Spec.CniType, ipvlanConfigField.String()))
 		}
 
@@ -191,7 +191,7 @@ func validateCNIConfig(multusConfig *spiderpoolv2beta1.SpiderMultusConfig) *fiel
 			return field.Invalid(vlanConfigField, *multusConfig.Spec.VlanConfig, err.Error())
 		}
 
-		if checkExistedConfig(&(multusConfig.Spec), constant.VlanCNI) {
+		if checkExistedConfig(&multusConfig.Spec, constant.VlanCNI) {
 			return field.Forbidden(cniTypeField, fmt.Sprintf("the cniType %s only supports %s, please remove other CNI configs", *multusConfig.Spec.CniType, vlanConfigField.String()))
 		}
 
@@ -230,7 +230,7 @@ func validateCNIConfig(multusConfig *spiderpoolv2beta1.SpiderMultusConfig) *fiel
 			return field.Required(sriovConfigField, fmt.Sprintf("no %s specified", sriovConfigField.Key("resourceName")))
 		}
 
-		if checkExistedConfig(&(multusConfig.Spec), constant.SriovCNI) {
+		if checkExistedConfig(&multusConfig.Spec, constant.SriovCNI) {
 			return field.Forbidden(cniTypeField, fmt.Sprintf("the cniType %s only supports %s, please remove other CNI configs", *multusConfig.Spec.CniType, sriovConfigField.String()))
 		}
 
@@ -255,7 +255,7 @@ func validateCNIConfig(multusConfig *spiderpoolv2beta1.SpiderMultusConfig) *fiel
 			return field.Required(ibsriovConfigField, fmt.Sprintf("no %s specified", ibsriovConfigField.Key("resourceName")))
 		}
 
-		if checkExistedConfig(&(multusConfig.Spec), constant.IBSriovCNI) {
+		if checkExistedConfig(&multusConfig.Spec, constant.IBSriovCNI) {
 			return field.Forbidden(cniTypeField, fmt.Sprintf("the cniType %s only supports %s, please remove other CNI configs", *multusConfig.Spec.CniType, sriovConfigField.String()))
 		}
 
@@ -280,7 +280,7 @@ func validateCNIConfig(multusConfig *spiderpoolv2beta1.SpiderMultusConfig) *fiel
 			return field.Required(ipoibConfigField, fmt.Sprintf("no %s specified", ipoibConfigField.Key("master")))
 		}
 
-		if checkExistedConfig(&(multusConfig.Spec), constant.IPoIBCNI) {
+		if checkExistedConfig(&multusConfig.Spec, constant.IPoIBCNI) {
 			return field.Forbidden(cniTypeField, fmt.Sprintf("the cniType %s only supports %s, please remove other CNI configs", *multusConfig.Spec.CniType, sriovConfigField.String()))
 		}
 
@@ -330,7 +330,7 @@ func validateCNIConfig(multusConfig *spiderpoolv2beta1.SpiderMultusConfig) *fiel
 			}
 		}
 
-		if checkExistedConfig(&(multusConfig.Spec), constant.OvsCNI) {
+		if checkExistedConfig(&multusConfig.Spec, constant.OvsCNI) {
 			return field.Forbidden(cniTypeField, fmt.Sprintf("the cniType %s only supports %s, please remove other CNI configs", *multusConfig.Spec.CniType, sriovConfigField.String()))
 		}
 
@@ -339,7 +339,7 @@ func validateCNIConfig(multusConfig *spiderpoolv2beta1.SpiderMultusConfig) *fiel
 			return field.Forbidden(cniTypeField, fmt.Sprintf("the cniType %s does not support RDMA resource or network resource injected", *multusConfig.Spec.CniType))
 		}
 		// multusConfig.Spec.CustomCNIConfig can be empty
-		if checkExistedConfig(&(multusConfig.Spec), constant.CustomCNI) {
+		if checkExistedConfig(&multusConfig.Spec, constant.CustomCNI) {
 			return field.Forbidden(cniTypeField, fmt.Sprintf("the cniType %s only supports %s, please remove other CNI configs", *multusConfig.Spec.CniType, customCniConfigField.String()))
 		}
 

--- a/pkg/multuscniconfig/multusconfig_validate_test.go
+++ b/pkg/multuscniconfig/multusconfig_validate_test.go
@@ -14,7 +14,8 @@ import (
 )
 
 var _ = Describe("MultusConfigValidate", Label("multusconfig_validate_test", "unittest"), func() {
-	DescribeTable("network-resource-inject validation",
+	DescribeTable(
+		"network-resource-inject validation",
 		func(multusConfig *spiderpoolv2beta1.SpiderMultusConfig) {
 			Expect(validateCNIConfig(multusConfig)).To(Succeed())
 		},

--- a/pkg/multuscniconfig/multusconfig_webhook.go
+++ b/pkg/multuscniconfig/multusconfig_webhook.go
@@ -46,7 +46,8 @@ func (*MultusConfigWebhook) Default(ctx context.Context, obj runtime.Object) err
 	smc := obj.(*spiderpoolv2beta1.SpiderMultusConfig)
 
 	mutateLogger := logger.Named("Mutating").With(
-		zap.String("SpiderMultusConfig", smc.Name))
+		zap.String("SpiderMultusConfig", smc.Name),
+	)
 	mutateLogger.Sugar().Debugf("Request SpiderMultusConfig: %+v", *smc)
 
 	mutateSpiderMultusConfig(logutils.IntoContext(ctx, mutateLogger), smc)

--- a/pkg/networking/networking/ipam_detection.go
+++ b/pkg/networking/networking/ipam_detection.go
@@ -105,7 +105,8 @@ func DetectIPConflictAndGatewayReachable(logger *zap.Logger, iface string, hostN
 					d.enableIPv4GatewayReachableDetection = ipa.EnableGatewayDetection
 					d.v4Gw = net.ParseIP(ipa.Gateway)
 				}
-				logger.Info("IPv4 Detection Configs",
+				logger.Info(
+					"IPv4 Detection Configs",
 					zap.String("iface", d.iface),
 					zap.Any("IP", ipaddress.String()),
 					zap.Any("Gateway", d.v4Gw),
@@ -123,7 +124,8 @@ func DetectIPConflictAndGatewayReachable(logger *zap.Logger, iface string, hostN
 					d.v6Gw = net.ParseIP(ipa.Gateway)
 				}
 
-				logger.Info("IPv6 Detection Configs",
+				logger.Info(
+					"IPv6 Detection Configs",
 					zap.String("Interface", d.iface),
 					zap.Any("IP", d.ip6),
 					zap.Any("Gateway", d.v6Gw),

--- a/pkg/podmanager/pod_webhook.go
+++ b/pkg/podmanager/pod_webhook.go
@@ -74,7 +74,8 @@ func (pw *PWebhook) Default(ctx context.Context, obj runtime.Object) error {
 	logger := logutils.FromContext(ctx)
 	pod := obj.(*corev1.Pod)
 	mutateLogger := logger.Named("PodMutating").With(
-		zap.String("Pod", pod.GenerateName))
+		zap.String("Pod", pod.GenerateName),
+	)
 	mutateLogger.Sugar().Debugf("Request Pod: %+v", *pod)
 
 	needInject, err := needPodNetworkInjection(ctx, pw.nsManager, pod)

--- a/pkg/reservedipmanager/reservedip_webhook_test.go
+++ b/pkg/reservedipmanager/reservedip_webhook_test.go
@@ -120,7 +120,8 @@ var _ = Describe("ReservedIPWebhook", Label("reservedip_webhook_test"), func() {
 
 			It("failed to merge 'spec.ips' due to the invalid 'spec.ipVersion'", func() {
 				rIPT.Spec.IPVersion = ptr.To(constant.InvalidIPVersion)
-				rIPT.Spec.IPs = append(rIPT.Spec.IPs,
+				rIPT.Spec.IPs = append(
+					rIPT.Spec.IPs,
 					[]string{
 						"172.18.40.10",
 						"172.18.40.1-172.18.40.2",
@@ -141,7 +142,8 @@ var _ = Describe("ReservedIPWebhook", Label("reservedip_webhook_test"), func() {
 
 			It("failed to merge 'spec.ips' due to the invalid 'spec.ips'", func() {
 				rIPT.Spec.IPVersion = ptr.To(constant.IPv4)
-				rIPT.Spec.IPs = append(rIPT.Spec.IPs,
+				rIPT.Spec.IPs = append(
+					rIPT.Spec.IPs,
 					[]string{
 						constant.InvalidIPRange,
 						"172.18.40.10",
@@ -164,7 +166,8 @@ var _ = Describe("ReservedIPWebhook", Label("reservedip_webhook_test"), func() {
 
 			It("merges IPv4 'spec.ips'", func() {
 				rIPT.Spec.IPVersion = ptr.To(constant.IPv4)
-				rIPT.Spec.IPs = append(rIPT.Spec.IPs,
+				rIPT.Spec.IPs = append(
+					rIPT.Spec.IPs,
 					[]string{
 						"172.18.40.10",
 						"172.18.40.1-172.18.40.2",
@@ -184,7 +187,8 @@ var _ = Describe("ReservedIPWebhook", Label("reservedip_webhook_test"), func() {
 
 			It("merges IPv6 'spec.ips'", func() {
 				rIPT.Spec.IPVersion = ptr.To(constant.IPv6)
-				rIPT.Spec.IPs = append(rIPT.Spec.IPs,
+				rIPT.Spec.IPs = append(
+					rIPT.Spec.IPs,
 					[]string{
 						"abcd:1234::a",
 						"abcd:1234::1-abcd:1234::2",
@@ -251,7 +255,8 @@ var _ = Describe("ReservedIPWebhook", Label("reservedip_webhook_test"), func() {
 
 			It("creates IPv4 ReservedIP with all fields valid", func() {
 				rIPT.Spec.IPVersion = ptr.To(constant.IPv4)
-				rIPT.Spec.IPs = append(rIPT.Spec.IPs,
+				rIPT.Spec.IPs = append(
+					rIPT.Spec.IPs,
 					[]string{
 						"172.18.40.1-172.18.40.2",
 						"172.18.40.10",
@@ -265,7 +270,8 @@ var _ = Describe("ReservedIPWebhook", Label("reservedip_webhook_test"), func() {
 
 			It("creates IPv6 ReservedIP with all fields valid", func() {
 				rIPT.Spec.IPVersion = ptr.To(constant.IPv6)
-				rIPT.Spec.IPs = append(rIPT.Spec.IPs,
+				rIPT.Spec.IPs = append(
+					rIPT.Spec.IPs,
 					[]string{
 						"abcd:1234::1-abcd:1234::2",
 						"abcd:1234::a",

--- a/pkg/subnetmanager/subnet_webhook_test.go
+++ b/pkg/subnetmanager/subnet_webhook_test.go
@@ -196,7 +196,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 			It("failed to merge 'spec.ips' due to the invalid 'spec.ipVersion'", func() {
 				subnetT.Spec.IPVersion = ptr.To(constant.InvalidIPVersion)
 				subnetT.Spec.Subnet = "172.18.40.0/24"
-				subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+				subnetT.Spec.IPs = append(
+					subnetT.Spec.IPs,
 					[]string{
 						"172.18.40.10",
 						"172.18.40.1-172.18.40.2",
@@ -218,7 +219,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 			It("failed to merge 'spec.ips' due to the invalid 'spec.ips'", func() {
 				subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 				subnetT.Spec.Subnet = "172.18.40.0/24"
-				subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+				subnetT.Spec.IPs = append(
+					subnetT.Spec.IPs,
 					[]string{
 						constant.InvalidIPRange,
 						"172.18.40.10",
@@ -241,7 +243,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 
 			It("merges IPv4 'spec.ips'", func() {
 				subnetT.Spec.Subnet = "172.18.40.0/24"
-				subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+				subnetT.Spec.IPs = append(
+					subnetT.Spec.IPs,
 					[]string{
 						"172.18.40.10",
 						"172.18.40.1-172.18.40.2",
@@ -261,7 +264,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 
 			It("merges IPv6 'spec.ips'", func() {
 				subnetT.Spec.Subnet = "abcd:1234::/120"
-				subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+				subnetT.Spec.IPs = append(
+					subnetT.Spec.IPs,
 					[]string{
 						"abcd:1234::a",
 						"abcd:1234::1-abcd:1234::2",
@@ -282,7 +286,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 			It("failed to merge 'spec.excludeIPs' due to the invalid 'spec.ipVersion'", func() {
 				subnetT.Spec.IPVersion = ptr.To(constant.InvalidIPVersion)
 				subnetT.Spec.Subnet = "172.18.40.0/24"
-				subnetT.Spec.ExcludeIPs = append(subnetT.Spec.ExcludeIPs,
+				subnetT.Spec.ExcludeIPs = append(
+					subnetT.Spec.ExcludeIPs,
 					[]string{
 						"172.18.40.10",
 						"172.18.40.1-172.18.40.2",
@@ -304,7 +309,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 			It("failed to merge 'spec.excludeIPs' due to the invalid 'spec.ips'", func() {
 				subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 				subnetT.Spec.Subnet = "172.18.40.0/24"
-				subnetT.Spec.ExcludeIPs = append(subnetT.Spec.ExcludeIPs,
+				subnetT.Spec.ExcludeIPs = append(
+					subnetT.Spec.ExcludeIPs,
 					[]string{
 						constant.InvalidIPRange,
 						"172.18.40.10",
@@ -327,7 +333,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 
 			It("merges IPv4 'spec.excludeIPs'", func() {
 				subnetT.Spec.Subnet = "172.18.40.0/24"
-				subnetT.Spec.ExcludeIPs = append(subnetT.Spec.ExcludeIPs,
+				subnetT.Spec.ExcludeIPs = append(
+					subnetT.Spec.ExcludeIPs,
 					[]string{
 						"172.18.40.10",
 						"172.18.40.1-172.18.40.2",
@@ -347,7 +354,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 
 			It("merges IPv6 'spec.excludeIPs'", func() {
 				subnetT.Spec.Subnet = "abcd:1234::/120"
-				subnetT.Spec.ExcludeIPs = append(subnetT.Spec.ExcludeIPs,
+				subnetT.Spec.ExcludeIPs = append(
+					subnetT.Spec.ExcludeIPs,
 					[]string{
 						"abcd:1234::a",
 						"abcd:1234::1-abcd:1234::2",
@@ -370,7 +378,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 			When("Validating 'spec.ipVersion'", func() {
 				It("inputs nil 'spec.ipVersion'", func() {
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -385,7 +394,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("inputs invalid 'spec.ipVersion'", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.InvalidIPVersion)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -401,7 +411,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 					subnetWebhook.EnableIPv4 = false
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -417,7 +428,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 					subnetWebhook.EnableIPv6 = false
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv6)
 					subnetT.Spec.Subnet = "adbc:1234::/120"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"adbc:1234::1-adbc:1234::2",
 							"adbc:1234::a",
@@ -434,7 +446,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("inputs invalid 'spec.subnet'", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = constant.InvalidCIDR
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -452,7 +465,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -467,7 +481,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("creates an existing Subnet", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -492,7 +507,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -514,7 +530,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -547,7 +564,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 								Group:    constant.SpiderpoolAPIGroup,
 								Version:  constant.SpiderpoolAPIVersion,
 								Resource: "spiderippools",
-							}, orphanPool.Namespace, orphanPool.Name)
+							}, orphanPool.Namespace, orphanPool.Name,
+						)
 						Expect(err).NotTo(HaveOccurred())
 					})
 
@@ -556,7 +574,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -583,7 +602,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("inputs 'spec.ips' that do not pertains to 'spec.subnet'", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.41.10",
@@ -616,7 +636,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 								Group:    constant.SpiderpoolAPIGroup,
 								Version:  constant.SpiderpoolAPIVersion,
 								Resource: "spiderippools",
-							}, orphanPool.Namespace, orphanPool.Name)
+							}, orphanPool.Namespace, orphanPool.Name,
+						)
 						Expect(err).NotTo(HaveOccurred())
 					})
 
@@ -625,7 +646,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/25"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.41-172.18.40.45",
 						}...,
@@ -641,7 +663,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("inputs invalid 'spec.excludeIPs'", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -657,7 +680,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("inputs 'spec.excludeIPs' that do not pertains to 'spec.subnet'", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -675,7 +699,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("inputs invalid 'spec.gateway'", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -691,7 +716,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("inputs 'spec.gateway' that do not pertains to 'spec.subnet'", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -707,7 +733,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("duplicate with 'spec.ips'", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -723,7 +750,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("excludes gateway address through 'spec.excludeIPs'", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -742,13 +770,15 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("inputs default route", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.2-172.18.40.3",
 							"172.18.40.10",
 						}...,
 					)
-					subnetT.Spec.Routes = append(subnetT.Spec.Routes,
+					subnetT.Spec.Routes = append(
+						subnetT.Spec.Routes,
 						spiderpoolv2beta1.Route{
 							Dst: "0.0.0.0/0",
 							Gw:  "172.18.40.1",
@@ -763,13 +793,15 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("inputs duplicate routes", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.2-172.18.40.3",
 							"172.18.40.10",
 						}...,
 					)
-					subnetT.Spec.Routes = append(subnetT.Spec.Routes,
+					subnetT.Spec.Routes = append(
+						subnetT.Spec.Routes,
 						spiderpoolv2beta1.Route{
 							Dst: "192.168.40.0/24",
 							Gw:  "172.18.40.1",
@@ -788,13 +820,15 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("inputs invalid destination", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.2-172.18.40.3",
 							"172.18.40.10",
 						}...,
 					)
-					subnetT.Spec.Routes = append(subnetT.Spec.Routes,
+					subnetT.Spec.Routes = append(
+						subnetT.Spec.Routes,
 						spiderpoolv2beta1.Route{
 							Dst: constant.InvalidCIDR,
 							Gw:  "172.18.40.1",
@@ -809,13 +843,15 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("inputs invalid gateway", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.2-172.18.40.3",
 							"172.18.40.10",
 						}...,
 					)
-					subnetT.Spec.Routes = append(subnetT.Spec.Routes,
+					subnetT.Spec.Routes = append(
+						subnetT.Spec.Routes,
 						spiderpoolv2beta1.Route{
 							Dst: "192.168.40.0/24",
 							Gw:  constant.InvalidIP,
@@ -830,13 +866,15 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("inputs gateway that do not pertains to 'spec.subnet'", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.2-172.18.40.3",
 							"172.18.40.10",
 						}...,
 					)
-					subnetT.Spec.Routes = append(subnetT.Spec.Routes,
+					subnetT.Spec.Routes = append(
+						subnetT.Spec.Routes,
 						spiderpoolv2beta1.Route{
 							Dst: "192.168.40.0/24",
 							Gw:  "172.18.41.1",
@@ -852,7 +890,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 			It("creates IPv4 Subnet with all fields valid", func() {
 				subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 				subnetT.Spec.Subnet = "172.18.40.0/24"
-				subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+				subnetT.Spec.IPs = append(
+					subnetT.Spec.IPs,
 					[]string{
 						"172.18.40.2-172.18.40.3",
 						"172.18.40.10",
@@ -860,7 +899,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				)
 				subnetT.Spec.ExcludeIPs = append(subnetT.Spec.ExcludeIPs, "172.18.40.10")
 				subnetT.Spec.Gateway = ptr.To("172.18.40.1")
-				subnetT.Spec.Routes = append(subnetT.Spec.Routes,
+				subnetT.Spec.Routes = append(
+					subnetT.Spec.Routes,
 					spiderpoolv2beta1.Route{
 						Dst: "192.168.40.0/24",
 						Gw:  "172.18.40.40",
@@ -875,7 +915,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 			It("creates IPv6 Subnet with all fields valid", func() {
 				subnetT.Spec.IPVersion = ptr.To(constant.IPv6)
 				subnetT.Spec.Subnet = "abcd:1234::/120"
-				subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+				subnetT.Spec.IPs = append(
+					subnetT.Spec.IPs,
 					[]string{
 						"abcd:1234::2-abcd:1234::3",
 						"abcd:1234::a",
@@ -883,7 +924,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				)
 				subnetT.Spec.ExcludeIPs = append(subnetT.Spec.ExcludeIPs, "abcd:1234::a")
 				subnetT.Spec.Gateway = ptr.To("abcd:1234::1")
-				subnetT.Spec.Routes = append(subnetT.Spec.Routes,
+				subnetT.Spec.Routes = append(
+					subnetT.Spec.Routes,
 					spiderpoolv2beta1.Route{
 						Dst: "fd00:40::/120",
 						Gw:  "abcd:1234::28",
@@ -916,7 +958,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 							Group:    constant.SpiderpoolAPIGroup,
 							Version:  constant.SpiderpoolAPIVersion,
 							Resource: "spiderippools",
-						}, orphanPool.Namespace, orphanPool.Name)
+						}, orphanPool.Namespace, orphanPool.Name,
+					)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -925,7 +968,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 
 				subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 				subnetT.Spec.Subnet = "172.18.40.0/25"
-				subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+				subnetT.Spec.IPs = append(
+					subnetT.Spec.IPs,
 					[]string{
 						"172.18.40.40-172.18.40.45",
 					}...,
@@ -942,7 +986,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("updates 'spec.ipVersion' to nil", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -960,7 +1005,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("changes 'spec.ipVersion'", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1008,7 +1054,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("changes 'spec.subnet'", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1028,7 +1075,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("appends invalid IP range to 'spec.ips'", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1061,7 +1109,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("appends invalid IP range to 'spec.excludeIPs'", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1079,7 +1128,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("appends IP range that do not pertains to 'spec.subnet' to 'spec.excludeIPs'", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1099,7 +1149,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("updates 'spec.gateway' to invalid gateway", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1117,7 +1168,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("updates 'spec.gateway' to a gateway that do not pertains to 'spec.subnet'", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1135,7 +1187,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("duplicate with 'spec.ips'", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1153,7 +1206,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("excludes gateway address through 'spec.excludeIPs'", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1174,7 +1228,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("appends default route", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.2-172.18.40.3",
 							"172.18.40.10",
@@ -1182,7 +1237,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 					)
 
 					newSubnetT := subnetT.DeepCopy()
-					newSubnetT.Spec.Routes = append(newSubnetT.Spec.Routes,
+					newSubnetT.Spec.Routes = append(
+						newSubnetT.Spec.Routes,
 						spiderpoolv2beta1.Route{
 							Dst: "0.0.0.0/0",
 							Gw:  "172.18.40.1",
@@ -1197,13 +1253,15 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("appends default route", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.2-172.18.40.3",
 							"172.18.40.10",
 						}...,
 					)
-					subnetT.Spec.Routes = append(subnetT.Spec.Routes,
+					subnetT.Spec.Routes = append(
+						subnetT.Spec.Routes,
 						spiderpoolv2beta1.Route{
 							Dst: "192.168.40.0/24",
 							Gw:  "172.18.40.1",
@@ -1211,7 +1269,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 					)
 
 					newSubnetT := subnetT.DeepCopy()
-					newSubnetT.Spec.Routes = append(newSubnetT.Spec.Routes,
+					newSubnetT.Spec.Routes = append(
+						newSubnetT.Spec.Routes,
 						spiderpoolv2beta1.Route{
 							Dst: "192.168.40.0/24",
 							Gw:  "172.18.40.2",
@@ -1226,7 +1285,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("appends route with invalid destination", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.2-172.18.40.3",
 							"172.18.40.10",
@@ -1234,7 +1294,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 					)
 
 					newSubnetT := subnetT.DeepCopy()
-					newSubnetT.Spec.Routes = append(newSubnetT.Spec.Routes,
+					newSubnetT.Spec.Routes = append(
+						newSubnetT.Spec.Routes,
 						spiderpoolv2beta1.Route{
 							Dst: constant.InvalidCIDR,
 							Gw:  "172.18.40.1",
@@ -1249,7 +1310,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("appends route with invalid gateway", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.2-172.18.40.3",
 							"172.18.40.10",
@@ -1257,7 +1319,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 					)
 
 					newSubnetT := subnetT.DeepCopy()
-					newSubnetT.Spec.Routes = append(newSubnetT.Spec.Routes,
+					newSubnetT.Spec.Routes = append(
+						newSubnetT.Spec.Routes,
 						spiderpoolv2beta1.Route{
 							Dst: "192.168.40.0/24",
 							Gw:  constant.InvalidIP,
@@ -1272,7 +1335,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("appends route whose gateway does not pertains to 'spec.subnet'", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.2-172.18.40.3",
 							"172.18.40.10",
@@ -1280,7 +1344,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 					)
 
 					newSubnetT := subnetT.DeepCopy()
-					newSubnetT.Spec.Routes = append(newSubnetT.Spec.Routes,
+					newSubnetT.Spec.Routes = append(
+						newSubnetT.Spec.Routes,
 						spiderpoolv2beta1.Route{
 							Dst: "192.168.40.0/24",
 							Gw:  "172.18.41.1",
@@ -1300,7 +1365,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1329,7 +1395,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("has invalid 'status.controlledIPPools'", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1356,7 +1423,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("removes IP ranges that is being used by IPPool", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1385,7 +1453,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				It("removes IP ranges not used by IPPool", func() {
 					subnetT.Spec.IPVersion = ptr.To(constant.IPv4)
 					subnetT.Spec.Subnet = "172.18.40.0/24"
-					subnetT.Spec.IPs = append(subnetT.Spec.IPs,
+					subnetT.Spec.IPs = append(
+						subnetT.Spec.IPs,
 						[]string{
 							"172.18.40.1-172.18.40.2",
 							"172.18.40.10",
@@ -1448,7 +1517,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				newSubnetT.Spec.IPs = append(newSubnetT.Spec.IPs, "172.18.40.10")
 				newSubnetT.Spec.ExcludeIPs = append(newSubnetT.Spec.ExcludeIPs, "172.18.40.10")
 				newSubnetT.Spec.Gateway = ptr.To("172.18.40.1")
-				newSubnetT.Spec.Routes = append(newSubnetT.Spec.Routes,
+				newSubnetT.Spec.Routes = append(
+					newSubnetT.Spec.Routes,
 					spiderpoolv2beta1.Route{
 						Dst: "192.168.40.0/24",
 						Gw:  "172.18.40.40",
@@ -1469,7 +1539,8 @@ var _ = Describe("SubnetWebhook", Label("subnet_webhook_test"), func() {
 				newSubnetT.Spec.IPs = append(newSubnetT.Spec.IPs, "abcd:1234::a")
 				newSubnetT.Spec.ExcludeIPs = append(newSubnetT.Spec.ExcludeIPs, "abcd:1234::a")
 				newSubnetT.Spec.Gateway = ptr.To("abcd:1234::1")
-				newSubnetT.Spec.Routes = append(newSubnetT.Spec.Routes,
+				newSubnetT.Spec.Routes = append(
+					newSubnetT.Spec.Routes,
 					spiderpoolv2beta1.Route{
 						Dst: "fd00:40::/120",
 						Gw:  "abcd:1234::28",

--- a/pkg/types/k8s.go
+++ b/pkg/types/k8s.go
@@ -1,71 +1,69 @@
 // Copyright 2022 Authors of spidernet-io
 // SPDX-License-Identifier: Apache-2.0
-
 package types
 
 import (
 	"fmt"
 	"strings"
 
+	stringutil "github.com/spidernet-io/spiderpool/pkg/utils/string"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
-
-	stringutil "github.com/spidernet-io/spiderpool/pkg/utils/string"
 )
 
-type PodStatus string
-
-type AppNamespacedName struct {
-	APIVersion string
-	Kind       string
-	Namespace  string
-	Name       string
-}
+type (
+	PodStatus         string
+	AppNamespacedName struct {
+		APIVersion string
+		Kind       string
+		Namespace  string
+		Name       string
+	}
+)
 
 type PodTopController struct {
 	AppNamespacedName
 	UID apitypes.UID
 	APP metav1.Object
 }
-
 type AnnoPodIPPoolValue struct {
 	IPv4Pools []string `json:"ipv4,omitempty"`
 	IPv6Pools []string `json:"ipv6,omitempty"`
 }
+type (
+	AnnoPodIPPoolsValue []AnnoIPPoolItem
+	AnnoIPPoolItem      struct {
+		NIC          string   `json:"interface,omitempty"`
+		IPv4Pools    []string `json:"ipv4,omitempty"`
+		IPv6Pools    []string `json:"ipv6,omitempty"`
+		CleanGateway bool     `json:"cleangateway"`
+	}
+)
 
-type AnnoPodIPPoolsValue []AnnoIPPoolItem
+type (
+	AnnoPodRoutesValue []AnnoRouteItem
+	AnnoRouteItem      struct {
+		Dst string `json:"dst"`
+		Gw  string `json:"gw"`
+	}
+)
 
-type AnnoIPPoolItem struct {
-	NIC          string   `json:"interface,omitempty"`
-	IPv4Pools    []string `json:"ipv4,omitempty"`
-	IPv6Pools    []string `json:"ipv6,omitempty"`
-	CleanGateway bool     `json:"cleangateway"`
-}
-
-type AnnoPodRoutesValue []AnnoRouteItem
-
-type AnnoRouteItem struct {
-	Dst string `json:"dst"`
-	Gw  string `json:"gw"`
-}
-
-type AnnoNSDefautlV4PoolValue []string
-
-type AnnoNSDefautlV6PoolValue []string
-
-type PodSubnetAnnoConfig struct {
-	MultipleSubnets []AnnoSubnetItem
-	SingleSubnet    *AnnoSubnetItem
-	FlexibleIPNum   *int
-	AssignIPNum     int
-	ReclaimIPPool   bool
-}
+type (
+	AnnoNSDefautlV4PoolValue []string
+	AnnoNSDefautlV6PoolValue []string
+	PodSubnetAnnoConfig      struct {
+		MultipleSubnets []AnnoSubnetItem
+		SingleSubnet    *AnnoSubnetItem
+		FlexibleIPNum   *int
+		AssignIPNum     int
+		ReclaimIPPool   bool
+	}
+)
 
 func (in *PodSubnetAnnoConfig) String() string {
 	if in == nil {
 		return "nil"
 	}
-
 	s := strings.Join([]string{
 		`&PodSubnetAnnoConfig{`,
 		`MultipleSubnets` + fmt.Sprintf("%v", in.MultipleSubnets) + `,`,
@@ -89,7 +87,6 @@ func (in *AnnoSubnetItem) String() string {
 	if in == nil {
 		return "nil"
 	}
-
 	return fmt.Sprintf(
 		"&AnnoSubnetItem{Interface:%v,IPv4:%v,IPv6:%v}",
 		in.Interface,
@@ -107,7 +104,6 @@ type AutoPoolProperty struct {
 	// AnnoPoolIPNumberVal serves for AutoPool annotation to explain whether it is IP number flexible or fixed.
 	AnnoPoolIPNumberVal string
 }
-
 type SpiderpoolConfigmapConfig struct {
 	EnableIPv4                                    bool                    `yaml:"enableIPv4"`
 	EnableIPv6                                    bool                    `yaml:"enableIPv6"`
@@ -125,13 +121,12 @@ type SpiderpoolConfigmapConfig struct {
 	PodResourceInjectConfig                       PodResourceInjectConfig `yaml:"podResourceInject"`
 	IaaSProviderConfig                            IaaSProviderConfig      `yaml:"iaasNetworkProvider,omitempty"`
 }
-
 type PodResourceInjectConfig struct {
 	Enabled           bool     `yaml:"enabled"`
 	NamespacesExclude []string `yaml:"namespacesExclude"`
 	NamespacesInclude []string `yaml:"namespacesInclude"`
 }
-
 type IaaSProviderConfig struct {
-	ServerURL string `yaml:"serverUrl,omitempty"`
+	ServerURL          string `yaml:"serverUrl,omitempty"`
+	HTTPRequestTimeout string `yaml:"httpRequestTimeout,omitempty"`
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -47,7 +47,8 @@ var _ = Describe("Utils", Label("utils"), Serial, func() {
 		"namespace": "kube-system"
 	}
 }`
-	DescribeTable("should extract CIDRs correctly",
+	DescribeTable(
+		"should extract CIDRs correctly",
 		func(testName, cmStr string, expectedPodCIDR, expectedServiceCIDR []string, expectError bool) {
 			var cm corev1.ConfigMap
 			err := json.Unmarshal([]byte(cmStr), &cm)
@@ -64,21 +65,24 @@ var _ = Describe("Utils", Label("utils"), Serial, func() {
 			Expect(podCIDR).To(Equal(expectedPodCIDR), "Pod CIDR does not match")
 			Expect(serviceCIDR).To(Equal(expectedServiceCIDR), "Service CIDR does not match")
 		},
-		Entry("ClusterConfiguration",
+		Entry(
+			"ClusterConfiguration",
 			"ClusterConfiguration",
 			clusterConfigurationJson,
 			[]string{"192.168.165.0/24"},
 			[]string{"245.100.128.0/18"},
 			false,
 		),
-		Entry("No ClusterConfiguration",
+		Entry(
+			"No ClusterConfiguration",
 			"No ClusterConfiguration",
 			noClusterConfigurationJson,
 			nil,
 			nil,
 			true,
 		),
-		Entry("No CIDR",
+		Entry(
+			"No CIDR",
 			"No CIDR",
 			noCIDRJson,
 			nil,

--- a/specs/004-iaas-http-timeout/checklists/requirements.md
+++ b/specs/004-iaas-http-timeout/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: IaaS Provider HTTP Timeout
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-02
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation completed on 2026-06-02. The spec keeps implementation choices for
+  the planning phase while preserving the user-required Helm configurability,
+  dynamic parent-budget comparison, and no-hardcoded-parent-timeout behavior.

--- a/specs/004-iaas-http-timeout/contracts/config-contract.md
+++ b/specs/004-iaas-http-timeout/contracts/config-contract.md
@@ -1,0 +1,98 @@
+# Contract: IaaS Provider Timeout Configuration & Validation
+
+This feature exposes no new network API. Its external contracts are (1) the Helm
+value / ConfigMap configuration surface and (2) the startup validation behavior.
+
+## 1. Helm value contract
+
+```yaml
+# charts/spiderpool/values.yaml
+iaasNetworkProvider:
+  ## @param iaasNetworkProvider.serverUrl the URL of the IaaS provider service.
+  serverUrl: ""
+  ## @param iaasNetworkProvider.httpRequestTimeout HTTP timeout for a single
+  ## provider request (allocate/release). Go duration string (e.g. "30s",
+  ## "1m30s"). Must be > 0, < 2m, and < 100s (the current CNI plugin-to-agent
+  ## timeout). Empty defaults to "30s".
+  httpRequestTimeout: "30s"
+```
+
+Rendered into the ConfigMap (`templates/configmap.yaml`):
+
+```yaml
+iaasNetworkProvider:
+  serverUrl: {{ (.Values.iaasNetworkProvider).serverUrl | default "" | quote }}
+  httpRequestTimeout: {{ (.Values.iaasNetworkProvider).httpRequestTimeout | default "30s" | quote }}
+```
+
+### Backward compatibility
+
+- Omitting `iaasNetworkProvider.httpRequestTimeout` MUST render `"30s"` and
+  preserve current behavior.
+- When `serverUrl` is empty (IaaS disabled), `httpRequestTimeout` is ignored and
+  never causes a validation failure.
+
+## 2. Go type contract
+
+```go
+// pkg/types/k8s.go
+type IaaSProviderConfig struct {
+    ServerURL          string `yaml:"serverUrl,omitempty"`
+    HTTPRequestTimeout string `yaml:"httpRequestTimeout,omitempty"` // Go duration string; "" => default 30s
+}
+```
+
+## 3. Shared constant contract
+
+```go
+// pkg/constant (or pkg/iaas/client)
+const (
+    // DefaultCNIClientTimeout is the timeout the CNI plugin uses when calling the
+    // Spiderpool agent. Shared by CNI ADD and CNI DEL.
+    DefaultCNIClientTimeout = 100 * time.Second
+
+    // IaaSTimeoutStaticLimit is the absolute upper bound for a provider timeout.
+    IaaSTimeoutStaticLimit = 2 * time.Minute
+
+    // DefaultIaaSProviderTimeout is used when serverUrl is set but timeout is empty.
+    DefaultIaaSProviderTimeout = 30 * time.Second
+)
+```
+
+`cmd/spiderpool/cmd/command_add.go` and `command_delete.go` MUST use
+`DefaultCNIClientTimeout` instead of the literal `100 * time.Second`.
+
+## 4. Validation contract
+
+`ValidateConfig(cfg *IaaSProviderConfig) error` behavior when `ServerURL != ""`:
+
+| Input `httpRequestTimeout` | Result |
+|-----------------|--------|
+| `""` | OK, effective value `30s` |
+| `"30s"` | OK |
+| `"1m30s"` | OK |
+| `"0s"` / negative | error: `must be greater than 0` |
+| `"abc"` | error: `invalid duration ...` |
+| `"2m"` / `">=2m"` | error: `must be less than the 2m safety limit` |
+| `"100s"` / `">=100s"` | error: `must be less than the 100s CNI plugin-to-agent timeout` |
+
+Error messages MUST include the configured value and the limit it violated
+(FR-012, SC-005). When `ServerURL == ""`, `ValidateConfig` returns `nil`
+regardless of `httpRequestTimeout`.
+
+## 5. Client construction contract
+
+`NewClient(cfg, logger)` MUST:
+
+1. Call `ValidateConfig(cfg)` and return its error.
+2. Parse the (validated) timeout, defaulting empty to `DefaultIaaSProviderTimeout`.
+3. Set `http.Client.Timeout` to the parsed value.
+
+## 6. Runtime call contract
+
+Before issuing each provider request, the client SHOULD inspect `ctx.Deadline()`:
+
+- deadline present and `time.Until(deadline) <= 0` → return a
+  "parent budget exhausted" error without calling the provider.
+- otherwise issue the request via `http.NewRequestWithContext(ctx, ...)`; the
+  effective bound is `min(http.Client.Timeout, remaining context budget)`.

--- a/specs/004-iaas-http-timeout/data-model.md
+++ b/specs/004-iaas-http-timeout/data-model.md
@@ -1,0 +1,93 @@
+# Phase 1 Data Model: IaaS Provider HTTP Timeout
+
+This feature introduces no Kubernetes CRD changes. The "data model" is the
+configuration and runtime types that carry the provider HTTP timeout.
+
+## Entity: IaaS Provider Timeout Setting
+
+Operator-configured duration controlling how long Spiderpool may wait for one
+provider HTTP interaction.
+
+| Field | Type | Source | Required | Default | Notes |
+|-------|------|--------|----------|---------|-------|
+| `httpRequestTimeout` | Go duration string | Helm value `iaasNetworkProvider.httpRequestTimeout` → ConfigMap → `IaaSProviderConfig.HTTPRequestTimeout` | No | `30s` (when IaaS enabled) | e.g. `30s`, `1m30s`. Empty/unset → default. |
+
+### Mapping through the stack
+
+```text
+charts/spiderpool/values.yaml
+  iaasNetworkProvider.httpRequestTimeout: "30s"
+        │
+        ▼  templates/configmap.yaml
+ConfigMap data: conf.yml
+  iaasNetworkProvider:
+    serverUrl: "..."
+    httpRequestTimeout: "30s"
+        │
+        ▼  pkg/types/k8s.go
+type IaaSProviderConfig struct {
+    ServerURL          string `yaml:"serverUrl,omitempty"`
+    HTTPRequestTimeout string `yaml:"httpRequestTimeout,omitempty"`   // NEW
+}
+        │
+        ▼  cmd/spiderpool-agent|controller/cmd/daemon.go (startup)
+ValidateConfig(cfg) → parse + bounds check
+        │
+        ▼  pkg/iaas/client/client.go NewClient
+http.Client{ Timeout: parsed }
+```
+
+### Validation rules
+
+Applied in `ValidateConfig` (startup, both agent and controller). All rules only
+apply when `ServerURL != ""` (IaaS integration enabled).
+
+1. If `HTTPRequestTimeout == ""` → use default `30s` (no error).
+2. Parse `HTTPRequestTimeout` with `time.ParseDuration`; on error → validation
+   error naming the bad value.
+3. `parsed > 0`, else → validation error.
+4. `parsed < StaticSafetyLimit` (`2 * time.Minute`), else → validation error.
+5. `parsed < CNIClientTimeout` (`100 * time.Second`), else → validation error.
+
+State: configuration is validated once at startup. There are no runtime state
+transitions for this entity.
+
+## Entity: CNI Plugin-to-Agent Timeout
+
+Spiderpool's timeout for CNI plugin requests sent to the Spiderpool Agent.
+
+| Property | Value | Location |
+|----------|-------|----------|
+| ADD timeout | `100 * time.Second` | `cmd/spiderpool/cmd/command_add.go` |
+| DEL timeout | `100 * time.Second` | `cmd/spiderpool/cmd/command_delete.go` |
+| Configurable today? | No | — |
+| Representation after change | shared constant `constant.DefaultCNIClientTimeout` | `pkg/constant` (or `pkg/iaas/client`) |
+
+This entity is the comparison budget for validation rule 5. If it becomes
+configurable later, validation reads the configured value instead of the constant.
+
+## Entity: Parent Operation Budget (runtime)
+
+Remaining time available from the current operation `context.Context` when a
+provider call is about to be made.
+
+| Property | Type | Source |
+|----------|------|--------|
+| deadline | `time.Time, ok bool` | `ctx.Deadline()` in the IaaS client |
+| remaining | `time.Duration` | `time.Until(deadline)` when `ok` |
+
+Effective per-call timeout = `min(configuredTimeout, remaining)` when a deadline
+is present; otherwise `configuredTimeout`. If `remaining <= 0`, the call is not
+started and a clear "parent budget exhausted" error is returned.
+
+## Entity: Provider Call Outcome
+
+Result of a provider interaction, used for diagnostics (User Story 3).
+
+| Outcome | Trigger |
+|---------|---------|
+| success | provider returns 2xx within budget |
+| provider timeout | request exceeds effective per-call timeout |
+| parent-budget rejection | `remaining <= 0` before call starts |
+| invalid configuration | startup validation failure |
+| provider error | non-2xx response or transport error |

--- a/specs/004-iaas-http-timeout/plan.md
+++ b/specs/004-iaas-http-timeout/plan.md
@@ -1,0 +1,135 @@
+# Implementation Plan: IaaS Provider HTTP Timeout
+
+**Branch**: `004-iaas-http-timeout` | **Date**: 2026-06-02 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/004-iaas-http-timeout/spec.md`
+
+## Summary
+
+Spiderpool's IaaS provider HTTP client currently hardcodes a 30-second request
+timeout in `pkg/iaas/client/client.go` (`NewClient`), and the configuration type
+`IaaSProviderConfig` only exposes `serverUrl`. This feature adds a configurable
+provider HTTP timeout (`iaasNetworkProvider.httpRequestTimeout`), surfaced
+through the Helm value and the agent/controller ConfigMap, applied to every
+provider allocation and release call. The timeout is validated at component startup: it MUST be positive and
+strictly smaller than the static safety limit (2 minutes) and smaller than the
+current CNI plugin-to-agent timeout (100 seconds, used by both CNI ADD and CNI
+DEL in `cmd/spiderpool/cmd/command_add.go` and `command_delete.go`). At call
+time the client also honors the parent `context.Context` deadline when one is
+present, so the effective timeout is the smaller of the configured value and the
+remaining context budget. The 100-second value is referenced from a shared
+constant so that if the CNI client timeout later becomes configurable, the
+validation compares against the configured value rather than a literal.
+
+## Technical Context
+
+**Language/Version**: Go 1.25 (per `go.mod`)
+
+**Primary Dependencies**: standard library `net/http`, `context`, `time`;
+`go.uber.org/zap` for logging; existing `pkg/iaas/client`, `pkg/types`,
+`pkg/ipam`; Helm chart `charts/spiderpool`.
+
+**Storage**: N/A (no persistent storage; configuration via ConfigMap/Helm values)
+
+**Testing**: Ginkgo v2 + Gomega unit tests (`make unittest-tests`); Helm
+rendering verification for chart changes.
+
+**Target Platform**: Linux; Spiderpool Agent and Controller pods in Kubernetes.
+
+**Project Type**: Kubernetes networking system (single Go repo: `cmd/`, `pkg/`,
+`charts/`, `docs/`).
+
+**Performance Goals**: No new hot-path cost. The change only sets an
+`http.Client.Timeout` and performs O(1) startup validation. Provider calls
+already exist on the IPAM ADD/DEL path; this feature bounds their latency rather
+than adding work.
+
+**Constraints**: Provider HTTP timeout MUST be `> 0`, `< 2m` (static safety
+limit), and `< 100s` (current CNI plugin-to-agent timeout). At call time the
+effective deadline is `min(configuredTimeout, remaining parent context budget)`.
+Default value when IaaS integration is enabled but the timeout is unset: `30s`
+(preserves current hardcoded behavior).
+
+**Scale/Scope**: Small, focused change. Affected files: `pkg/types/k8s.go`,
+`pkg/iaas/client/client.go`, agent/controller daemon wiring, a shared timeout
+constant, `charts/spiderpool/values.yaml`, `charts/spiderpool/templates/configmap.yaml`,
+`charts/spiderpool/README.md`, and docs (EN + ZH).
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Code quality and API compatibility**: Adds an optional `httpRequestTimeout`
+  field (`HTTPRequestTimeout`) to `IaaSProviderConfig` (`pkg/types/k8s.go`) and an
+  optional Helm value `iaasNetworkProvider.httpRequestTimeout`. Both are additive and backward compatible: an
+  empty/unset value preserves the existing 30s behavior. `NewClient` signature is
+  extended to consume the configured timeout from the config struct (no new
+  positional parameter), keeping the public function shape stable. The 100s CNI
+  timeout literal in `command_add.go`/`command_delete.go` is replaced by a shared
+  exported constant to remove duplication and enable future configurability.
+- **Testing standard**: Unit tests (Ginkgo/Gomega) for: timeout parsing and
+  validation (positive, `<2m`, `<100s`, zero/negative/unparsable, default), and
+  for the client applying the configured timeout. Helm rendering test/verification
+  that `iaasNetworkProvider.httpRequestTimeout` propagates into the ConfigMap. Generated test
+  files include the required Ginkgo `Label(...)`.
+- **User/operator consistency**: New Helm value documented in
+  `charts/spiderpool/values.yaml` and `charts/spiderpool/README.md`; user docs
+  updated in both English and Chinese. Validation errors name the configured
+  value and the limit/budget it violated. Default and accepted duration format
+  (Go duration string, e.g. `30s`, `1m30s`) documented.
+- **Performance budget**: No performance-sensitive hot path is added. The change
+  sets `http.Client.Timeout` once at client construction and performs O(1)
+  validation at startup. Provider calls already run on the IPAM ADD/DEL path; this
+  feature only bounds their duration.
+- **Generated artifacts**: No CRD/OpenAPI/deepcopy/RBAC source definitions change,
+  so `make manifests generate-k8s-api` / `make openapi-code-gen` are not required.
+  Chart README parameter table is regenerated/updated to match `values.yaml`.
+
+**Gate Result**: PASS — additive, backward-compatible config change with clear
+validation and test coverage; no generated-artifact or performance-budget
+violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-iaas-http-timeout/
+├── plan.md              # This file (/speckit.plan output)
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (config + validation contract)
+└── tasks.md             # Phase 2 output (/speckit.tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+cmd/
+├── spiderpool/cmd/command_add.go        # CNI ADD: 100s plugin-to-agent timeout (use shared const)
+├── spiderpool/cmd/command_delete.go     # CNI DEL: 100s plugin-to-agent timeout (use shared const)
+├── spiderpool-agent/cmd/daemon.go       # IaaS client creation + startup validation
+└── spiderpool-controller/cmd/daemon.go  # IaaS client creation + startup validation
+
+pkg/
+├── types/k8s.go                         # IaaSProviderConfig: add HTTPRequestTimeout field
+├── iaas/client/client.go                # NewClient: apply configured timeout; ValidateConfig: validate timeout
+└── constant/ (or pkg/iaas/client)       # shared CNI plugin-to-agent timeout constant
+
+charts/spiderpool/
+├── values.yaml                          # iaasNetworkProvider.httpRequestTimeout
+├── templates/configmap.yaml             # render timeout into ConfigMap
+└── README.md                            # parameter table
+
+docs/                                    # EN + ZH operator docs for the new value
+```
+
+**Structure Decision**: Single-repo Go layout. The feature reuses the existing
+IaaS integration surfaces (`pkg/iaas/client`, `pkg/types`, the agent/controller
+daemons, and the Helm chart) without introducing new packages, matching
+Constitution Principle V and the repository layout in `AGENTS.md`.
+
+## Complexity Tracking
+
+> No Constitution Check violations. Section intentionally empty.

--- a/specs/004-iaas-http-timeout/quickstart.md
+++ b/specs/004-iaas-http-timeout/quickstart.md
@@ -1,0 +1,153 @@
+# Quickstart: IaaS Provider HTTP Timeout
+
+## What this feature does
+
+Lets operators configure how long Spiderpool waits for a single IaaS provider
+HTTP call (allocate/release). The value is validated at startup so it can never
+exceed the time Spiderpool has to complete a CNI operation.
+
+## Provider timing model
+
+Understanding the provider internals is important for choosing a correct value.
+
+A single IaaS provider request goes through two stages:
+
+| Stage | Max duration | Description |
+|---|---|---|
+| Rate-limit wait | 30 s | Provider checks its token bucket; if no slot is available it waits up to 30 s before accepting the request |
+| Cloud API call | 16 s | Provider forwards the request to the underlying cloud platform; network latency and cloud-side processing can take up to 16 s |
+| **Worst case total** | **~48 s** | Sum of the two stages plus a small network round-trip margin |
+
+**Consequence**: a timeout value shorter than ~48 s risks cancelling a request
+that the provider has already accepted and started executing. This creates a
+state inconsistency: Spiderpool treats it as a failure while the cloud
+operation may have succeeded or be in progress.
+
+## Time budget hierarchy
+
+The full budget chain explains why `httpRequestTimeout` has the constraints it does:
+
+| Layer | Default timeout | Description |
+|---|---|---|
+| kubelet sandbox operation | **2 min** | kubelet's default timeout for the entire sandbox setup. If the CNI pipeline does not finish within this window, the Pod fails to start. This is the outermost budget. |
+| Spiderpool CNI plugin → agent call | **100 s** | The timeout the Spiderpool CNI binary uses when calling spiderpool-agent. This is the total budget available to the agent to complete all IPAM and IaaS work. |
+| IaaS provider HTTP call | **50 s** (default) | Per-call timeout set by `httpRequestTimeout`. Must fit inside the 100 s agent budget alongside all other IPAM processing. |
+| Provider worst-case completion | **~48 s** | Maximum time a single provider request can take (30 s rate-limit wait + 16 s cloud API). This is the minimum meaningful value for `httpRequestTimeout`. |
+
+## Recommended value
+
+| Scenario | Recommended `httpRequestTimeout` |
+|---|---|
+| Default / general use | `50s` (default) |
+| Low-latency private cloud with no rate limiting | `20s` |
+| High-contention environment with long rate-limit queues | `55s`–`59s` (must stay `< 100s`) |
+
+**Why 50 s**: covers the 48 s worst case with a 2 s margin, while staying well
+below the 100 s CNI plugin-to-agent budget.
+
+## Configure via Helm
+
+```yaml
+# values.yaml
+iaasNetworkProvider:
+  serverUrl: "https://iaas-provider.example.com:8443"
+  httpRequestTimeout: "50s"   # Go duration; must be > 0, < 2m, and < 100s
+```
+
+```bash
+helm upgrade --install spiderpool spiderpool/spiderpool \
+  --set iaasNetworkProvider.serverUrl="https://iaas-provider.example.com:8443" \
+  --set iaasNetworkProvider.httpRequestTimeout="50s"
+```
+
+### Validation rules
+
+- Accepted format: Go duration string (`50s`, `45s`, `1m`).
+- Must be greater than `0`.
+- Must be less than `2m` (static safety limit).
+- Must be less than `100s` (current CNI plugin-to-agent timeout for ADD and DEL).
+- Empty/unset defaults to `50s`.
+- Ignored entirely when `serverUrl` is empty (IaaS integration disabled).
+- Validation failure at startup is **fatal**: the agent/controller will not start
+  with an invalid timeout.
+
+## Verify
+
+### Helm rendering
+
+```bash
+helm template spiderpool charts/spiderpool \
+  --set iaasNetworkProvider.serverUrl="https://x:8443" \
+  --set iaasNetworkProvider.httpRequestTimeout="50s" \
+  | grep -A2 iaasNetworkProvider
+# expect:
+#   iaasNetworkProvider:
+#     serverUrl: "https://x:8443"
+#     httpRequestTimeout: "50s"
+```
+
+### Startup validation (negative case)
+
+Set an unsafe value and confirm the component reports a clear error:
+
+```bash
+helm upgrade ... --set iaasNetworkProvider.httpRequestTimeout="2m"
+# agent/controller log (fatal):
+#   IaaS provider configuration validation failed: invalid iaasNetworkProvider.httpRequestTimeout "2m": ...
+```
+
+### Unit tests
+
+```bash
+make unittest-tests
+# or target the IaaS client package:
+go test ./pkg/iaas/client/...
+```
+
+## Behavior at runtime
+
+Each allocate/release call enforces two independent guards before sending the
+HTTP request:
+
+### Guard 1 — minimum parent budget check
+
+Before starting a call, Spiderpool checks how much time remains in the parent
+operation context (the CNI ADD/DEL budget). If the remaining time is **less than
+the provider worst-case** (~48 s), Spiderpool **does not start the call** and
+returns immediately with `"parent budget insufficient"`.
+
+**Why**: sending a request with insufficient budget risks the provider consuming
+a rate-limit slot and starting the cloud operation, only for Spiderpool to
+receive a cancellation error. This guard prevents that state inconsistency.
+
+**What this means for operators**: if CNI operations are consistently failing
+with `"parent budget insufficient"`, either the `httpRequestTimeout` is too
+large relative to the available CNI budget, or the overall CNI pipeline is
+taking too long before reaching the IaaS call.
+
+### Guard 2 — per-request timeout context
+
+After passing Guard 1, Spiderpool derives a child context with a deadline of
+`httpRequestTimeout` from the current time. The effective HTTP deadline is:
+
+```
+effective deadline = min(now + httpRequestTimeout, parent deadline)
+```
+
+Since Guard 1 ensures `remaining parent budget >= 48 s >= httpRequestTimeout`
+for correctly configured deployments, the configured `httpRequestTimeout`
+normally wins and the provider call has its full configured budget.
+
+### Error message guide
+
+| Error message | Meaning | Action |
+|---|---|---|
+| `parent budget insufficient: Xs remaining is less than provider worst-case 48s` | CNI operation budget was almost exhausted before the IaaS call was attempted | Check pipeline latency; consider raising CNI timeout or lowering `httpRequestTimeout` |
+| `provider-interaction timeout: ... exceeded configured timeout 50s` | Provider did not respond within `httpRequestTimeout` | Check provider health; consider raising `httpRequestTimeout` if provider load is high |
+| `parent budget exhausted: ... cancelled by parent context deadline` | Parent deadline arrived while provider was responding | As above, but the parent budget ran out before the configured timeout |
+
+## Rollback
+
+Remove or empty `iaasNetworkProvider.httpRequestTimeout`; behavior reverts to the
+default `50s`. Removing `serverUrl` disables IaaS integration and the timeout
+entirely.

--- a/specs/004-iaas-http-timeout/research.md
+++ b/specs/004-iaas-http-timeout/research.md
@@ -1,0 +1,112 @@
+# Phase 0 Research: IaaS Provider HTTP Timeout
+
+This document resolves the unknowns flagged in the spec's Clarifications,
+Assumptions, and Edge Cases sections by inspecting the current Spiderpool code.
+
+## Decision 1: Where the provider HTTP timeout is applied
+
+- **Decision**: Add a configurable timeout to the IaaS HTTP client and set it as
+  `http.Client.Timeout` in `NewClient`, replacing the hardcoded `30 * time.Second`.
+- **Rationale**: The IaaS client is the single chokepoint for all provider
+  interactions. Both `AllocateIPs` and `ReleaseIP` use the same
+  `c.httpClient.Do(httpReq)` path, so setting `http.Client.Timeout` once bounds
+  every provider call (FR-003). `http.Client.Timeout` covers connection, redirects,
+  and reading the response body.
+- **Evidence**:
+  - `pkg/iaas/client/client.go:85-90` — `httpClient := &http.Client{ ... Timeout: 30 * time.Second }`.
+  - `pkg/iaas/client/client.go:127` (`AllocateIPs`) and `:219` (`releaseSingleIP`)
+    both call `c.httpClient.Do(httpReq)`.
+- **Alternatives considered**: Per-call `context.WithTimeout` inside
+  `AllocateIPs`/`ReleaseIP`. Rejected as the primary mechanism because it
+  duplicates logic across call sites; however it is used additively (see Decision 3)
+  to also honor the parent context deadline.
+
+## Decision 2: What the configured timeout is compared against (parent budget)
+
+- **Decision**: Validate at startup that the configured provider timeout is
+  strictly smaller than the current CNI plugin-to-agent timeout of **100 seconds**,
+  which is shared by both CNI ADD and CNI DEL. Also enforce the static safety
+  limit of **2 minutes** and `> 0`.
+- **Rationale**: The clarification session established that kubelet's original CNI
+  timeout is not reliably visible to the agent. The concrete, code-defined budget
+  that bounds a CNI-triggered provider call is the plugin-to-agent timeout the CNI
+  binary sets before calling the agent. Today that value is a hardcoded 100s for
+  both operations.
+- **Evidence**:
+  - `cmd/spiderpool/cmd/command_add.go:112` — `ctx, cancel := context.WithTimeout(context.Background(), 100*time.Second)`.
+  - `cmd/spiderpool/cmd/command_delete.go:92` — identical `100*time.Second`.
+- **Alternatives considered**: Hardcoding a 2-minute kubelet assumption. Rejected
+  per the spec because kubelet defaults are configurable and not the binding budget
+  in the current flow.
+
+## Decision 3: Whether the parent context deadline can be obtained
+
+- **Decision**: At call time, derive the effective per-call deadline as
+  `min(configuredTimeout, remaining parent context budget)` by checking
+  `ctx.Deadline()` before issuing the request. `http.Client.Timeout` provides the
+  static upper bound; the context deadline (when present) provides the dynamic one.
+- **Rationale**: Go's `http.Client.Do` already aborts when the request context is
+  cancelled or its deadline passes, because requests are created with
+  `http.NewRequestWithContext(ctx, ...)`. So if the parent context carries a
+  deadline, the call already cannot exceed it. The explicit `ctx.Deadline()` check
+  is used only to produce a clear, operator-facing error (User Story 3 / FR-012)
+  when the remaining budget is already smaller than or exhausted relative to the
+  configured timeout, rather than failing opaquely at the network layer.
+- **Evidence**:
+  - `pkg/iaas/client/client.go:119` and `:212` — `http.NewRequestWithContext(ctx, ...)`,
+    so the parent context already governs cancellation.
+  - The IPAM ADD/DEL path passes the inbound request context down to
+    `callIaaSAllocate`/`callIaaSRelease` (`pkg/ipam/iaas.go:25,113`), which forward
+    it into the client calls.
+- **Caveat**: Over the unix-socket OpenAPI transport the CNI plugin's 100s deadline
+  is not automatically propagated as a context deadline into the agent process; the
+  agent's request context may carry a server-side deadline or none. The static
+  100s comparison (Decision 2) therefore remains the authoritative startup gate,
+  and the runtime `ctx.Deadline()` check is best-effort defense in depth.
+
+## Decision 4: Default value and configuration surface
+
+- **Decision**: Add an optional `httpRequestTimeout` field (Go `HTTPRequestTimeout`)
+  to `IaaSProviderConfig` (`yaml:"httpRequestTimeout,omitempty"`), surfaced as Helm
+  value `iaasNetworkProvider.httpRequestTimeout` and rendered into the
+  agent/controller ConfigMap. Accepted format is a Go
+  duration string (e.g. `30s`, `1m30s`). When IaaS integration is enabled and the
+  timeout is unset/empty, default to **30s** (the current hardcoded value).
+- **Rationale**: Matches the existing `serverUrl` configuration pattern, preserves
+  backward compatibility (Principle III, FR-004/FR-013), and keeps explicit
+  configuration above inferred defaults.
+- **Evidence**:
+  - The name is namespaced under `iaasNetworkProvider`, so it omits a redundant
+    "provider" prefix while still stating it bounds a single HTTP request.
+  - `pkg/types/k8s.go:135-137` — `IaaSProviderConfig{ ServerURL string }`.
+  - `charts/spiderpool/values.yaml:1072-1074` — `iaasNetworkProvider.serverUrl`.
+  - `charts/spiderpool/templates/configmap.yaml:39-40` — renders `serverUrl`.
+
+## Decision 5: Removing the duplicated 100s literal
+
+- **Decision**: Introduce a shared exported constant for the CNI plugin-to-agent
+  timeout (e.g. `constant.DefaultCNIClientTimeout = 100 * time.Second`) and use it
+  in `command_add.go`, `command_delete.go`, and the startup validation.
+- **Rationale**: FR-008/FR-009/FR-010 require ADD and DEL to share one value today
+  and to support future configurability without re-touching the literal. A single
+  constant removes drift and gives validation one source of truth.
+- **Alternatives considered**: Keep two literals and a third in validation.
+  Rejected: violates DRY and risks the three values diverging.
+
+## Validation rules summary (resolves Edge Cases)
+
+| Condition | Behavior |
+|-----------|----------|
+| httpRequestTimeout unset/empty, IaaS enabled | default to `30s` |
+| httpRequestTimeout `<= 0` | startup validation error |
+| httpRequestTimeout unparsable | startup validation error |
+| httpRequestTimeout `>= 2m` (static limit) | startup validation error |
+| httpRequestTimeout `>= 100s` (CNI client timeout) | startup validation error |
+| valid httpRequestTimeout, parent ctx has deadline | use `min(httpRequestTimeout, remaining budget)` |
+| parent ctx deadline already exhausted | do not start call; clear error |
+| parent ctx has no deadline | use configured httpRequestTimeout + static validation |
+
+## Open items
+
+- None blocking. mTLS for the IaaS client remains a separate TODO
+  (`pkg/iaas/client/client.go:80`) and is out of scope for this feature.

--- a/specs/004-iaas-http-timeout/spec.md
+++ b/specs/004-iaas-http-timeout/spec.md
@@ -1,0 +1,219 @@
+# Feature Specification: IaaS Provider HTTP Timeout
+
+**Feature Branch**: `004-iaas-http-timeout`
+
+**Created**: 2026-06-02
+
+**Status**: Draft
+
+**Input**: User description: "Add a configuration in Spiderpool's IaaS provider integration for HTTP interaction timeout, configurable via Helm values. When Spiderpool calls the provider, set the timeout which must not exceed 2 minutes because kubelet's CNI ADD default timeout is 2 minutes. However, this 2-minute default can be changed, and CNI DEL has different timeout behavior, so it should not be hardcoded. Currently Spiderpool reuses the parent context when calling the provider; check if the parent context's timeout can be retrieved, then compare it with the configured HTTP timeout - the HTTP timeout must be smaller than the parent context's timeout."
+
+## Clarifications
+
+### Session 2026-06-02
+
+- Q: Can Spiderpool obtain the provider call's parent timeout from context? -> A: Only a context deadline can be obtained when present; current Spiderpool CNI-to-agent calls use a derived internal deadline, so the plan must verify deadline propagation instead of assuming kubelet's original timeout is visible.
+- Q: What parent budget should the provider HTTP timeout be compared against in the current Spiderpool CNI flow? -> A: Compare against the current CNI plugin-to-agent timeout of 100 seconds; ADD and DEL both use this value today, and this timeout is not currently configurable. If that timeout becomes configurable later, startup validation must compare the provider HTTP timeout with the configured CNI client timeout.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Configure Provider Timeout (Priority: P1)
+
+As a cluster administrator using Spiderpool with an IaaS provider, I want to
+configure the provider HTTP interaction timeout through the Spiderpool Helm
+values so that provider calls cannot consume the whole CNI operation budget.
+
+**Why this priority**: This is the primary safety control. Without it, a slow
+provider can make Spiderpool wait until the parent CNI operation expires.
+
+**Independent Test**: Install or render Spiderpool with a valid timeout value and
+verify the value is accepted, documented, and available to the components that
+call the provider.
+
+**Acceptance Scenarios**:
+
+1. **Given** IaaS provider integration is enabled, **When** the administrator
+   configures a valid provider timeout in Helm values, **Then** Spiderpool uses
+   that value for provider interactions.
+2. **Given** IaaS provider integration is disabled, **When** the administrator
+   leaves the timeout unset, **Then** Spiderpool continues to install and operate
+   without requiring a provider timeout.
+
+---
+
+### User Story 2 - Prevent Unsafe Timeout Values (Priority: P1)
+
+As a cluster administrator, I want Spiderpool to reject or report provider
+timeout values that are not safely below the caller's available time budget so
+that CNI ADD, CNI DEL, and cleanup flows fail predictably instead of expiring at
+the outer deadline.
+
+**Why this priority**: The configured timeout must not be equal to or greater
+than Spiderpool's CNI plugin-to-agent operation timeout. In the current code,
+CNI ADD and CNI DEL both use a 100-second timeout at that boundary.
+
+**Independent Test**: Run provider allocation and release flows with the current
+CNI plugin-to-agent timeout and verify Spiderpool only starts provider calls when
+the configured provider timeout is shorter than that budget.
+
+**Acceptance Scenarios**:
+
+1. **Given** a parent CNI ADD operation uses the current 100-second
+   plugin-to-agent timeout, **When** the configured provider timeout is shorter
+   than that budget,
+   **Then** Spiderpool calls the provider using the configured timeout.
+2. **Given** a parent CNI ADD or CNI DEL operation uses the current 100-second
+   plugin-to-agent timeout, **When** the configured provider timeout is equal to
+   or greater than that budget, **Then** Spiderpool rejects the configuration or
+   does not start an unsafe provider call.
+3. **Given** the CNI plugin-to-agent timeout becomes configurable, **When**
+   Spiderpool validates the provider timeout, **Then** Spiderpool compares it
+   with the configured CNI client timeout rather than a literal 100-second value.
+
+---
+
+### User Story 3 - Diagnose Timeout Decisions (Priority: P2)
+
+As an operator troubleshooting IaaS provider calls, I want Spiderpool to report
+clear timeout-related errors and observations so that I can tell whether a call
+timed out, was rejected because the configured timeout was unsafe, or proceeded
+with a valid budget.
+
+**Why this priority**: Timeout failures affect Pod startup and cleanup. Clear
+diagnostics reduce recovery time and avoid misconfiguring provider integration.
+
+**Independent Test**: Trigger provider call timeout, unsafe timeout, and valid
+timeout cases and verify the operator-facing messages distinguish the outcomes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a provider call exceeds the configured provider timeout, **When**
+   Spiderpool reports the failure, **Then** the message identifies that the
+   provider interaction timed out.
+2. **Given** Spiderpool rejects a provider call because its configured timeout is
+   not below the parent budget, **When** the failure is reported, **Then** the
+   message includes the configured provider timeout and the available parent
+   budget.
+
+### Edge Cases
+
+- Parent operation has no discoverable deadline: Spiderpool uses the configured
+  provider timeout and still applies static configuration validation.
+- Parent context carries an internal Spiderpool deadline rather than the
+  runtime's original CNI timeout: Spiderpool compares against the available
+  context deadline and the plan verifies whether runtime timeout propagation
+  must be added.
+- Current CNI ADD and CNI DEL plugin-to-agent calls both use the same
+  100-second timeout. The provider HTTP timeout must be strictly smaller than
+  that value until a separate Spiderpool CNI client timeout configuration exists.
+- A future Spiderpool CNI client timeout setting is added or discovered:
+  component startup validation must compare the provider HTTP timeout with that
+  configured CNI client timeout.
+- IPAM release derives a shorter operation context from Pod deletion grace
+  period after the CNI DEL request reaches the agent: provider release calls
+  must still honor the current operation context deadline at call time.
+- Parent operation has already expired or has no remaining time: Spiderpool does
+  not start the provider call and reports that the parent budget is exhausted.
+- Configured provider timeout is zero, negative, unparsable, or missing while
+  IaaS provider integration is enabled: Spiderpool reports an invalid
+  configuration or uses the documented default.
+- Configured provider timeout equals the parent remaining budget exactly:
+  Spiderpool treats it as unsafe because the provider timeout must be smaller.
+- CNI ADD and CNI DEL expose different parent budgets in a future change:
+  Spiderpool evaluates each call against the budget of the current operation.
+- Runtime scheduling delay leaves less remaining parent time than was available
+  when the operation started: Spiderpool compares against the remaining time at
+  the point the provider call is made.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide an IaaS provider HTTP timeout setting that can
+  be configured through Spiderpool Helm values.
+- **FR-002**: System MUST document the timeout setting, accepted duration format,
+  default value, and invalid-value behavior for operators.
+- **FR-003**: System MUST apply the configured timeout to every Spiderpool
+  interaction with the IaaS provider, including allocation and release flows.
+- **FR-004**: System MUST preserve existing behavior when IaaS provider
+  integration is disabled.
+- **FR-005**: System MUST validate that configured timeout values are positive
+  and do not exceed the documented static safety limit.
+- **FR-006**: System MUST compare the configured provider timeout with the
+  current operation's remaining context deadline whenever that deadline is
+  available.
+- **FR-007**: System MUST require the configured provider timeout to be strictly
+  smaller than the current 100-second CNI plugin-to-agent timeout before
+  accepting the configuration for CNI-triggered provider calls.
+- **FR-008**: System MUST validate the provider HTTP timeout during component
+  startup when IaaS provider integration is enabled.
+- **FR-009**: System MUST use a configured Spiderpool CNI client timeout for the
+  comparison if that timeout becomes configurable; otherwise the current
+  100-second ADD/DEL timeout is the comparison budget.
+- **FR-010**: System MUST confirm CNI ADD and CNI DEL timeout behavior in tests;
+  today both operations use the same 100-second plugin-to-agent timeout.
+- **FR-011**: System MUST handle controller cleanup and IPAM release flows
+  according to their current operation context, because these flows may have
+  budgets that differ from the CNI plugin-to-agent timeout.
+- **FR-012**: System MUST return or log a clear operator-facing error when the
+  configured timeout is invalid, unsafe for the current parent budget, or reached
+  during a provider call.
+- **FR-013**: System MUST preserve existing Spiderpool API, CRD, Helm,
+  annotation, and webhook behavior unless an explicit compatibility exception is
+  documented.
+- **FR-014**: System MUST expose user/operator-facing names, defaults,
+  validation errors, status fields, and examples consistently with existing
+  Spiderpool conventions.
+
+### Key Entities
+
+- **IaaS Provider Timeout Setting**: Operator-configured duration controlling how
+  long Spiderpool may wait for one provider HTTP interaction.
+- **Parent Operation Budget**: Remaining time available from the current
+  operation context, such as CNI ADD, CNI DEL, or controller cleanup, when
+  Spiderpool is about to contact the provider.
+- **CNI Plugin-to-Agent Timeout**: Spiderpool's timeout for CNI plugin requests
+  sent to the Spiderpool Agent. The current ADD and DEL value is 100 seconds.
+- **Provider Call Outcome**: Result of a provider interaction, including success,
+  provider timeout, parent-budget rejection, invalid configuration, or provider
+  error.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of provider allocation and release calls use the configured
+  provider timeout when IaaS provider integration is enabled.
+- **SC-002**: 100% of provider calls with a discoverable parent budget are
+  rejected before start when the configured provider timeout is equal to or
+  greater than the remaining parent budget.
+- **SC-003**: CNI ADD and CNI DEL validation tests confirm both operations use
+  the same 100-second plugin-to-agent timeout today and reject provider HTTP
+  timeout values that are equal to or greater than that value.
+- **SC-004**: Operator-facing documentation includes the Helm value name, default,
+  valid examples, invalid examples, and the requirement that the provider timeout
+  be smaller than the parent operation budget.
+- **SC-005**: Invalid or unsafe timeout configurations produce distinct messages
+  that identify the configured timeout and the relevant limit or parent budget.
+- **SC-006**: When IaaS provider integration is disabled, the timeout setting does
+  not change successful Pod allocation or release outcomes.
+
+## Assumptions
+
+- The feature extends the existing IaaS provider integration rather than adding a
+  second provider integration mode.
+- The default provider timeout is defined by the project during planning and is
+  below the documented static safety limit.
+- The static safety limit remains two minutes unless the project exposes a
+  separate supported configuration for changing that limit.
+- Current Spiderpool CNI ADD and CNI DEL plugin-to-agent calls both use a
+  100-second timeout and this value is not currently exposed through Helm values
+  or runtime configuration.
+- Parent operation budget is determined from the current context deadline when
+  that deadline is exposed to Spiderpool.
+- Context can reveal a deadline, not the original configured timeout value. The
+  plan must verify whether the current deadline represents kubelet's runtime
+  budget or a Spiderpool-derived internal budget.
+- If no context deadline is exposed, Spiderpool cannot compare against a dynamic
+  parent budget and relies on the configured provider timeout plus static
+  validation.

--- a/specs/004-iaas-http-timeout/tasks.md
+++ b/specs/004-iaas-http-timeout/tasks.md
@@ -1,0 +1,194 @@
+# Tasks: IaaS Provider HTTP Timeout
+
+**Feature Branch**: `004-iaas-http-timeout`
+**Plan**: [plan.md](./plan.md) | **Spec**: [spec.md](./spec.md)
+**Inputs**: research.md, data-model.md, contracts/config-contract.md, quickstart.md
+
+## Conventions
+
+- Config field: Helm/YAML `iaasNetworkProvider.httpRequestTimeout`, Go
+  `IaaSProviderConfig.HTTPRequestTimeout` (Go duration string).
+- Shared constants live in `pkg/constant`: `DefaultCNIClientTimeout = 100s`,
+  `IaaSTimeoutStaticLimit = 2m`, `DefaultIaaSProviderTimeout = 30s`.
+- Tests use Ginkgo v2 + Gomega; non-suite `*_test.go` files MUST include a
+  Ginkgo `Label(...)`.
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 Verify the IaaS integration surfaces compile and tests pass before changes by running `go build ./... && go test ./pkg/iaas/... ./pkg/types/...` from the repo root
+
+---
+
+## Phase 2: Foundational (blocking prerequisites for all user stories)
+
+**Purpose**: Shared types and constants every user story depends on. No user
+story can be completed until these exist.
+
+- [ ] T002 [P] Add shared timeout constants `DefaultCNIClientTimeout = 100 * time.Second`, `IaaSTimeoutStaticLimit = 2 * time.Minute`, and `DefaultIaaSProviderTimeout = 30 * time.Second` in `pkg/constant/` (e.g. a new `pkg/constant/timeout.go`), with English doc comments
+- [ ] T003 [P] Add the `HTTPRequestTimeout string` field with tag `yaml:"httpRequestTimeout,omitempty"` to `IaaSProviderConfig` in `pkg/types/k8s.go`
+- [ ] T004 Replace the literal `100*time.Second` with `constant.DefaultCNIClientTimeout` in `cmd/spiderpool/cmd/command_add.go` (CNI ADD plugin-to-agent timeout)
+- [ ] T005 Replace the literal `100*time.Second` with `constant.DefaultCNIClientTimeout` in `cmd/spiderpool/cmd/command_delete.go` (CNI DEL plugin-to-agent timeout)
+
+**Checkpoint**: Config type and constants exist; CNI ADD/DEL reference the shared constant. Project builds.
+
+---
+
+## Phase 3: User Story 1 - Configure Provider Timeout (Priority: P1)
+
+**Goal**: Operators can set `iaasNetworkProvider.httpRequestTimeout` via Helm and
+Spiderpool applies it to every provider allocate/release call (replacing the
+hardcoded 30s).
+
+**Independent Test**: Render the chart with a valid `httpRequestTimeout`, confirm
+it appears in the ConfigMap, and confirm the IaaS HTTP client is constructed with
+that timeout (unit test on `NewClient`).
+
+### Tests for User Story 1
+
+> Write/update these tests before the implementation is considered complete.
+
+- [ ] T006 [P] [US1] Ginkgo/Gomega test that `NewClient` builds an `http.Client` whose `Timeout` equals the configured `HTTPRequestTimeout`, and defaults to `30s` when empty, in `pkg/iaas/client/client_test.go` (include `Label(...)`)
+- [ ] T007 [P] [US1] Helm rendering test/verification that `--set iaasNetworkProvider.httpRequestTimeout=45s` renders `httpRequestTimeout: "45s"` into the agent/controller ConfigMap (add to existing chart test harness or `charts/spiderpool` rendering tests)
+
+### Implementation for User Story 1
+
+- [ ] T008 [P] [US1] Add `httpRequestTimeout: "30s"` with `@param` documentation under `iaasNetworkProvider` in `charts/spiderpool/values.yaml`
+- [ ] T009 [P] [US1] Render `httpRequestTimeout: {{ (.Values.iaasNetworkProvider).httpRequestTimeout | default "30s" | quote }}` under `iaasNetworkProvider` in `charts/spiderpool/templates/configmap.yaml`
+- [ ] T010 [US1] In `pkg/iaas/client/client.go` `NewClient`, parse `cfg.HTTPRequestTimeout` (defaulting empty to `constant.DefaultIaaSProviderTimeout`) and set it as `http.Client.Timeout`, removing the hardcoded `30 * time.Second` (depends on T002, T003)
+- [ ] T011 [US1] Update the `iaasNetworkProvider` parameter table in `charts/spiderpool/README.md` to include `iaasNetworkProvider.httpRequestTimeout`
+
+**Checkpoint**: Configured timeout flows Helm → ConfigMap → client and bounds every provider call.
+
+---
+
+## Phase 4: User Story 2 - Prevent Unsafe Timeout Values (Priority: P1)
+
+**Goal**: Spiderpool rejects provider timeout values that are not safely below the
+parent budget: at startup the value MUST be `> 0`, `< 2m`, and `< 100s` (the
+current CNI plugin-to-agent timeout shared by ADD and DEL).
+
+**Independent Test**: Run `ValidateConfig` with valid and unsafe values and confirm
+acceptance/rejection; start the agent/controller with an unsafe value and confirm
+startup fails with a clear error.
+
+### Tests for User Story 2
+
+- [ ] T012 [P] [US2] Ginkgo/Gomega table test for `ValidateConfig` covering empty (default ok), `30s` (ok), `0s`/negative (error), unparsable (error), `>= 2m` (error), `>= 100s` (error), and `ServerURL == ""` (always nil) in `pkg/iaas/client/client_test.go` (include `Label(...)`)
+- [ ] T013 [P] [US2] Test confirming both CNI ADD and CNI DEL share `constant.DefaultCNIClientTimeout` (value-equality assertion) so the validation budget matches both flows (SC-003), in `cmd/spiderpool/cmd/command_test.go` or `pkg/constant` test
+
+### Implementation for User Story 2
+
+- [ ] T014 [US2] Extend `ValidateConfig` in `pkg/iaas/client/client.go` to validate `HTTPRequestTimeout` when `ServerURL != ""`: parse, `> 0`, `< constant.IaaSTimeoutStaticLimit`, `< constant.DefaultCNIClientTimeout`; return errors that name the configured value and the violated limit (depends on T002, T003)
+- [ ] T015 [US2] In `cmd/spiderpool-agent/cmd/daemon.go`, make IaaS config validation failure fatal (currently a warning at lines ~83-85) when `ServerURL != ""`, so an unsafe timeout aborts startup
+- [ ] T016 [US2] In `cmd/spiderpool-controller/cmd/daemon.go`, make IaaS config validation failure fatal (currently a warning at lines ~86-88) when `ServerURL != ""`, mirroring the agent
+
+**Checkpoint**: Unsafe values are rejected at startup; ADD/DEL share one validated budget.
+
+---
+
+## Phase 5: User Story 3 - Diagnose Timeout Decisions (Priority: P2)
+
+**Goal**: Operators get clear, distinct messages for provider timeout, parent-budget
+rejection, invalid configuration, and provider errors.
+
+**Independent Test**: Trigger each case (slow provider, exhausted context budget,
+invalid config) and confirm the messages distinguish the outcomes and include the
+configured value and the relevant budget.
+
+### Tests for User Story 3
+
+- [ ] T017 [P] [US3] Ginkgo/Gomega test that the client returns a distinct "parent budget exhausted" error (without issuing the request) when `ctx.Deadline()` is already passed, in `pkg/iaas/client/client_test.go` (include `Label(...)`)
+- [ ] T018 [P] [US3] Test that a provider-timeout failure produces a message identifying a provider-interaction timeout (distinct from validation/budget errors), in `pkg/iaas/client/client_test.go`
+
+### Implementation for User Story 3
+
+- [ ] T019 [US3] In `pkg/iaas/client/client.go` `AllocateIPs` and `releaseSingleIP`, before `http.NewRequestWithContext`, check `ctx.Deadline()`; if `time.Until(deadline) <= 0` return a clear "parent budget exhausted" error without calling the provider (effective bound becomes `min(httpRequestTimeout, remaining budget)`)
+- [ ] T020 [US3] Ensure timeout/transport errors from `httpClient.Do` are wrapped with an operator-facing message that identifies a provider-interaction timeout, and that validation errors (US2) name the configured value and limit, keeping the four outcomes distinct (FR-012, SC-005)
+
+**Checkpoint**: All three user stories independently functional and diagnosable.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [ ] T021 [P] Add/update English operator docs for `iaasNetworkProvider.httpRequestTimeout` (name, default `30s`, duration format, valid/invalid examples, the `< parent budget` requirement) under `docs/`
+- [ ] T022 [P] Add/update the synchronized Chinese localized docs for the same content under `docs/` (per AGENTS.md EN+ZH requirement)
+- [ ] T023 Run `make gofmt` and `make lint-golang` and fix any findings
+- [ ] T024 Run `make unittest-tests` and ensure all new/updated tests pass with required Ginkgo labels
+- [ ] T025 Run the `quickstart.md` Helm-render and negative-validation checks to confirm operator-facing behavior
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup. BLOCKS all user stories (T002/T003 provide the constant + field used everywhere).
+- **User Story 1 (Phase 3)**: Depends on Foundational.
+- **User Story 2 (Phase 4)**: Depends on Foundational. T014 reuses `ValidateConfig`; independent of US1 but typically lands together.
+- **User Story 3 (Phase 5)**: Depends on Foundational. Builds on the client call sites; independently testable.
+- **Polish (Phase 6)**: Depends on all targeted user stories.
+
+### Key task dependencies
+
+- T002, T003 → T004, T005, T010, T014 (constant + field consumed)
+- T010 (NewClient applies timeout) → independent of T014 but both touch `client.go`
+- T014 (ValidateConfig) → T015, T016 (daemons rely on validation being authoritative)
+- T019, T020 share `client.go` with T010/T014; sequence edits to that file to avoid conflicts.
+
+### Parallel Opportunities
+
+- T002 and T003 can run in parallel (different files).
+- US1: T006, T007 (tests) parallel; T008, T009 (chart) parallel.
+- US2: T012, T013 (tests) parallel.
+- US3: T017, T018 (tests) parallel.
+- Polish: T021, T022 (EN/ZH docs) parallel.
+- Note: edits within `pkg/iaas/client/client.go` (T010, T014, T019, T020) touch the same file — do NOT mark those [P]; sequence them.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Tests (different files) in parallel:
+Task: "NewClient timeout unit test in pkg/iaas/client/client_test.go"
+Task: "Helm rendering test for httpRequestTimeout in charts/spiderpool tests"
+
+# Chart edits (different files) in parallel:
+Task: "Add httpRequestTimeout to charts/spiderpool/values.yaml"
+Task: "Render httpRequestTimeout in charts/spiderpool/templates/configmap.yaml"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 + 2)
+
+US1 and US2 are both P1 and together form the safety-critical MVP: configurable
+timeout (US1) is only safe with validation (US2).
+
+1. Phase 1 Setup → Phase 2 Foundational.
+2. Phase 3 (US1) → validate config flows to the client.
+3. Phase 4 (US2) → validate unsafe values are rejected at startup.
+4. STOP and VALIDATE: render chart + start components with valid/invalid values.
+
+### Incremental Delivery
+
+1. Foundational ready (constant + field, CNI uses constant).
+2. US1 → configurable timeout applied. Demo Helm render + client behavior.
+3. US2 → startup validation. Demo rejection of unsafe values.
+4. US3 → diagnostics. Demo distinct error messages.
+5. Polish → EN/ZH docs, lint, tests, quickstart verification.
+
+---
+
+## Notes
+
+- [P] = different files, no dependency on incomplete tasks.
+- Tests precede or accompany implementation per the Constitution; verify they fail first where applicable.
+- Backward compatible: empty/unset `httpRequestTimeout` defaults to `30s`; empty `serverUrl` disables IaaS and skips validation.
+- No CRD/OpenAPI/deepcopy generation required; only the chart README table is regenerated/updated.


### PR DESCRIPTION
* add httpRequestTimeout parameter to iaasNetworkProvider in values.yaml and README
* add HTTPRequestTimeout field to IaaSProviderConfig in types
* add timeout constants in pkg/constant/timeout.go with validation limits
* validate httpRequestTimeout in ValidateConfig against static and CNI client limits
* apply configured timeout to IaaS HTTP client in NewClient
* check parent context budget before IaaS API calls in AllocateIPs and

# Thanks for contributing!

**Notice**:

* [ ] unite test or E2E test
* [ ] do not forget essential code comment and log
* [ ] document for the PR
* [ ] release note label
  "release/none"
  "release/bug"
  "release/feature"
* [ ] read about  Contribution notice: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>

**What issue(s) does this PR fix**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
