### PR TITLE
docs: add SR-IOV VF MTU configuration principles

### DIFF
--- a/docs/usage/install/ai/get-started-sriov-roce-zh_CN.md
+++ b/docs/usage/install/ai/get-started-sriov-roce-zh_CN.md
@@ -575,7 +575,14 @@ EOF
 
 ## 自定义 VF 的 MTU
 
-  默认情况下，SR-IOV VF 的 MTU 不会继承其 PF 的值影响，因此在一些特殊通信场景下，用户需要为 Pod 自定义 MTU 大小以满足不同数据报文通信需求。您可以参考以下方式自定义配置 Pod 的 MTU 大小(以 Ethernet 为例)：
+  默认情况下，SR-IOV VF 的 MTU 不会继承其 PF 的值影响，因此在一些特殊通信场景下，用户需要为 Pod 自定义 MTU 大小以满足不同数据报文通信需求。
+
+  MTU 配置原则：
+
+  1. MTU 大小关系必须满足：交换机 MTU ≥ PF MTU ≥ VF MTU。VF 不会自动跟随 PF 的 MTU 变化，需通过如下方式显式配置。
+  2. 大多数交换机 MTU 为 9216，对于 RDMA 场景推荐 PF 和 VF 都设置为 4200（= RDMA 最大 active_mtu 4096 + 报头开销），更大的 MTU 值（如 9000）对 RDMA 传输性能没有收益，仅当同一网卡还承载大量 TCP 流量时才有意义。
+
+  您可以参考以下方式自定义配置 Pod 的 MTU 大小(以 Ethernet 为例)：
 
   ```yaml
   apiVersion: spiderpool.spidernet.io/v2beta1
@@ -588,7 +595,7 @@ EOF
     sriov:
       resourceName: spidernet.io/gpu1sriov
       enableRdma: true
-      mtu: 8000
+      mtu: 4200
       ippools:
         ipv4: ["gpu1-net11"]
   ```

--- a/docs/usage/install/ai/get-started-sriov-roce-zh_CN.md
+++ b/docs/usage/install/ai/get-started-sriov-roce-zh_CN.md
@@ -131,7 +131,7 @@ spec:
 EOF
 ```
 
-如果您需要自定义配置 VF 的 MTU，参考 [自定义配置 VF 的 MTU](#自定义-vf-的-mtu).
+RDMA 场景下，VF 的 MTU 必须显式配置以与 PF 对齐，这是一个必做的对齐步骤，参考 [自定义配置 VF 的 MTU](#自定义-vf-的-mtu)。
 
 ### 独享子网方案配置 
 
@@ -575,14 +575,9 @@ EOF
 
 ## 自定义 VF 的 MTU
 
-  默认情况下，SR-IOV VF 的 MTU 不会继承其 PF 的值影响，因此在一些特殊通信场景下，用户需要为 Pod 自定义 MTU 大小以满足不同数据报文通信需求。
+  默认情况下，SR-IOV VF 的 MTU 不会继承其 PF 的值，因此在 RDMA 场景下，必须显式配置 VF 的 MTU 以与 PF 对齐。请遵循 [主机准备](./index-zh_CN.md#主机准备) 中的 MTU 配置原则：交换机 MTU ≥ PF MTU ≥ VF MTU，推荐 PF 和 VF 都设置为 4200（= RDMA 最大 active_mtu 4096 + 报头开销），更大的 MTU 值（如 9000）对 RDMA 传输性能没有收益。
 
-  MTU 配置原则：
-
-  1. MTU 大小关系必须满足：交换机 MTU ≥ PF MTU ≥ VF MTU。VF 不会自动跟随 PF 的 MTU 变化，需通过如下方式显式配置。
-  2. 大多数交换机 MTU 为 9216，对于 RDMA 场景推荐 PF 和 VF 都设置为 4200（= RDMA 最大 active_mtu 4096 + 报头开销），更大的 MTU 值（如 9000）对 RDMA 传输性能没有收益，仅当同一网卡还承载大量 TCP 流量时才有意义。
-
-  您可以参考以下方式自定义配置 Pod 的 MTU 大小(以 Ethernet 为例)：
+  您可以参考以下方式配置 Pod 的 MTU 大小(以 Ethernet 为例)：
 
   ```yaml
   apiVersion: spiderpool.spidernet.io/v2beta1

--- a/docs/usage/install/ai/get-started-sriov-roce.md
+++ b/docs/usage/install/ai/get-started-sriov-roce.md
@@ -216,7 +216,11 @@ kubectl patch daemonset spiderpool-agent -n spiderpool -p '{"spec":{"template":{
 
 4. Configure IP addresses, MTU, and policy routing for all RDMA network cards
 
-   > In RDMA scenarios, both switches and host network cards typically operate with larger MTU values for better performance.
+   > In RDMA scenarios, both switches and host network cards must operate with larger MTU values for better performance. MTU configuration principles:
+   >
+   > 1. The MTU sizes must satisfy: switch MTU ≥ PF MTU ≥ VF MTU. The VF does not automatically follow MTU changes on the PF and must be configured explicitly.
+   > 2. It is recommended to set the switch MTU to 9216, and set both PF and VF MTU to 4200 (= the maximum RDMA active_mtu of 4096 + header overhead). A larger MTU (e.g. 9000) does not improve RDMA performance and is only meaningful when the same NIC also carries heavy TCP traffic.
+   > 3. Note: The factory default MTU of switches is usually 1500. Make sure the switch MTU has been adjusted accordingly, otherwise RDMA packets will be dropped.
    >
    > Since Linux hosts have only one default route by default, in multi-NIC scenarios, policy-based routing needs to be configured for different network cards to ensure that hostNetwork mode tasks can run All-to-All communication properly.
    >
@@ -227,7 +231,9 @@ kubectl patch daemonset spiderpool-agent -n spiderpool -p '{"spec":{"template":{
    ```shell
    $ chmod +x ./setNicAddr.sh
 
-   # For Solution 1, configure the network card
+   # For Solution 1, configure the network card.
+   # MTU="4200" sets the PF MTU, which is recommended for RDMA scenarios (= max RDMA active_mtu 4096 + header overhead).
+   # Make sure the connected switch ports are configured with a larger MTU (e.g. 9216) as well.
    $ INTERFACE="eno3np2" IPV4_IP="172.16.0.10/24" IPV4_GATEWAY="172.16.0.1" \
          MTU="4200" ENABLE_POLICY_ROUTE="true" ./setNicAddr.sh
 
@@ -498,7 +504,7 @@ spec:
 EOF
 ```
 
-If you need to customize the VF MTU, see Customize VF MTU.
+In RDMA scenarios, the VF MTU must be explicitly configured to align with the PF MTU. This is a required step, not an optional one; see [Customize VF MTU](#customize-vf-mtu).
 
 ## Create CNI Configs and IPPools for Solution 2
 
@@ -855,12 +861,7 @@ To simplify multi-NIC AI app configuration, Spiderpool supports grouping NIC con
 
 ## Customize VF MTU
 
-By default, SR-IOV VF MTU does not inherit from the PF. In some scenarios, you may need to customize the Pod's MTU for specific payloads.
-
-MTU configuration principles:
-
-1. The MTU sizes must satisfy: switch MTU ≥ PF MTU ≥ VF MTU. The VF does not automatically follow MTU changes on the PF, so it must be configured explicitly as shown below.
-2. Most switches use an MTU of 9216. For RDMA scenarios, it is recommended to set both PF and VF MTU to 4200 (= the maximum RDMA active_mtu of 4096 + header overhead). Setting a larger MTU (e.g. 9000) does not improve RDMA performance and is only meaningful when the same NIC also carries heavy TCP traffic.
+By default, SR-IOV VF MTU does not inherit from the PF, so in RDMA scenarios the VF MTU must be explicitly configured to align with the PF MTU. Follow the MTU configuration principles described in [Host Preparation](#host-preparation): switch MTU ≥ PF MTU ≥ VF MTU, with 4200 recommended for both PF and VF (= the maximum RDMA active_mtu of 4096 + header overhead); a larger MTU (e.g. 9000) does not improve RDMA performance.
 
 Example (Ethernet):
 

--- a/docs/usage/install/ai/get-started-sriov-roce.md
+++ b/docs/usage/install/ai/get-started-sriov-roce.md
@@ -855,7 +855,14 @@ To simplify multi-NIC AI app configuration, Spiderpool supports grouping NIC con
 
 ## Customize VF MTU
 
-By default, SR-IOV VF MTU does not inherit from the PF. In some scenarios, you may need to customize the Pod's MTU for specific payloads. Example (Ethernet):
+By default, SR-IOV VF MTU does not inherit from the PF. In some scenarios, you may need to customize the Pod's MTU for specific payloads.
+
+MTU configuration principles:
+
+1. The MTU sizes must satisfy: switch MTU ≥ PF MTU ≥ VF MTU. The VF does not automatically follow MTU changes on the PF, so it must be configured explicitly as shown below.
+2. Most switches use an MTU of 9216. For RDMA scenarios, it is recommended to set both PF and VF MTU to 4200 (= the maximum RDMA active_mtu of 4096 + header overhead). Setting a larger MTU (e.g. 9000) does not improve RDMA performance and is only meaningful when the same NIC also carries heavy TCP traffic.
+
+Example (Ethernet):
 
 ```yaml
 apiVersion: spiderpool.spidernet.io/v2beta1
@@ -868,7 +875,7 @@ spec:
   sriov:
     resourceName: spidernet.io/gpu1sriov
     enableRdma: true
-    mtu: 8000
+    mtu: 4200
     ippools:
       ipv4: ["gpu1-net11"]
 ```

--- a/docs/usage/install/ai/index-zh_CN.md
+++ b/docs/usage/install/ai/index-zh_CN.md
@@ -275,7 +275,10 @@ $ GPU_RDMA_MODE="infiniband" OTHER_RDMA_MODE="roce" ./setNicRdmaMode.sh
 
 - Roce 组网方案下，RDMA 流量需要通过以太网进行传输，linux 主机默认只有一个缺省路由，在多网卡场景下，需要为不同网卡设置策略默认路由，以确保 hostnetwork 模式下的任务能正常运行 All-to-All 等通信，但不同组网方案配置细节有所差异。
 - Infiniband 组网方案下，RDMA 流量不需要通过以太网传输，因此不需要额外配置策略路由。
-- 无论 RoCE 还是 Infiniband，通常交换机和主机网卡都会工作在较大的 MTU 参数下，以提高性能。
+- 无论 RoCE 还是 Infiniband，交换机和主机网卡都需要工作在较大的 MTU 参数下，以提高性能。MTU 配置原则：
+    1. MTU 大小关系必须满足：交换机 MTU ≥ PF MTU ≥ VF MTU。VF 不会自动跟随 PF 的 MTU 变化，必须显式配置。
+    2. RDMA 场景下，建议交换机 MTU 设置为 9216，PF 和 VF 都设置为 4200（= RDMA 最大 active_mtu 4096 + 报头开销），更大的 MTU 值（如 9000）对 RDMA 传输性能没有收益，仅当同一网卡还承载大量 TCP 流量时才有意义。
+    3. 注意：交换机出厂默认 MTU 通常为 1500，请务必检查交换机 MTU 是否已调整到位，否则会导致 RDMA 报文丢包。
 
 首先获取 [ubuntu 网卡配置脚本:](https://github.com/spidernet-io/spiderpool/blob/main/tools/scripts/setNicAddr.sh)
 
@@ -293,6 +296,8 @@ $ chmod +x ./setNicAddr.sh
    $ chmod +x ./setNicAddr.sh
 
    # 对于共享子网组网方案，设置网卡
+   # MTU="4200" 用于设置 PF 的 MTU，为 RDMA 场景的推荐值（= RDMA 最大 active_mtu 4096 + 报头开销）
+   # 请确保对端交换机端口也配套设置了更大的 MTU（如 9216）
    $ INTERFACE="eno3np2" IPV4_IP="172.16.0.10/24"  IPV4_GATEWAY="172.16.0.1" \
          MTU="4200" ENABLE_POLICY_ROUTE="true" ./setNicAddr.sh
 

--- a/docs/usage/install/ai/index.md
+++ b/docs/usage/install/ai/index.md
@@ -273,7 +273,10 @@ $ GPU_RDMA_MODE="infiniband" OTHER_RDMA_MODE="roce" ./setNicRdmaMode.sh
 
 - In RoCE mode, RDMA traffic is transmitted over Ethernet. Linux has only one default route by default; in multi-NIC scenarios you need policy routing, and the details differ by networking mode.
 - In InfiniBand mode, RDMA traffic does not go through Ethernet, so policy routing is not required.
-- For both RoCE and InfiniBand, MTU is typically configured to a larger value for better performance.
+- For both RoCE and InfiniBand, switches and host network cards must be configured with a larger MTU for better performance. MTU configuration principles:
+    1. The MTU sizes must satisfy: switch MTU ≥ PF MTU ≥ VF MTU. The VF does not automatically follow MTU changes on the PF and must be configured explicitly.
+    2. In RDMA scenarios, it is recommended to set the switch MTU to 9216, and set both PF and VF MTU to 4200 (= the maximum RDMA active_mtu of 4096 + header overhead). A larger MTU (e.g. 9000) does not improve RDMA performance and is only meaningful when the same NIC also carries heavy TCP traffic.
+    3. Note: The factory default MTU of switches is usually 1500. Make sure the switch MTU has been adjusted accordingly, otherwise RDMA packets will be dropped.
 
 Get the script: [setNicAddr.sh](https://github.com/spidernet-io/spiderpool/blob/main/tools/scripts/setNicAddr.sh)
 
@@ -288,6 +291,8 @@ $ chmod +x ./setNicAddr.sh
    ```shell
    $ chmod +x ./setNicAddr.sh
 
+   # MTU="4200" sets the PF MTU, which is recommended for RDMA scenarios (= max RDMA active_mtu 4096 + header overhead).
+   # Make sure the connected switch ports are configured with a larger MTU (e.g. 9216) as well.
    $ INTERFACE="eno3np2" IPV4_IP="172.16.0.10/24"  IPV4_GATEWAY="172.16.0.1" \
          MTU="4200" ENABLE_POLICY_ROUTE="true" ./setNicAddr.sh
    ```


### PR DESCRIPTION
## Description

Clarify SR-IOV VF MTU configuration principles in the AI RoCE docs (both English and Chinese):

1. The MTU sizes must satisfy: switch MTU ≥ PF MTU ≥ VF MTU. The VF does not automatically follow MTU changes on the PF, so it must be configured explicitly.
2. Most switches use an MTU of 9216. For RDMA scenarios, it is recommended to set both PF and VF MTU to 4200 (= the maximum RDMA active_mtu of 4096 + header overhead). A larger MTU (e.g. 9000) does not improve RDMA performance and is only meaningful when the same NIC also carries heavy TCP traffic.

Also updates the example `mtu: 8000` to `mtu: 4200`.

Docs-only change; no code or test impact.

```release-note
NONE
```