### PR TITLE
ci: fix auto-cherrypick aborting before processing all target branches

### DIFF
--- a/.github/workflows/auto-cherrypick.yaml
+++ b/.github/workflows/auto-cherrypick.yaml
@@ -5,6 +5,7 @@ permissions: write-all
 env:
   PR_LABEL_PREFIX_CHERRYPICK: "cherrypick-"
   CHERRYPICK_LABEL: "robot-cherrypick"
+  DEFAULT_REVIEWER: "weizhoublue"
 
 on:
   push:
@@ -127,12 +128,11 @@ jobs:
               if ! git ls-remote --exit-code --heads origin ${BRANCH} ; then
                   # todo: create issue
                   echo "error, branch $BRANCH does not exist"
-                  gh issue create  \
+                  if ! gh issue create  \
                       --body "reason: the branch $BRANCH does not exist. PR <${PR_URL}> ,  action <${ACTION_URL}> " \
                       --title "failed to auto cherry pick PR ${PR_NUMBER} to branch ${BRANCH}" \
                       --label "${{ env.CHERRYPICK_LABEL }}" \
-                      --assignee "${PR_AUTHOR},${{ env.DEFAULT_REVIEWER }}"
-                  if (($?!=0)) ; then
+                      --assignee "${PR_AUTHOR},${{ env.DEFAULT_REVIEWER }}" ; then
                       echo "!!!! error, failed to create issue"
                       FINAL_FAILURE=true
                   fi
@@ -141,12 +141,11 @@ jobs:
               git fetch origin ${BRANCH}:${BRANCH} || true
               if ! git checkout ${BRANCH} ; then
                   echo "error, failed to checkout to branch $BRANCH"
-                  gh issue create  \
+                  if ! gh issue create  \
                       --body "reason: failed to get the branch $BRANCH. PR <${PR_URL}> ,  action <${ACTION_URL}> " \
                       --title "failed to auto cherry pick PR ${PR_NUMBER} to branch ${BRANCH}" \
                       --label "${{ env.CHERRYPICK_LABEL }}" \
-                      --assignee "${PR_AUTHOR},${{ env.DEFAULT_REVIEWER }}"
-                  if (($?!=0)) ; then
+                      --assignee "${PR_AUTHOR},${{ env.DEFAULT_REVIEWER }}" ; then
                       echo "!!!! error, failed to create issue"
                       FINAL_FAILURE=true
                   fi
@@ -191,18 +190,22 @@ jobs:
                         --title "failed to cherry pick PR ${PR_NUMBER} from ${PR_AUTHOR}, to branch ${BRANCH}" \
                         --label "${{ env.CHERRYPICK_LABEL }}" \
                         --assignee "${PR_AUTHOR},${{ env.DEFAULT_REVIEWER }}" \
-                        --body-file -
+                        --body-file - \
+                    || { echo "!!!! error, failed to create issue" ; }
               fi
               if [ "$UPDATE" == "true" ] ; then
                   echo "succeeded to cherry pick to branch $BRANCH "
                   # create a pr
                   git commit -s -S --amend --no-edit
                   git push origin ${PR_BRANCH}:${PR_BRANCH} -f
-                  gh pr create --title "${PR_TITLE}" \
+                  if ! gh pr create --title "${PR_TITLE}" \
                       --assignee "${PR_AUTHOR},${{ env.DEFAULT_REVIEWER }}" \
                       --label "${{ env.CHERRYPICK_LABEL }},${INITIAL_LABEL}" \
                       --body "robot cherry pick PR <${PR_URL}> from ${PR_AUTHOR},to branch ${BRANCH},  action <${ACTION_URL}>  , commits $PR_COMMITS " \
-                      --base ${BRANCH}
+                      --base ${BRANCH} ; then
+                      echo "!!!! error, failed to create pr for branch ${BRANCH}"
+                      FINAL_FAILURE=true
+                  fi
               else
                   echo "no changes happened for commits $PR_COMMITS, ignore create pr"
               fi

--- a/.github/workflows/auto-cherrypick.yaml
+++ b/.github/workflows/auto-cherrypick.yaml
@@ -5,7 +5,7 @@ permissions: write-all
 env:
   PR_LABEL_PREFIX_CHERRYPICK: "cherrypick-"
   CHERRYPICK_LABEL: "robot-cherrypick"
-  DEFAULT_REVIEWER: "weizhoublue"
+  DEFAULT_REVIEWER: "cyclinder"
 
 on:
   push:


### PR DESCRIPTION
## Description

The auto-cherrypick workflow only ever processed the first target branch and then failed, e.g. run [30439584794](https://github.com/spidernet-io/spiderpool/actions/runs/30439584794) for #5739 created #5746 for `release-v1.0` but never attempted `release-v1.1`/`release-v1.2`.

Root cause:
- `DEFAULT_REVIEWER` is referenced via `${{ env.DEFAULT_REVIEWER }}` but never defined, so every `gh pr create`/`gh issue create` passes `--assignee "author,"` with a trailing empty login, failing with `GraphQL: Could not resolve to a user or bot with the login ''`.
- The step runs under `bash -e`, and these gh calls were unguarded, so the whole loop aborted after the first branch. (This also explains the earlier failed runs for #5727/#5730.)

Fix:
- define `DEFAULT_REVIEWER` in the workflow env
- guard the `gh pr create`/`gh issue create` calls so a failure on one branch sets `FINAL_FAILURE` and the loop continues with the remaining branches

## Release note

```
NONE
```