### PR TITLE
fix: include disabled calico ippools in spidercoordinator status

### DIFF
--- a/pkg/coordinatormanager/coordinator_informer.go
+++ b/pkg/coordinatormanager/coordinator_informer.go
@@ -556,7 +556,10 @@ func (cc *CoordinatorController) updateCalicoPodCIDR(ctx context.Context, coordi
 
 	podCIDR := make([]string, 0, len(ipPoolList.Items))
 	for _, p := range ipPoolList.Items {
-		if p.DeletionTimestamp == nil && !p.Spec.Disabled {
+		// Include disabled IPPools as well: a disabled pool no longer allocates
+		// new IPs, but existing pods may still use its CIDR, so routes to it
+		// must still be reconciled for underlay pods.
+		if p.DeletionTimestamp == nil {
 			podCIDR = append(podCIDR, p.Spec.CIDR)
 		}
 	}


### PR DESCRIPTION
### Thanks for contributing!

**What type of PR is this?**

release/bug

**What this PR does / why we need it**:

In underlay mode, when the cluster's old default calico ippool runs out of IPs, a new ippool in a different subnet may be added and the old one disabled. `updateCalicoPodCIDR` skipped disabled ippools, so their CIDRs were removed from `spidercoordinator.status.overlayPodCIDR`. Newly created macvlan pods then lacked routes to existing pods still using the disabled calico subnet, breaking connectivity.

This PR keeps collecting CIDRs of disabled calico ippools (only pools being deleted are skipped), so the coordinator still reconciles routes for pods on disabled subnets. The calico ippool informer already enqueues reconciliation on any ippool change, so no informer change is needed.

**Which issue(s) this PR fixes**:

Fixes #5738

**Special notes for your reviewer**:

Disabled pools no longer allocate new IPs, but existing pods may still hold addresses from them, so routes must remain.

```release-note
Fix underlay pods losing routes to existing overlay pods that use a disabled calico ippool subnet
```