### PR TITLE
fix: include disabled calico ippools in spidercoordinator status (#5739)

### DIFF
--- a/pkg/coordinatormanager/coordinator_informer.go
+++ b/pkg/coordinatormanager/coordinator_informer.go
@@ -556,7 +556,10 @@ func (cc *CoordinatorController) updateCalicoPodCIDR(ctx context.Context, coordi
 
 	podCIDR := make([]string, 0, len(ipPoolList.Items))
 	for _, p := range ipPoolList.Items {
-		if p.DeletionTimestamp == nil && !p.Spec.Disabled {
+		// Include disabled IPPools as well: a disabled pool no longer allocates
+		// new IPs, but existing pods may still use its CIDR, so routes to it
+		// must still be reconciled for underlay pods.
+		if p.DeletionTimestamp == nil {
 			podCIDR = append(podCIDR, p.Spec.CIDR)
 		}
 	}


### PR DESCRIPTION
## Description

Cherry-pick #5739 to `release-v1.2`. Applied cleanly.

The auto cherry-pick only processed `release-v1.0` (#5746) before aborting; see #5747 for the workflow fix.

## Notes

Original PR: #5739
Target branch: `release-v1.2`