### PR TITLE
ci: consolidate duplicate CI failure issues by updating existing issue

### DIFF
--- a/.github/workflows/auto-diff-k8s-ci.yaml
+++ b/.github/workflows/auto-diff-k8s-ci.yaml
@@ -206,14 +206,49 @@ jobs:
           echo ${{ github.repository_owner }}
           echo "TIMESTAMP=`date +%Y-%m-%d`" >> $GITHUB_ENV
 
-      - name: create an issue
-        uses: dacbd/create-issue-action@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          title: "Nightly K8s Matrix CI ${{ ENV.TIMESTAMP }}: Failed"
-          body: |
+      - name: create or update issue
+        uses: actions/github-script@v7
+        env:
+          ISSUE_PREFIX: "Nightly K8s Matrix CI "
+          ISSUE_BODY: |
             action url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          labels: "kind/ci-bug"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const issuePrefix = process.env.ISSUE_PREFIX;
+            const issueTitle = `${issuePrefix}${process.env.TIMESTAMP}: Failed`;
+            const issueBody = process.env.ISSUE_BODY;
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              labels: 'kind/ci-bug',
+              per_page: 100,
+            });
+            const existingIssue = issues.find(issue =>
+              !issue.pull_request && issue.title.startsWith(issuePrefix)
+            );
+
+            if (existingIssue) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: existingIssue.number,
+                body: `Another CI failure was reported:\n\n${issueBody}`,
+              });
+              core.info(`Updated existing issue #${existingIssue.number}: ${existingIssue.title}`);
+            } else {
+              const { data: issue } = await github.rest.issues.create({
+                owner,
+                repo,
+                title: issueTitle,
+                body: issueBody,
+                labels: ['kind/ci-bug'],
+              });
+              core.info(`Created issue #${issue.number}: ${issue.title}`);
+            }
 
   call_inputs_k8s:
     # workflow_dispatch event flow triggered by running the input k8s version

--- a/.github/workflows/auto-nightly-ci.yaml
+++ b/.github/workflows/auto-nightly-ci.yaml
@@ -200,11 +200,46 @@ jobs:
           echo ${{ github.repository_owner }}
           echo "TIMESTAMP=`date +%Y-%m-%d`" >> $GITHUB_ENV
 
-      - name: create an issue
-        uses: dacbd/create-issue-action@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          title: "Night CI ${{ ENV.TIMESTAMP }}: Failed"
-          body: |
+      - name: create or update issue
+        uses: actions/github-script@v7
+        env:
+          ISSUE_PREFIX: "Night CI "
+          ISSUE_BODY: |
             action url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          labels: "kind/ci-bug"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const issuePrefix = process.env.ISSUE_PREFIX;
+            const issueTitle = `${issuePrefix}${process.env.TIMESTAMP}: Failed`;
+            const issueBody = process.env.ISSUE_BODY;
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              labels: 'kind/ci-bug',
+              per_page: 100,
+            });
+            const existingIssue = issues.find(issue =>
+              !issue.pull_request && issue.title.startsWith(issuePrefix)
+            );
+
+            if (existingIssue) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: existingIssue.number,
+                body: `Another CI failure was reported:\n\n${issueBody}`,
+              });
+              core.info(`Updated existing issue #${existingIssue.number}: ${existingIssue.title}`);
+            } else {
+              const { data: issue } = await github.rest.issues.create({
+                owner,
+                repo,
+                title: issueTitle,
+                body: issueBody,
+                labels: ['kind/ci-bug'],
+              });
+              core.info(`Created issue #${issue.number}: ${issue.title}`);
+            }

--- a/.github/workflows/auto-upgrade-ci.yaml
+++ b/.github/workflows/auto-upgrade-ci.yaml
@@ -400,12 +400,47 @@ jobs:
           echo ${{ github.repository_owner }}
           echo "TIMESTAMP=`date +%Y-%m-%d`" >> $GITHUB_ENV
 
-      - name: create an issue
-        uses: dacbd/create-issue-action@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          title: "upgrade CI ${{ ENV.TIMESTAMP }}: Failed"
-          body: |
+      - name: create or update issue
+        uses: actions/github-script@v7
+        env:
+          ISSUE_PREFIX: "upgrade CI "
+          ISSUE_BODY: |
             action url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          labels: "kind/ci-bug"
-          assignees: "cyclinder"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const issuePrefix = process.env.ISSUE_PREFIX;
+            const issueTitle = `${issuePrefix}${process.env.TIMESTAMP}: Failed`;
+            const issueBody = process.env.ISSUE_BODY;
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              labels: 'kind/ci-bug',
+              per_page: 100,
+            });
+            const existingIssue = issues.find(issue =>
+              !issue.pull_request && issue.title.startsWith(issuePrefix)
+            );
+
+            if (existingIssue) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: existingIssue.number,
+                body: `Another CI failure was reported:\n\n${issueBody}`,
+              });
+              core.info(`Updated existing issue #${existingIssue.number}: ${existingIssue.title}`);
+            } else {
+              const { data: issue } = await github.rest.issues.create({
+                owner,
+                repo,
+                title: issueTitle,
+                body: issueBody,
+                labels: ['kind/ci-bug'],
+                assignees: ['cyclinder'],
+              });
+              core.info(`Created issue #${issue.number}: ${issue.title}`);
+            }


### PR DESCRIPTION
… issues instead of creating new ones

* replace dacbd/create-issue-action with actions/github-script@v7 in auto-diff-k8s-ci.yaml, auto-nightly-ci.yaml, and auto-upgrade-ci.yaml
* search for existing open issues with kind/ci-bug label matching issue title prefix
* add comment to existing issue when found instead of creating duplicate
* create new issue only when no matching open issue exists
* refactor IaaS provider e2e tests to support both ENI slot and master NIC resource validation

# Thanks for contributing!

**Notice**:

* [ ] unite test or E2E test
* [ ] do not forget essential code comment and log
* [ ] document for the PR
* [ ] release note label
  "release/none"
  "release/bug"
  "release/feature"
* [ ] read about  Contribution notice: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>

**What issue(s) does this PR fix**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
