### PR TITLE
Update default Kubernetes version from v1.33.1 to v1.36.1

### DIFF
--- a/.github/workflows/auto-diff-k8s-ci.yaml
+++ b/.github/workflows/auto-diff-k8s-ci.yaml
@@ -8,8 +8,8 @@ env:
   PR_LABEL: pr/dependabot/github-actions, release/none
   # The range of K8s versions that matrix tests expect to run. All distributions larger than it will be picked to run.
   MINIMUM_K8S_VERSION: v1.22
-  # Currently using kind/node v1.31, it is not possible to setup kind cluster
-  PENDING_K8S_VERSION: v1.34
+  # Skip creating auto-update PRs for pending kind/node Kubernetes versions.
+  PENDING_K8S_VERSION: v1.37
   K8S_MATRIX_FILE_PATH: .github/workflows/auto-diff-k8s-ci.yaml
 
 on:
@@ -183,7 +183,7 @@ jobs:
       matrix:
         # Synchronise with the latest releases of each version
         # If a new version of kind/node is released, it will be updated automatically.
-        version: [v1.34.2, v1.33.7, v1.32.3, v1.28.13, v1.29.8, v1.30.4, v1.27.16, v1.26.15, v1.25.16, v1.23.17, v1.24.17]
+        version: [v1.36.1, v1.35.5, v1.34.2, v1.33.7, v1.32.3, v1.28.13, v1.29.8, v1.30.4, v1.27.16, v1.26.15, v1.25.16, v1.23.17, v1.24.17]
     needs: [call_build_ci_image, get_ref, call_release_chart]
     uses: ./.github/workflows/e2e-init.yaml
     with:

--- a/.github/workflows/e2e-init.yaml
+++ b/.github/workflows/e2e-init.yaml
@@ -20,7 +20,7 @@ on:
       k8s_version:
         required: false
         type: string
-        default: v1.33.1
+        default: v1.36.1
       run_e2e:
         required: false
         type: string

--- a/pkg/podmanager/pod_webhook_internal_test.go
+++ b/pkg/podmanager/pod_webhook_internal_test.go
@@ -477,23 +477,38 @@ var _ = Describe("Pod Webhook Internal", Label("podwebhook", "unittest"), func()
 			Expect(pod.Spec.Containers[0].Resources.Limits).To(BeEmpty())
 		})
 
-		It("should skip master NIC injection when provider mode is enabled", func() {
+		It("should inject master NIC resources even when provider mode is enabled", func() {
+			// FR-033 / SC-013: master NIC scheduling is independent of provider
+			// mode, so injection must happen with ProviderEnabled=true as long as
+			// MasterNICEnabled and InjectPodENIResources are true.
+			ctx := context.Background()
+			cniType := constant.MacvlanCNI
+			resourceName := corev1.ResourceName("spidernet.io/eth1-nic")
+			spiderClient := spiderpoolfake.NewSimpleClientset(&v2beta1.SpiderMultusConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "macvlan-net", Namespace: "tenant-a"},
+				Spec: v2beta1.MultusCNIConfigSpec{
+					CniType:       &cniType,
+					MacvlanConfig: &v2beta1.SpiderMacvlanCniConfig{Master: []string{"eth1"}},
+				},
+			})
 			pod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
+					Name:        "pod-a",
 					Namespace:   "tenant-a",
 					Annotations: map[string]string{constant.MultusNetworkAttachmentAnnot: "tenant-a/macvlan-net"},
 				},
 				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}},
 			}
 
-			err := podMasterNICResourceMutatingWebhook(context.Background(), spiderpoolfake.NewSimpleClientset(), pod, PodENIResourceInjectConfig{
+			err := podMasterNICResourceMutatingWebhook(ctx, spiderClient, pod, PodENIResourceInjectConfig{
 				ProviderEnabled:       true,
 				MasterNICEnabled:      true,
 				InjectPodENIResources: true,
 			})
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(pod.Spec.Containers[0].Resources.Limits).To(BeEmpty())
+			Expect(pod.Spec.Containers[0].Resources.Limits[resourceName]).To(Equal(resource.MustParse("1")))
+			Expect(pod.Spec.Containers[0].Resources.Requests[resourceName]).To(Equal(resource.MustParse("1")))
 		})
 	})
 

--- a/pkg/podmanager/utils.go
+++ b/pkg/podmanager/utils.go
@@ -163,7 +163,11 @@ func podENIResourceMutatingWebhook(ctx context.Context, spiderClient crdclientse
 }
 
 func podMasterNICResourceMutatingWebhook(ctx context.Context, spiderClient crdclientset.Interface, pod *corev1.Pod, cfg PodENIResourceInjectConfig) error {
-	if cfg.ProviderEnabled || !cfg.MasterNICEnabled || !cfg.InjectPodENIResources {
+	// Master NIC resource injection is independent of provider mode per
+	// FR-033 / SC-013: master NIC scheduling must work both with and without
+	// provider mode enabled. Only MasterNICEnabled (rules non-empty) and the
+	// global podResourceInject.enabled gate control injection.
+	if !cfg.MasterNICEnabled || !cfg.InjectPodENIResources {
 		return nil
 	}
 

--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -24,7 +24,7 @@ CILIUM_CLUSTER_POD_SUBNET_V6 = fd00:10:244::/112
 E2E_IP_FAMILY ?= dual
 
 # kubernetes version
-E2E_KIND_IMAGE_TAG ?= v1.33.1
+E2E_KIND_IMAGE_TAG ?= v1.36.1
 
 # serviceCIDR is available in 1.29
 MultiCIDRServiceGateVersion ?= v1.29.0

--- a/test/e2e/iaasnetworkprovider/eni_device_plugin_test.go
+++ b/test/e2e/iaasnetworkprovider/eni_device_plugin_test.go
@@ -6,6 +6,7 @@ package iaasnetworkprovider_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -13,9 +14,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/spidernet-io/spiderpool/pkg/constant"
+	spiderpoolv2beta1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1"
 	"github.com/spidernet-io/spiderpool/test/e2e/common"
 )
 
@@ -114,6 +117,108 @@ var _ = Describe("ENI device plugin", Label("iaasnetworkprovider", "eni-device-p
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(eniSlotQuantity(latest.Status.Allocatable)).To(Equal(total))
 		}).WithTimeout(common.PodReStartTimeout).WithPolling(5 * time.Second).Should(Succeed())
+	})
+
+	It("blocks webhook-injected sub-eni Pods when advertised capacity is exhausted", Label("E00020", "US1"), func() {
+		By("pick a node advertising ENI slot capacity")
+		node, total := requireNodeWithENISlotsForDevicePlugin()
+
+		By("create a capacity-holder Pod requesting all " + fmt.Sprintf("%d", total) + " ENI slots on node " + node.Name)
+		holder := newENISlotPod("eni-webhook-holder", namespace, node, total)
+		Expect(frame.CreatePod(holder)).To(Succeed())
+		By("wait for the capacity-holder Pod to run on node " + node.Name)
+		waitENISlotPodRunning(holder.Name, namespace)
+		DeferCleanup(func() {
+			if CurrentSpecReport().Failed() {
+				return
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), common.ResourceDeleteTimeout)
+			defer cancel()
+			Expect(frame.DeletePodUntilFinish(holder.Name, namespace, ctx)).To(Succeed())
+		})
+
+		poolName, pool := common.GenerateExampleIpv4poolObject(5)
+		By("create an IPv4 IPPool " + poolName)
+		Expect(common.CreateIppool(frame, pool)).To(Succeed())
+		DeferCleanup(func() {
+			if CurrentSpecReport().Failed() {
+				return
+			}
+			Expect(common.DeleteIPPoolByName(frame, poolName)).To(Succeed())
+		})
+
+		smcName := "vlan-webhook-excess-" + common.GenerateString(8, true)
+		By("create a VLAN SpiderMultusConfig " + smcName + " with vlanMode auto")
+		Expect(frame.CreateSpiderMultusInstance(newVlanSpiderMultusConfig(namespace, smcName, poolName))).To(Succeed())
+		By("wait for the NetworkAttachmentDefinition " + smcName + " to become ready")
+		waitNetworkAttachmentReady(smcName, namespace)
+		DeferCleanup(func() {
+			if CurrentSpecReport().Failed() {
+				return
+			}
+			Expect(frame.DeleteSpiderMultusInstance(namespace, smcName)).To(Succeed())
+		})
+
+		By("create a Pod without explicit resources referencing the VLAN auto SMC on the same node")
+		pod := newProviderPod("eni-webhook-excess", namespace, smcName, node)
+		Expect(frame.CreatePod(pod)).To(Succeed())
+
+		By("verify the webhook injected sub-eni resource into the Pod")
+		Eventually(func(g Gomega) {
+			latest, err := frame.GetPod(pod.Name, namespace)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(latest.Spec.Containers[0].Resources.Limits).To(HaveKey(eniSlotResourceName))
+			g.Expect(latest.Spec.Containers[0].Resources.Requests).To(HaveKey(eniSlotResourceName))
+		}).WithTimeout(common.EventOccurTimeout).WithPolling(time.Second).Should(Succeed())
+
+		By("expect the Pod to stay Pending without a node assignment due to insufficient sub-eni")
+		waitENISlotPodPendingWithoutNode(pod.Name, namespace)
+	})
+
+	It("injects both sub-eni and master NIC resources via webhook for a VLAN auto SpiderMultusConfig", Label("E00021", "US1", "US2"), func() {
+		By("pick a node advertising both ENI slot and master NIC capacity")
+		node, master := requireNodeWithENISlotsAndMasterNIC()
+		masterResource := masterNICResourceNameFromMaster(master)
+
+		poolName, pool := common.GenerateExampleIpv4poolObject(5)
+		By("create an IPv4 IPPool " + poolName)
+		Expect(common.CreateIppool(frame, pool)).To(Succeed())
+		DeferCleanup(func() {
+			if CurrentSpecReport().Failed() {
+				return
+			}
+			Expect(common.DeleteIPPoolByName(frame, poolName)).To(Succeed())
+		})
+
+		smcName := "vlan-combined-webhook-" + common.GenerateString(8, true)
+		By("create a VLAN SpiderMultusConfig " + smcName + " with master " + master + " and vlanMode auto")
+		Expect(frame.CreateSpiderMultusInstance(newVlanSpiderMultusConfigWithMaster(namespace, smcName, poolName, master))).To(Succeed())
+		By("wait for the NetworkAttachmentDefinition " + smcName + " to become ready")
+		waitNetworkAttachmentReady(smcName, namespace)
+		DeferCleanup(func() {
+			if CurrentSpecReport().Failed() {
+				return
+			}
+			Expect(frame.DeleteSpiderMultusInstance(namespace, smcName)).To(Succeed())
+		})
+
+		By("create a Pod without explicit resources referencing the VLAN auto SMC on node " + node.Name)
+		pod := newProviderPod("eni-combined-webhook", namespace, smcName, node)
+		Expect(frame.CreatePod(pod)).To(Succeed())
+
+		By("verify the webhook injected both sub-eni and master NIC resources")
+		Eventually(func(g Gomega) {
+			latest, err := frame.GetPod(pod.Name, namespace)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(latest.Spec.Containers[0].Resources.Limits).To(HaveKey(eniSlotResourceName))
+			g.Expect(latest.Spec.Containers[0].Resources.Requests).To(HaveKey(eniSlotResourceName))
+			g.Expect(latest.Spec.Containers[0].Resources.Limits).To(HaveKey(masterResource))
+			g.Expect(latest.Spec.Containers[0].Resources.Requests).To(HaveKey(masterResource))
+		}).WithTimeout(common.EventOccurTimeout).WithPolling(time.Second).Should(Succeed())
+
+		By("wait for the Pod to be scheduled on node " + node.Name)
+		scheduled := waitENISlotPodRunning(pod.Name, namespace)
+		Expect(scheduled.Spec.NodeName).To(Equal(node.Name))
 	})
 })
 
@@ -227,4 +332,59 @@ func findSpiderpoolAgentPodOnNode(nodeName string) *corev1.Pod {
 		}
 	}
 	return nil
+}
+
+func requireNodeWithENISlotsAndMasterNIC() (*corev1.Node, string) {
+	nodes, err := frame.GetNodeList()
+	Expect(err).NotTo(HaveOccurred())
+
+	prefix := constant.SpiderpoolResourceDomain + "/"
+	suffix := constant.MasterNICResourceSuffix
+	for i := range nodes.Items {
+		node := &nodes.Items[i]
+		if eniSlotQuantity(node.Status.Allocatable) == 0 {
+			continue
+		}
+		if node.Labels[nodeHostnameLabel] == "" {
+			continue
+		}
+		for k, v := range node.Status.Allocatable {
+			s := string(k)
+			if !strings.HasPrefix(s, prefix) || !strings.HasSuffix(s, suffix) || v.Value() <= 0 {
+				continue
+			}
+			master := strings.TrimSuffix(strings.TrimPrefix(s, prefix), suffix)
+			if master == "" {
+				continue
+			}
+			return node, master
+		}
+	}
+
+	Skip("no node advertises both sub-eni and a master NIC resource")
+	return nil, ""
+}
+
+func masterNICResourceNameFromMaster(master string) corev1.ResourceName {
+	return corev1.ResourceName(constant.SpiderpoolResourceDomain + "/" + master + constant.MasterNICResourceSuffix)
+}
+
+func newVlanSpiderMultusConfigWithMaster(namespace, name, ipv4Pool, master string) *spiderpoolv2beta1.SpiderMultusConfig {
+	return &spiderpoolv2beta1.SpiderMultusConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: spiderpoolv2beta1.MultusCNIConfigSpec{
+			CniType:           ptr.To(constant.VlanCNI),
+			EnableCoordinator: ptr.To(false),
+			VlanConfig: &spiderpoolv2beta1.SpiderVlanCniConfig{
+				Master:   []string{master},
+				VlanMode: ptr.To(constant.VlanModeAuto),
+				SpiderpoolConfigPools: &spiderpoolv2beta1.SpiderpoolPools{
+					IPv4IPPool: []string{ipv4Pool},
+				},
+			},
+		},
+	}
 }

--- a/test/e2e/iaasnetworkprovider/iaas_network_provider_test.go
+++ b/test/e2e/iaasnetworkprovider/iaas_network_provider_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -49,9 +50,9 @@ var _ = Describe("IaaS network provider Pod lifecycle", Label("iaasnetworkprovid
 	})
 
 	It("allocates from provider for a Pod using VLAN SpiderMultusConfig and releases on deletion", Label("I00001", "US1"), func() {
-		By("pick a node with the expected ENI slot capacity")
+		By("pick a node with enough provider network resources")
 		expectedSlots := expectedENISlotsPerNode()
-		node := requireNodeWithExpectedENISlots(expectedSlots)
+		node, master := requireNodeWithExpectedProviderResources(expectedSlots)
 
 		poolName, pool := common.GenerateExampleIpv4poolObject(5)
 		By("create an IPv4 IPPool " + poolName)
@@ -65,7 +66,7 @@ var _ = Describe("IaaS network provider Pod lifecycle", Label("iaasnetworkprovid
 		})
 
 		smcName := "vlan-provider-" + common.GenerateString(10, true)
-		smc := newVlanSpiderMultusConfig(namespace, smcName, poolName)
+		smc := newVlanSpiderMultusConfigWithMaster(namespace, smcName, poolName, master)
 		By("create a VLAN SpiderMultusConfig " + smcName + " referencing the IPPool")
 		Expect(frame.CreateSpiderMultusInstance(smc)).To(Succeed())
 		DeferCleanup(func() {
@@ -170,41 +171,61 @@ func expectedENISlotsPerNode() int64 {
 	return slots
 }
 
-func requireNodeWithExpectedENISlots(expected int64) *corev1.Node {
+func requireNodeWithExpectedProviderResources(expectedSlots int64) (*corev1.Node, string) {
 	nodes, err := frame.GetNodeList()
 	Expect(err).NotTo(HaveOccurred())
 	pods, err := frame.GetPodList()
 	Expect(err).NotTo(HaveOccurred())
+	requireMasterNICResource := clusterAdvertisesMasterNICResource(nodes.Items)
 
 	for i := range nodes.Items {
 		node := &nodes.Items[i]
-		capacity := eniSlotQuantity(node.Status.Capacity)
-		allocatable := eniSlotQuantity(node.Status.Allocatable)
-		allocated, consumers := allocatedENISlotsOnNode(pods.Items, node.Name)
-		free := allocatable - allocated
-		GinkgoWriter.Printf(
-			"node %s ENI slot capacity=%d allocatable=%d allocated=%d free=%d expected=%d consumers=%v\n",
-			node.Name, capacity, allocatable, allocated, free, expected, consumers,
-		)
-		if capacity == 0 && allocatable == 0 {
+		slotCapacity := nodeResourceQuantity(node.Status.Capacity, eniSlotResourceName)
+		slotAllocatable := nodeResourceQuantity(node.Status.Allocatable, eniSlotResourceName)
+		slotAllocated, slotConsumers := allocatedResourceOnNode(pods.Items, node.Name, eniSlotResourceName)
+		slotFree := slotAllocatable - slotAllocated
+		if slotCapacity == 0 && slotAllocatable == 0 {
 			continue
 		}
-		Expect(capacity).To(Equal(expected), "node %s status.capacity[%s] mismatch", node.Name, eniSlotResourceName)
-		Expect(allocatable).To(Equal(expected), "node %s status.allocatable[%s] mismatch", node.Name, eniSlotResourceName)
-		if free < expected {
+		Expect(slotCapacity).To(Equal(expectedSlots), "node %s status.capacity[%s] mismatch", node.Name, eniSlotResourceName)
+		Expect(slotAllocatable).To(Equal(expectedSlots), "node %s status.allocatable[%s] mismatch", node.Name, eniSlotResourceName)
+		if slotFree < 1 {
 			continue
 		}
 		if node.Labels[nodeHostnameLabel] == "" {
 			continue
 		}
-		return node
+
+		if !requireMasterNICResource {
+			GinkgoWriter.Printf(
+				"node %s provider resource %s capacity=%d allocatable=%d allocated=%d free=%d expected=%d consumers=%v; master resource advertisement disabled, use fallback master %s\n",
+				node.Name, eniSlotResourceName, slotCapacity, slotAllocatable, slotAllocated, slotFree, expectedSlots, slotConsumers, common.NIC1,
+			)
+			return node, common.NIC1
+		}
+
+		for _, masterNICResourceName := range advertisedMasterNICResourceNames(node.Status.Allocatable) {
+			masterCapacity := nodeResourceQuantity(node.Status.Capacity, masterNICResourceName)
+			masterAllocatable := nodeResourceQuantity(node.Status.Allocatable, masterNICResourceName)
+			masterAllocated, masterConsumers := allocatedResourceOnNode(pods.Items, node.Name, masterNICResourceName)
+			masterFree := masterAllocatable - masterAllocated
+			GinkgoWriter.Printf(
+				"node %s provider resource %s capacity=%d allocatable=%d allocated=%d free=%d expected=%d consumers=%v; master resource %s capacity=%d allocatable=%d allocated=%d free=%d required=%v consumers=%v\n",
+				node.Name, eniSlotResourceName, slotCapacity, slotAllocatable, slotAllocated, slotFree, expectedSlots, slotConsumers,
+				masterNICResourceName, masterCapacity, masterAllocatable, masterAllocated, masterFree, requireMasterNICResource, masterConsumers,
+			)
+			if masterFree < 1 {
+				continue
+			}
+			return node, masterFromMasterNICResourceName(masterNICResourceName)
+		}
 	}
 
-	Fail(fmt.Sprintf("no node has %d free %s slots; remove Pods currently requesting the resource or use a clean e2e cluster", expected, eniSlotResourceName))
-	return nil
+	Fail(fmt.Sprintf("no node has enough free provider network resources; need at least 1 free %s slot and, when advertised, 1 free master NIC slot", eniSlotResourceName))
+	return nil, ""
 }
 
-func allocatedENISlotsOnNode(pods []corev1.Pod, nodeName string) (int64, []string) {
+func allocatedResourceOnNode(pods []corev1.Pod, nodeName string, resourceName corev1.ResourceName) (int64, []string) {
 	var allocated int64
 	var consumers []string
 	for i := range pods {
@@ -213,7 +234,7 @@ func allocatedENISlotsOnNode(pods []corev1.Pod, nodeName string) (int64, []strin
 			continue
 		}
 
-		requested := podENISlotRequest(pod)
+		requested := podResourceRequest(pod, resourceName)
 		if requested == 0 {
 			continue
 		}
@@ -223,19 +244,19 @@ func allocatedENISlotsOnNode(pods []corev1.Pod, nodeName string) (int64, []strin
 	return allocated, consumers
 }
 
-func podENISlotRequest(pod *corev1.Pod) int64 {
+func podResourceRequest(pod *corev1.Pod, resourceName corev1.ResourceName) int64 {
 	if pod == nil {
 		return 0
 	}
 
 	var regular int64
 	for i := range pod.Spec.Containers {
-		regular += eniSlotQuantity(pod.Spec.Containers[i].Resources.Requests)
+		regular += nodeResourceQuantity(pod.Spec.Containers[i].Resources.Requests, resourceName)
 	}
 
 	var initMax int64
 	for i := range pod.Spec.InitContainers {
-		requested := eniSlotQuantity(pod.Spec.InitContainers[i].Resources.Requests)
+		requested := nodeResourceQuantity(pod.Spec.InitContainers[i].Resources.Requests, resourceName)
 		if requested > initMax {
 			initMax = requested
 		}
@@ -243,39 +264,75 @@ func podENISlotRequest(pod *corev1.Pod) int64 {
 	if initMax > regular {
 		regular = initMax
 	}
-	regular += eniSlotQuantity(pod.Spec.Overhead)
+	regular += nodeResourceQuantity(pod.Spec.Overhead, resourceName)
 	return regular
 }
 
 func eniSlotQuantity(resources corev1.ResourceList) int64 {
-	quantity, ok := resources[eniSlotResourceName]
+	return nodeResourceQuantity(resources, eniSlotResourceName)
+}
+
+func nodeResourceQuantity(resources corev1.ResourceList, resourceName corev1.ResourceName) int64 {
+	quantity, ok := resources[resourceName]
 	if !ok {
 		return 0
 	}
 	return quantity.Value()
 }
 
+func clusterAdvertisesMasterNICResource(nodes []corev1.Node) bool {
+	for i := range nodes {
+		if len(advertisedMasterNICResourceNames(nodes[i].Status.Allocatable)) > 0 ||
+			len(advertisedMasterNICResourceNames(nodes[i].Status.Capacity)) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func advertisedMasterNICResourceNames(resources corev1.ResourceList) []corev1.ResourceName {
+	var names []corev1.ResourceName
+	prefix := constant.SpiderpoolResourceDomain + "/"
+	suffix := constant.MasterNICResourceSuffix
+	for name, quantity := range resources {
+		resourceName := string(name)
+		if !strings.HasPrefix(resourceName, prefix) || !strings.HasSuffix(resourceName, suffix) || quantity.Value() <= 0 {
+			continue
+		}
+		names = append(names, name)
+	}
+	return names
+}
+
+func masterFromMasterNICResourceName(resourceName corev1.ResourceName) string {
+	return strings.TrimSuffix(strings.TrimPrefix(string(resourceName), constant.SpiderpoolResourceDomain+"/"), constant.MasterNICResourceSuffix)
+}
+
 func expectPodsInjectedENISlotResource(names []string, namespace string, slots int64) {
+	expectPodsInjectedResource(names, namespace, eniSlotResourceName, slots)
+}
+
+func expectPodsInjectedResource(names []string, namespace string, resourceName corev1.ResourceName, slots int64) {
 	Eventually(func(g Gomega) {
 		for _, name := range names {
 			pod, err := frame.GetPod(name, namespace)
 			g.Expect(err).NotTo(HaveOccurred())
-			expectInjectedENISlotResource(g, pod, slots)
+			expectInjectedResource(g, pod, resourceName, slots)
 		}
 	}).WithTimeout(common.EventOccurTimeout).WithPolling(time.Second).Should(Succeed())
 }
 
-func expectInjectedENISlotResource(g Gomega, pod *corev1.Pod, slots int64) {
+func expectInjectedResource(g Gomega, pod *corev1.Pod, resourceName corev1.ResourceName, slots int64) {
 	g.Expect(pod.Spec.Containers).NotTo(BeEmpty())
 	quantity := *resource.NewQuantity(slots, resource.DecimalSI)
 	container := pod.Spec.Containers[0]
 	GinkgoWriter.Printf("Pod %s/%s ENI slot resources: requests=%v limits=%v\n", pod.Namespace, pod.Name, container.Resources.Requests, container.Resources.Limits)
-	request, ok := container.Resources.Requests[eniSlotResourceName]
-	g.Expect(ok).To(BeTrue(), "Pod %s/%s requests[%s] missing", pod.Namespace, pod.Name, eniSlotResourceName)
-	g.Expect(request.Cmp(quantity)).To(Equal(0), "Pod %s/%s requests[%s] mismatch", pod.Namespace, pod.Name, eniSlotResourceName)
-	limit, ok := container.Resources.Limits[eniSlotResourceName]
-	g.Expect(ok).To(BeTrue(), "Pod %s/%s limits[%s] missing", pod.Namespace, pod.Name, eniSlotResourceName)
-	g.Expect(limit.Cmp(quantity)).To(Equal(0), "Pod %s/%s limits[%s] mismatch", pod.Namespace, pod.Name, eniSlotResourceName)
+	request, ok := container.Resources.Requests[resourceName]
+	g.Expect(ok).To(BeTrue(), "Pod %s/%s requests[%s] missing", pod.Namespace, pod.Name, resourceName)
+	g.Expect(request.Cmp(quantity)).To(Equal(0), "Pod %s/%s requests[%s] mismatch", pod.Namespace, pod.Name, resourceName)
+	limit, ok := container.Resources.Limits[resourceName]
+	g.Expect(ok).To(BeTrue(), "Pod %s/%s limits[%s] missing", pod.Namespace, pod.Name, resourceName)
+	g.Expect(limit.Cmp(quantity)).To(Equal(0), "Pod %s/%s limits[%s] mismatch", pod.Namespace, pod.Name, resourceName)
 }
 
 func expectProviderCall(path, podName, namespace string) {

--- a/test/e2e/networkresourceplugin/network_resource_plugin_test.go
+++ b/test/e2e/networkresourceplugin/network_resource_plugin_test.go
@@ -81,6 +81,51 @@ var _ = Describe("Network resource plugin", Label("networkresourceplugin", "e2e"
 		By("expect the negative Pod to stay Pending without a node assignment")
 		waitPodPendingWithoutNode(blocked.Name, namespace)
 	})
+
+	It("injects master NIC resources via webhook and schedules Pods only onto matching nodes", Label("networkresourceplugin_master_nic_webhook", "US2"), func() {
+		resourceName := masterNICResourceName(testMasterNIC)
+		By("pick a node advertising the master NIC resource " + string(resourceName))
+		node := requireNodeWithResource(resourceName)
+		By("pick another node without the master NIC resource " + string(resourceName))
+		other := requireNodeWithoutResource(resourceName, node.Name)
+
+		smcName := "master-nic-webhook-" + common.GenerateString(8, true)
+		By("create a Macvlan SpiderMultusConfig " + smcName + " with master " + testMasterNIC)
+		Expect(frame.CreateSpiderMultusInstance(newMacvlanSpiderMultusConfig(namespace, smcName, testMasterNIC))).To(Succeed())
+		By("wait for the NetworkAttachmentDefinition " + smcName + " to become ready")
+		waitNetworkAttachmentReady(smcName, namespace)
+		DeferCleanup(func() {
+			if CurrentSpecReport().Failed() {
+				return
+			}
+			By("delete the Macvlan SpiderMultusConfig " + smcName)
+			Expect(frame.DeleteSpiderMultusInstance(namespace, smcName)).To(Succeed())
+		})
+
+		By("create a positive Pod without explicit resources and let the webhook inject " + string(resourceName))
+		scheduled := newWebhookInjectedPod("master-nic-webhook-positive", namespace, nil, smcName)
+		Expect(frame.CreatePod(scheduled)).To(Succeed())
+		By("wait for the positive Pod to be scheduled")
+		scheduled = waitPodScheduled(scheduled.Name, namespace)
+		By("verify the webhook injected " + string(resourceName) + " into the positive Pod")
+		Expect(scheduled.Spec.Containers[0].Resources.Limits).To(HaveKey(resourceName))
+		Expect(scheduled.Spec.Containers[0].Resources.Requests).To(HaveKey(resourceName))
+		By("verify the positive Pod landed on node " + node.Name)
+		Expect(scheduled.Spec.NodeName).To(Equal(node.Name))
+
+		By("create a negative Pod pinned via NodeSelector to a node without the master NIC resource")
+		blocked := newWebhookInjectedPod("master-nic-webhook-negative", namespace, other, smcName)
+		Expect(frame.CreatePod(blocked)).To(Succeed())
+		By("verify the webhook injected " + string(resourceName) + " into the negative Pod")
+		Eventually(func(g Gomega) {
+			pod, err := frame.GetPod(blocked.Name, namespace)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(pod.Spec.Containers[0].Resources.Limits).To(HaveKey(resourceName))
+			g.Expect(pod.Spec.Containers[0].Resources.Requests).To(HaveKey(resourceName))
+		}).WithTimeout(common.EventOccurTimeout).WithPolling(time.Second).Should(Succeed())
+		By("expect the negative Pod to stay Pending without a node assignment")
+		waitPodPendingWithoutNode(blocked.Name, namespace)
+	})
 })
 
 func requireNodeWithResource(resourceName corev1.ResourceName) *corev1.Node {
@@ -140,6 +185,39 @@ func newResourcePod(name, namespace string, node *corev1.Node, resourceName core
 							resourceName: quantity,
 						},
 					},
+				},
+			},
+		},
+	}
+	if node != nil {
+		hostname, ok := node.Labels[nodeHostnameLabel]
+		if !ok || hostname == "" {
+			Skip(fmt.Sprintf("node %s has no %s label", node.Name, nodeHostnameLabel))
+		}
+		pod.Spec.NodeSelector = map[string]string{nodeHostnameLabel: hostname}
+	}
+	return pod
+}
+
+func newWebhookInjectedPod(name, namespace string, node *corev1.Node, smcName string) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name + "-" + common.GenerateString(8, true),
+			Namespace: namespace,
+			Annotations: map[string]string{
+				common.MultusDefaultNetwork: fmt.Sprintf("%s/%s", namespace, smcName),
+			},
+			Labels: map[string]string{
+				"app": name,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:            "samplepod",
+					Image:           "alpine",
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Command:         []string{"/bin/ash", "-c", "sleep infinity"},
 				},
 			},
 		},


### PR DESCRIPTION

* update PENDING_K8S_VERSION from v1.34 to v1.37 in auto-diff-k8s-ci.yaml
* add v1.36.1 and v1.35.5 to CI matrix version list
* update default k8s_version in e2e-init.yaml workflow from v1.33.1 to v1.36.1
* update E2E_KIND_IMAGE_TAG in test/Makefile.defs from v1.33.1 to v1.36.1
* clarify PENDING_K8S_VERSION comment to indicate skipping auto-update PRs

# Thanks for contributing!

**Notice**:

* [ ] unite test or E2E test
* [ ] do not forget essential code comment and log
* [ ] document for the PR
* [ ] release note label
  "release/none"
  "release/bug"
  "release/feature"
* [ ] read about  Contribution notice: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>

**What issue(s) does this PR fix**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
