### PR TITLE
Add spiderpool-system to namespacesExclude to allow Spiderpool installation in the spiderpool-system namespace.

### DIFF
--- a/charts/spiderpool/values.yaml
+++ b/charts/spiderpool/values.yaml
@@ -736,6 +736,7 @@ spiderpoolController:
     namespacesExclude:
       - kube-system
       - spiderpool
+      - spiderpool-system
       - metallb-system
       - istio-system
 


### PR DESCRIPTION
# What this PR does
- Add `spiderpool-system` to namespacesExclude to allow Spiderpool installation in the `spiderpool-system` namespace.
