### PR TITLE
fix: decouple coordinator DEL from Pod lookup

### DIFF
--- a/cmd/coordinator/cmd/command_del.go
+++ b/cmd/coordinator/cmd/command_del.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"net"
 	"os"
 
 	"github.com/containernetworking/cni/pkg/skel"
@@ -13,6 +14,7 @@ import (
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
 	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
 
 	"github.com/spidernet-io/spiderpool/api/v1/agent/client/daemonset"
 	"github.com/spidernet-io/spiderpool/api/v1/agent/models"
@@ -74,35 +76,38 @@ func CmdDel(args *skel.CmdArgs) (err error) {
 		hostRuleTable: int(*conf.HostRuleTable),
 	}
 
+	// The kernel removes routes that reference the veth when unregistering it.
+	hostVeth := getHostVethName(args.ContainerID)
+	vethLink := &netlink.Veth{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: hostVeth,
+		},
+	}
+	if err = netlink.LinkDel(vethLink); err != nil {
+		var linkNotFoundErr netlink.LinkNotFoundError
+		if os.IsNotExist(err) || errors.Is(err, unix.ENODEV) || errors.As(err, &linkNotFoundErr) {
+			logger.Debug("Host veth is already gone", zap.String("HostVeth", hostVeth))
+		} else {
+			logger.Warn("failed to delete host veth, continuing with remaining cleanup",
+				zap.String("HostVeth", hostVeth), zap.Error(err))
+		}
+	} else {
+		logger.Debug("deleted host veth", zap.String("HostVeth", hostVeth))
+	}
+
 	c.netns, err = ns.GetNS(args.Netns)
 	if err != nil {
 		var nsPathErr ns.NSPathNotExistErr
 		if errors.As(err, &nsPathErr) {
-			logger.Sugar().Debug("Pod's netns already gone. Nothing to do.")
+			logger.Debug("Pod netns is already gone, skipping netns cleanup")
+			logger.Info("cmdDel end")
 			return nil
 		}
-		logger.Sugar().Error("failed to GetNS,", zap.Error(err))
-		return fmt.Errorf("failed to GetNS %s: %w", args.Netns, err)
+		logger.Warn("failed to get Pod netns, skipping netns cleanup", zap.String("Netns", args.Netns), zap.Error(err))
+		logger.Info("cmdDel end")
+		return nil
 	}
 	defer func() { _ = c.netns.Close() }()
-
-	hostVeth := getHostVethName(args.ContainerID)
-	vethLink, err := netlink.LinkByName(hostVeth)
-	if err != nil {
-		var linkNotFoundErr netlink.LinkNotFoundError
-		if errors.As(err, &linkNotFoundErr) {
-			logger.Sugar().Debug("Host veth has gone, nothing to do", zap.String("HostVeth", hostVeth))
-		} else {
-			logger.Sugar().Warn(fmt.Sprintf("failed to get host veth device %s: %v", hostVeth, err))
-			return fmt.Errorf("failed to get host veth device %s: %w", hostVeth, err)
-		}
-	} else {
-		if err = netlink.LinkDel(vethLink); err != nil {
-			logger.Sugar().Warn("failed to del hostVeth", zap.Error(err))
-			return fmt.Errorf("failed to del hostVeth %s: %w", hostVeth, err)
-		}
-		logger.Sugar().Debug("success to del hostVeth", zap.String("HostVeth", hostVeth))
-	}
 
 	err = c.netns.Do(func(netNS ns.NetNS) error {
 		c.currentAddress, err = networking.GetAddersByName(args.IfName, netlink.FAMILY_ALL)
@@ -112,19 +117,27 @@ func CmdDel(args *skel.CmdArgs) (err error) {
 		return nil
 	})
 	if err != nil {
-		// ignore err
-		logger.Sugar().Warn("failed to GetAddersByName, ignore error", zap.Error(err))
+		logger.Warn("failed to get interface addresses, skipping legacy rule cleanup", zap.String("IfName", args.IfName), zap.Error(err))
 	}
 
 	for idx := range c.currentAddress {
 		ipNet := networking.ConvertMaxMaskIPNet(c.currentAddress[idx].IP)
-		err = networking.DelToRuleTable(ipNet, c.hostRuleTable)
-		if err != nil && !os.IsNotExist(err) {
-			logger.Sugar().Error("failed to DelToRuleTable", zap.Int("HostRuleTable", c.hostRuleTable), zap.String("Dst", ipNet.String()), zap.Error(err))
-			return fmt.Errorf("failed to DelToRuleTable: %w", err)
-		}
+		deleteLegacyHostRule(logger, ipNet, c.hostRuleTable)
 	}
 
 	logger.Info("cmdDel end")
 	return nil
+}
+
+func deleteLegacyHostRule(logger *zap.Logger, dst *net.IPNet, hostRuleTable int) {
+	if dst == nil {
+		return
+	}
+
+	if err := networking.DelToRuleTable(dst, hostRuleTable); err != nil && !os.IsNotExist(err) {
+		logger.Warn("failed to delete legacy per-Pod host rule, continuing with remaining cleanup",
+			zap.Int("HostRuleTable", hostRuleTable), zap.String("Dst", dst.String()), zap.Error(err))
+	} else {
+		logger.Debug("deleted legacy per-Pod host rule", zap.Int("HostRuleTable", hostRuleTable), zap.String("Dst", dst.String()))
+	}
 }

--- a/cmd/spiderpool-agent/cmd/coordinator.go
+++ b/cmd/spiderpool-agent/cmd/coordinator.go
@@ -7,13 +7,14 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime/middleware"
-	corev1 "k8s.io/api/core/v1"
+	"go.uber.org/zap"
 
 	"github.com/spidernet-io/spiderpool/api/v1/agent/models"
 	"github.com/spidernet-io/spiderpool/api/v1/agent/server/restapi/daemonset"
 	"github.com/spidernet-io/spiderpool/pkg/constant"
 	"github.com/spidernet-io/spiderpool/pkg/coordinatormanager"
 	spiderpoolv2beta1 "github.com/spidernet-io/spiderpool/pkg/k8s/apis/spiderpool.spidernet.io/v2beta1"
+	"github.com/spidernet-io/spiderpool/pkg/logutils"
 )
 
 var unixGetCoordinatorConfig = &_unixGetCoordinatorConfig{}
@@ -40,12 +41,16 @@ func (g *_unixGetCoordinatorConfig) Handle(params daemonset.GetCoordinatorConfig
 		return daemonset.NewGetCoordinatorConfigFailure().WithPayload(models.Error(fmt.Sprintf("spidercoordinator: %s no ready", coord.Name)))
 	}
 
-	var err error
+	logger := logutils.Logger.Named("CoordinatorConfig").With(
+		zap.String("PodNamespace", params.GetCoordinatorConfig.PodNamespace),
+		zap.String("PodName", params.GetCoordinatorConfig.PodName),
+	)
 
-	var pod *corev1.Pod
-	pod, err = podClient.GetPodByName(ctx, params.GetCoordinatorConfig.PodNamespace, params.GetCoordinatorConfig.PodName, constant.UseCache)
+	pod, err := podClient.GetPodByName(ctx, params.GetCoordinatorConfig.PodNamespace, params.GetCoordinatorConfig.PodName, constant.UseCache)
 	if err != nil {
-		return daemonset.NewGetCoordinatorConfigFailure().WithPayload(models.Error(fmt.Sprintf("failed to get pod %s/%s", params.GetCoordinatorConfig.PodNamespace, params.GetCoordinatorConfig.PodName)))
+		pod = nil
+		logger.Warn("failed to get Pod, so annotation ipam.spidernet.io/default-route-nic is unavailable and SpiderCoordinator spec.podDefaultRouteNIC will be used",
+			zap.Error(err))
 	}
 
 	var prefix string
@@ -67,9 +72,11 @@ func (g *_unixGetCoordinatorConfig) Handle(params daemonset.GetCoordinatorConfig
 		vethMTU = int64(*coord.Spec.VethMTU)
 	}
 
-	defaultRouteNic, ok := pod.Annotations[constant.AnnoDefaultRouteInterface]
-	if ok {
-		nic = defaultRouteNic
+	if pod != nil {
+		defaultRouteNic, ok := pod.Annotations[constant.AnnoDefaultRouteInterface]
+		if ok {
+			nic = defaultRouteNic
+		}
 	}
 
 	config := &models.CoordinatorConfig{

--- a/test/Makefile
+++ b/test/Makefile
@@ -202,7 +202,7 @@ setup_kind:
 		|| kubectl apply --kubeconfig $(E2E_KUBECONFIG) -f ./yamls/monitoring.coreos.com_prometheusrules.yaml
 	{ timeout 10 kubectl apply --timeout 10s --kubeconfig $(E2E_KUBECONFIG) -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml  ;} \
 		|| kubectl apply --kubeconfig $(E2E_KUBECONFIG) -f ./yamls/monitoring.coreos.com_probes.yaml
-	{ timeout 10 kubectl apply --timeout 10s --kubeconfig $(E2E_KUBECONFIG) -f https://raw.githubusercontent.com/grafana/grafana-operator/refs/heads/master/config/crd/bases/grafana.integreatly.org_grafanadashboards.yaml  ;} \
+	{ timeout 10 kubectl apply --timeout 10s --kubeconfig $(E2E_KUBECONFIG) -f https://github.com/grafana/grafana-operator/releases/download/$(GRAFANA_OPERATOR_VERSION)/crds.yaml  ;} \
 		|| kubectl apply --kubeconfig $(E2E_KUBECONFIG) -f ./yamls/grafanadashboards.yaml
 
 .PHONY: setup_network_resource_dummy_master_nics

--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -26,6 +26,8 @@ E2E_IP_FAMILY ?= dual
 # kubernetes version
 E2E_KIND_IMAGE_TAG ?= v1.36.1
 
+GRAFANA_OPERATOR_VERSION ?= v5.24.0
+
 # serviceCIDR is available in 1.29
 MultiCIDRServiceGateVersion ?= v1.29.0
 


### PR DESCRIPTION
# Thanks for contributing!

**Notice**:

* [ ] unit test or E2E test (not added or run; this PR is limited to the production-code fix)
* [x] essential code comments and logs
* [x] documentation impact reviewed (no documentation change required)
* [x] release note label (recommended: `release/bug`)
* [x] read the [contribution notice](https://spidernet-io.github.io/spiderpool/latest/develop/contributing/)

**What issue(s) does this PR fix**:

Fix https://github.com/spidernet-io/spiderpool/issues/5735

**Special notes for your reviewer**:

Coordinator CNI DEL previously requested its configuration from `spiderpool-agent`, whose handler unconditionally fetched the Kubernetes Pod to read the default-route-interface annotation. If the Pod had already been deleted, the configuration request failed and Coordinator DEL exited before cleaning host-side networking resources.

This PR:

* makes the agent Pod lookup best-effort for every Coordinator configuration request;
* falls back to `SpiderCoordinator.spec.podDefaultRouteNIC` when the Pod or its default-route annotation is unavailable;
* only applies `ipam.spidernet.io/default-route-nic` when the Pod lookup succeeds;
* performs host cleanup before checking the Pod netns;
* finds and deletes the Coordinator host veth from the container ID, relying on the kernel to remove routes that reference the unregistered link;
* preserves the node-level shared `from all lookup <HostRuleTable>` rule;
* removes legacy per-Pod `to <PodIP> lookup <HostRuleTable>` rules when the Pod netns still provides the interface addresses; and
* treats missing Pods, netns paths, veths, routes, rules, and repeated DEL calls as non-fatal cleanup states.

Current ADD/DEL symmetry was checked: ADD creates the shared host rule, per-Pod host routes, and the Coordinator veth for the first underlay invocation. Current ADD no longer creates per-Pod destination rules.

Validation performed:

* ran `gofmt` on the changed Go files;
* ran `git diff --check`;
* no tests, build, or lint were run; and
* no test files or test cases were changed or added.

**Release note**:

```release-note
Fix Coordinator CNI DEL so it can continue best-effort host network cleanup when the Kubernetes Pod object or Pod netns no longer exists.
```
