### PR TITLE
docs: add X-Request-Timeout-Ms header to IaaS provider HTTP API 

### DIFF
--- a/docs/usage/iaas-network-provider-zh_CN.md
+++ b/docs/usage/iaas-network-provider-zh_CN.md
@@ -124,6 +124,7 @@ spiderpoolAgent:
 
 * 如果剩余时间**小于 Provider 最坏情况耗时**（~48 s），Spiderpool **不会发起调用**，直接返回 `parent budget insufficient` 错误。这样可以避免 Provider 已消耗令牌桶但 Spiderpool 收到取消错误的状态不一致。
 * 如果剩余时间充足，Spiderpool 会派生一个以 `httpRequestTimeout` 为上限的子 context 执行 HTTP 请求。实际生效的截止时间为 `min(当前时间 + httpRequestTimeout, 父 context 截止时间)`。
+* 对每次 Provider 调用，Spiderpool 会通过 `X-Request-Timeout-Ms` HTTP header 传递本次请求的有效剩余预算。该值是正整数，单位为毫秒，由 Spiderpool 在发送 HTTP 请求前基于请求 context 计算。Provider 可以用它约束限流等待、Cloud API 调用和内部重试，不需要依赖与 Spiderpool 机器的时钟同步。
 
 #### 错误信息说明
 
@@ -367,7 +368,14 @@ Provider 需要实现以下 HTTP API。
 ```text
 POST /v1/apis/network.iaas.io/ipam/allocate-ips
 Content-Type: application/json
+X-Request-Timeout-Ms: 50000
 ```
+
+请求 Header：
+
+| Header | 是否必填 | 说明 |
+| --- | --- | --- |
+| `X-Request-Timeout-Ms` | 是 | 本次请求的剩余预算，单位为毫秒。Provider 应将其视为从收到请求开始可用的最大处理时间，并应在该预算耗尽前返回。 |
 
 请求体：
 
@@ -443,7 +451,14 @@ Content-Type: application/json
 ```text
 POST /v1/apis/network.iaas.io/ipam/release-ip
 Content-Type: application/json
+X-Request-Timeout-Ms: 50000
 ```
+
+请求 Header：
+
+| Header | 是否必填 | 说明 |
+| --- | --- | --- |
+| `X-Request-Timeout-Ms` | 是 | 本次请求的剩余预算，单位为毫秒。Provider 应将其视为从收到请求开始可用的最大处理时间，并应在该预算耗尽前返回。 |
 
 请求体：
 

--- a/docs/usage/iaas-network-provider.md
+++ b/docs/usage/iaas-network-provider.md
@@ -124,6 +124,7 @@ Before sending each provider HTTP call, Spiderpool checks how much time remains 
 
 - If the remaining time is **less than the provider worst-case** (~48 s), Spiderpool **does not start the call** and returns a `parent budget insufficient` error immediately. This prevents the provider from consuming a rate-limit slot for a call that cannot complete, which would leave the cloud-side operation in an unknown state.
 - If the remaining time is sufficient, Spiderpool derives a per-call context bounded by `httpRequestTimeout`. The effective HTTP deadline is `min(now + httpRequestTimeout, parent deadline)`.
+- For each provider call, Spiderpool sends the effective remaining request budget in the `X-Request-Timeout-Ms` HTTP header. The value is a positive integer in milliseconds, calculated from the request context immediately before the HTTP request is sent. Provider implementations can use this value to bound rate-limit waiting, cloud API calls, and internal retries without relying on clock synchronization with Spiderpool.
 
 #### Error messages
 
@@ -371,7 +372,14 @@ The provider must implement the following HTTP APIs.
 ```text
 POST /v1/apis/network.iaas.io/ipam/allocate-ips
 Content-Type: application/json
+X-Request-Timeout-Ms: 50000
 ```
+
+Request headers:
+
+| Header | Required | Description |
+| --- | --- | --- |
+| `X-Request-Timeout-Ms` | Yes | Remaining request budget in milliseconds. The provider should treat this as the maximum time available from when it receives the request, and should return before this budget is exhausted. |
 
 Request body:
 
@@ -447,7 +455,14 @@ If `macAddress` or `vlanId` is empty, Spiderpool keeps the original allocation r
 ```text
 POST /v1/apis/network.iaas.io/ipam/release-ip
 Content-Type: application/json
+X-Request-Timeout-Ms: 50000
 ```
+
+Request headers:
+
+| Header | Required | Description |
+| --- | --- | --- |
+| `X-Request-Timeout-Ms` | Yes | Remaining request budget in milliseconds. The provider should treat this as the maximum time available from when it receives the request, and should return before this budget is exhausted. |
 
 Request body:
 

--- a/pkg/iaas/client/client.go
+++ b/pkg/iaas/client/client.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -23,8 +24,10 @@ import (
 )
 
 const (
-	allocateAPIPath = "/v1/apis/network.iaas.io/ipam/allocate-ips"
-	releaseAPIPath  = "/v1/apis/network.iaas.io/ipam/release-ip"
+	allocateAPIPath           = "/v1/apis/network.iaas.io/ipam/allocate-ips"
+	releaseAPIPath            = "/v1/apis/network.iaas.io/ipam/release-ip"
+	requestTimeoutMsHeader    = "X-Request-Timeout-Ms"
+	nanosecondsPerMillisecond = int64(time.Millisecond)
 )
 
 // isTimeoutError checks if an error is a timeout error
@@ -34,6 +37,21 @@ func isTimeoutError(err error) bool {
 	}
 	errStr := err.Error()
 	return strings.Contains(errStr, "timeout") || strings.Contains(errStr, "deadline exceeded")
+}
+
+func setRequestTimeoutHeader(httpReq *http.Request) {
+	deadline, ok := httpReq.Context().Deadline()
+	if !ok {
+		return
+	}
+
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return
+	}
+
+	timeoutMs := (int64(remaining) + nanosecondsPerMillisecond - 1) / nanosecondsPerMillisecond
+	httpReq.Header.Set(requestTimeoutMsHeader, strconv.FormatInt(timeoutMs, 10))
 }
 
 // Client is the interface for IaaS provider API client
@@ -181,6 +199,7 @@ func (c *IaaSClient) AllocateIPs(ctx context.Context, req *AllocateIPRequest) (*
 	}
 
 	httpReq.Header.Set("Content-Type", "application/json")
+	setRequestTimeoutHeader(httpReq)
 
 	// Execute request
 	resp, err := c.httpClient.Do(httpReq)
@@ -298,6 +317,7 @@ func (c *IaaSClient) releaseSingleIP(ctx context.Context, reqURL string, req *Re
 	}
 
 	httpReq.Header.Set("Content-Type", "application/json")
+	setRequestTimeoutHeader(httpReq)
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {

--- a/pkg/iaas/client/client_test.go
+++ b/pkg/iaas/client/client_test.go
@@ -6,6 +6,8 @@ package client
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -266,6 +268,87 @@ var _ = Describe("IaaS Client Context Deadline Handling", Label("unitest"), func
 			err = client.ReleaseIP(ctx, req)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("parent budget insufficient"))
+		})
+	})
+
+	Describe("request timeout header", func() {
+		It("should send remaining request timeout for allocate requests", Label("timeout-header"), func() {
+			headerCh := make(chan string, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				headerCh <- r.Header.Get(requestTimeoutMsHeader)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"nodeName":"test-node","iaasIPsAllocationResponse":[]}`))
+			}))
+			defer server.Close()
+
+			cfg := &spiderpooltypes.IaaSProviderConfig{
+				ServerURL:          server.URL,
+				HTTPRequestTimeout: "50s",
+			}
+			client, err := NewClient(cfg, logger)
+			Expect(err).NotTo(HaveOccurred())
+
+			ctx, cancel := context.WithTimeout(context.Background(), 70*time.Second)
+			defer cancel()
+
+			req := &AllocateIPRequest{
+				NodeName:     "test-node",
+				PodName:      "test-pod",
+				PodNamespace: "default",
+				PodUID:       "test-uuid",
+				IaaSIPsAllocationRequest: []IaaSIPAllocationItem{
+					{IPAddress: "10.0.0.1", Subnet: "10.0.0.0/24"},
+				},
+			}
+
+			_, err = client.AllocateIPs(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			header := <-headerCh
+			Expect(header).NotTo(BeEmpty())
+			timeoutMs, err := strconv.ParseInt(header, 10, 64)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(timeoutMs).To(BeNumerically(">", 0))
+			Expect(timeoutMs).To(BeNumerically("<=", int64((50*time.Second)/time.Millisecond)))
+		})
+
+		It("should send remaining request timeout for release requests", Label("timeout-header"), func() {
+			headerCh := make(chan string, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				headerCh <- r.Header.Get(requestTimeoutMsHeader)
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer server.Close()
+
+			cfg := &spiderpooltypes.IaaSProviderConfig{
+				ServerURL:          server.URL,
+				HTTPRequestTimeout: "50s",
+			}
+			client, err := NewClient(cfg, logger)
+			Expect(err).NotTo(HaveOccurred())
+
+			ctx, cancel := context.WithTimeout(context.Background(), 70*time.Second)
+			defer cancel()
+
+			req := &ReleaseIPRequest{
+				NodeName:     "test-node",
+				PodName:      "test-pod",
+				PodNamespace: "default",
+				PodUID:       "test-uuid",
+				ParentNicMac: "00:11:22:33:44:55",
+				Subnet:       "10.0.0.0/24",
+				IPAddress:    "10.0.0.1",
+			}
+
+			err = client.ReleaseIP(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			header := <-headerCh
+			Expect(header).NotTo(BeEmpty())
+			timeoutMs, err := strconv.ParseInt(header, 10, 64)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(timeoutMs).To(BeNumerically(">", 0))
+			Expect(timeoutMs).To(BeNumerically("<=", int64((50*time.Second)/time.Millisecond)))
 		})
 	})
 })


### PR DESCRIPTION
…fication

* add X-Request-Timeout-Ms header to allocate-ips and release-ip API documentation
* document header as required with millisecond timeout value for provider request budget
* implement setRequestTimeoutHeader to calculate and set timeout header from request context deadline
* add requestTimeoutMsHeader constant and nanosecondsPerMillisecond for time conversion
* call setRequestTimeoutHeader in AllocateIPs and releaseSingleIP before HTTP request execution
* add unit

# Thanks for contributing!

**Notice**:

* [ ] unite test or E2E test
* [ ] do not forget essential code comment and log
* [ ] document for the PR
* [ ] release note label
  "release/none"
  "release/bug"
  "release/feature"
* [ ] read about  Contribution notice: <https://spidernet-io.github.io/spiderpool/latest/develop/contributing/>

**What issue(s) does this PR fix**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
